### PR TITLE
Clean Up Workflow Manager Async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,7 @@ name = "workflow-manager"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
+ "async-trait",
  "config",
  "cosmos-grpc-client",
  "cosmwasm-std 2.1.3",

--- a/workflow-manager/Cargo.toml
+++ b/workflow-manager/Cargo.toml
@@ -13,6 +13,7 @@ serde              = { workspace = true }
 serde_json         = { workspace = true }
 aho-corasick       = "1.1"
 serde_json_any_key = "2"
+async-trait = "0.1.81"
 
 services-utils      = { workspace = true }
 valence-macros      = { workspace = true }

--- a/workflow-manager/src/domain/cosmos_cw.rs
+++ b/workflow-manager/src/domain/cosmos_cw.rs
@@ -9,9 +9,11 @@ use cosmos_grpc_client::{
 };
 use cosmwasm_std::CanonicalAddr;
 
+use async_trait::async_trait;
+
 use crate::{account::AccountType, config::ChainInfo};
 
-use super::{Connector, PinnedFuture};
+use super::Connector;
 
 const MNEMONIC: &str = "crazy into this wheel interest enroll basket feed fashion leave feed depth wish throw rack language comic hand family shield toss leisure repair kite";
 
@@ -27,92 +29,90 @@ impl fmt::Debug for CosmosCwConnector {
     }
 }
 
+impl CosmosCwConnector {
+    pub async fn new(chain_info: ChainInfo) -> Self {
+        let grpc = GrpcClient::new(&chain_info.grpc).await.unwrap();
+
+        let wallet = Wallet::from_seed_phrase(
+            grpc,
+            MNEMONIC,
+            chain_info.prefix,
+            chain_info.coin_type,
+            0,
+            Decimal::from_str(&chain_info.gas_price).unwrap(),
+            Decimal::from_str("1.5").unwrap(),
+            &chain_info.gas_denom,
+        )
+        .await
+        .unwrap();
+
+        CosmosCwConnector { wallet }
+    }
+}
+
+#[async_trait]
 impl Connector for CosmosCwConnector {
-    fn new(chain_info: ChainInfo) -> PinnedFuture<'static, Self> {
-        Box::pin(async move {
-            let grpc = GrpcClient::new(&chain_info.grpc).await.unwrap();
+    async fn init_account(&mut self, _account_type: &AccountType) -> String {
+        // TODO: get code id from config
+        // TODO: Get init message
+        // let init_msg = valence_base_account::msg::InstantiateMsg {
+        //     admin: self.wallet.account_address.to_string(),
+        // };
 
-            let wallet = Wallet::from_seed_phrase(
-                grpc,
-                MNEMONIC,
-                chain_info.prefix,
-                chain_info.coin_type,
-                0,
-                Decimal::from_str(&chain_info.gas_price).unwrap(),
-                Decimal::from_str("1.5").unwrap(),
-                &chain_info.gas_denom,
-            )
+        // Should be enough because we know the address is correct.
+        let addr: CanonicalAddr = self.wallet.account_address.as_bytes().into();
+
+        // instantiate2_address(checksum, creator, salt);
+        MsgInstantiateContract2 {
+            sender: todo!(),
+            admin: todo!(),
+            code_id: todo!(),
+            label: todo!(),
+            msg: todo!(),
+            funds: todo!(),
+            salt: todo!(),
+            fix_msg: todo!(),
+        };
+        // let msg = MsgInstantiateContract {
+        //     sender: self.wallet.account_address.to_string(),
+        //     code_id: 5987,
+        //     msg: to_vec(&init_msg).unwrap(),d
+        //     funds: vec![],
+        //     label: "base_account".to_string(),
+        //     admin: self.wallet.account_address.clone(),
+        // }
+        // .build_any();
+        // let response = self
+        //     .wallet
+        //     .broadcast_tx(vec![msg], None, None, BroadcastMode::Sync)
+        //     .await
+        //     .unwrap()
+        //     .tx_response;
+        // println!("{:?}", response);
+        self.wallet.chain_id.clone()
+    }
+
+    async fn get_balance(&mut self, addr: String) -> Option<Coin> {
+        let request = QueryBalanceRequest {
+            address: addr,
+            denom: "untrn".to_string(),
+        };
+        let response = self
+            .wallet
+            .client
+            .clients
+            .bank
+            .balance(request)
             .await
-            .unwrap();
-
-            CosmosCwConnector { wallet }
-        })
+            .unwrap()
+            .into_inner();
+        response.balance.clone()
     }
 
-    fn init_account(&mut self, _account_type: &AccountType) -> PinnedFuture<String> {
-        Box::pin(async move {
-            // TODO: get code id from config
-            // TODO: Get init message
-            // let init_msg = valence_base_account::msg::InstantiateMsg {
-            //     admin: self.wallet.account_address.to_string(),
-            // };
-
-            // Should be enough because we know the address is correct.
-            let addr: CanonicalAddr = self.wallet.account_address.as_bytes().into();
-
-            // instantiate2_address(checksum, creator, salt);
-            MsgInstantiateContract2 {
-                sender: todo!(),
-                admin: todo!(),
-                code_id: todo!(),
-                label: todo!(),
-                msg: todo!(),
-                funds: todo!(),
-                salt: todo!(),
-                fix_msg: todo!(),
-            };
-            // let msg = MsgInstantiateContract {
-            //     sender: self.wallet.account_address.to_string(),
-            //     code_id: 5987,
-            //     msg: to_vec(&init_msg).unwrap(),
-            //     funds: vec![],
-            //     label: "base_account".to_string(),
-            //     admin: self.wallet.account_address.clone(),
-            // }
-            // .build_any();
-            // let response = self
-            //     .wallet
-            //     .broadcast_tx(vec![msg], None, None, BroadcastMode::Sync)
-            //     .await
-            //     .unwrap()
-            //     .tx_response;
-            // println!("{:?}", response);
-            self.wallet.chain_id.clone()
-        })
-    }
-
-    fn get_balance(&mut self, addr: String) -> PinnedFuture<Option<Coin>> {
-        Box::pin(async move {
-            let request = QueryBalanceRequest {
-                address: addr,
-                denom: "untrn".to_string(),
-            };
-            let response = self
-                .wallet
-                .client
-                .clients
-                .bank
-                .balance(request)
-                .await
-                .unwrap()
-                .into_inner();
-            response.balance.clone()
-        })
-    }
-
-    fn get_account_addr(&mut self, account_type: &AccountType) -> PinnedFuture<String> {
+    async fn get_account_addr(&self, account_type: &AccountType) -> String {
         todo!()
     }
+
     // Other method implementations...
 }
 

--- a/workflow-manager/src/workflow_config.rs
+++ b/workflow-manager/src/workflow_config.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeMap;
 
-use valence_authorization_utils::authorization::AuthorizationInfo;
 use services_utils::Id;
+use valence_authorization_utils::authorization::AuthorizationInfo;
 
 use crate::{
     account::{AccountInfo, AccountType},
     context::Ctx,
-    domain::ConnectorInner,
     service::ServiceInfo,
 };
 


### PR DESCRIPTION
This PR fixes some difficulties @Art3miX was encountering on the workflow-manager branch. This PR simplifies some of the async and connector logic (and fixes the issue with type cycles) by:
- Using async-trait instead of PinnedFuture
- Excluding `new` from the connector trait (no need for a macro now)
- Removing the ConnectorWrapper in favor of a `Box<dyn Connector>`