### PR TITLE
Remove owner from processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,7 +4093,6 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema 2.1.3",
  "cosmwasm-std 2.1.3",
- "cw-ownable",
  "cw-storage-plus",
  "cw-utils",
  "cw2",
@@ -4108,7 +4107,6 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema 2.1.3",
  "cosmwasm-std 2.1.3",
- "cw-ownable",
  "cw-storage-plus",
  "cw-utils",
  "serde",

--- a/contracts/authorization/src/tests/helpers.rs
+++ b/contracts/authorization/src/tests/helpers.rs
@@ -129,7 +129,6 @@ pub fn store_and_instantiate_authorization_with_processor_contract(
         .instantiate(
             code_id_processor,
             &ProcessorInstantiateMsg {
-                owner: signer.address().to_string(),
                 authorization_contract: predicted_address.clone(),
                 polytone_contracts: None,
             },

--- a/contracts/processor/Cargo.toml
+++ b/contracts/processor/Cargo.toml
@@ -17,7 +17,6 @@ cw-storage-plus             = { workspace = true }
 cosmwasm-schema             = { workspace = true }
 thiserror                   = { workspace = true }
 cw2                         = { workspace = true }
-cw-ownable                  = { workspace = true }
 valence-processor-utils     = { workspace = true }
 valence-authorization-utils = { workspace = true }
 cw-utils                    = { workspace = true }

--- a/contracts/processor/src/error.rs
+++ b/contracts/processor/src/error.rs
@@ -1,4 +1,3 @@
-use cw_ownable::OwnershipError;
 use thiserror::Error;
 
 use cosmwasm_std::StdError;
@@ -7,9 +6,6 @@ use cosmwasm_std::StdError;
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
-
-    #[error(transparent)]
-    Ownership(#[from] OwnershipError),
 
     #[error(transparent)]
     Unauthorized(#[from] UnauthorizedReason),

--- a/packages/processor-utils/Cargo.toml
+++ b/packages/processor-utils/Cargo.toml
@@ -12,5 +12,4 @@ valence-authorization-utils = { workspace = true }
 cw-storage-plus             = { workspace = true }
 serde                       = { workspace = true }
 cw-utils                    = { workspace = true }
-cw-ownable                  = { workspace = true }
 serde_json                  = { workspace = true }

--- a/packages/processor-utils/src/msg.rs
+++ b/packages/processor-utils/src/msg.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Binary;
-use cw_ownable::{cw_ownable_execute, cw_ownable_query};
 use valence_authorization_utils::{
     authorization::{ActionsConfig, Priority},
     msg::ProcessorMessage,
@@ -10,7 +9,6 @@ use crate::processor::{Config, MessageBatch};
 
 #[cw_serde]
 pub struct InstantiateMsg {
-    pub owner: String,
     pub authorization_contract: String,
     // In case the processor is sitting on a different domain
     pub polytone_contracts: Option<PolytoneContracts>,
@@ -22,21 +20,11 @@ pub struct PolytoneContracts {
     pub polytone_note_address: String,
 }
 
-#[cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
-    OwnerAction(OwnerMsg),
     AuthorizationModuleAction(AuthorizationMsg),
     PermissionlessAction(PermissionlessMsg),
     InternalProcessorAction(InternalProcessorMsg),
-}
-
-#[cw_serde]
-pub enum OwnerMsg {
-    UpdateConfig {
-        authorization_contract: Option<String>,
-        polytone_contracts: Option<PolytoneContracts>,
-    },
 }
 
 #[cw_serde]
@@ -75,7 +63,6 @@ pub enum InternalProcessorMsg {
     ExecuteAtomic { batch: MessageBatch },
 }
 
-#[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {


### PR DESCRIPTION
We don't need an owner in the first place. Config doesn't need to be updated, and if we ever want to add it (don't think we will, we'll probably just create a new one) it needs to be done properly from the authorization contract over IBC because it implies much more than just updating contract addresses. Current ownership and update is dangerous/unnecessary by itself