### PR TITLE
Fix: retries for non-atomic actions

### DIFF
--- a/contracts/authorization/src/tests/processor.rs
+++ b/contracts/authorization/src/tests/processor.rs
@@ -1799,7 +1799,7 @@ fn retry_multi_action_non_atomic_batch_until_success() {
     assert_eq!(query_med_prio_queue.len(), 1);
 
     // No matter how many times we tick, the second message will always fail and it will be re-added to the queue
-    for _ in 0..5 {
+    for i in 0..5 {
         wasm.execute::<ProcessorExecuteMsg>(
             &processor_contract,
             &ProcessorExecuteMsg::PermissionlessAction(ProcessorPermissionlessMsg::Tick {}),
@@ -1821,6 +1821,11 @@ fn retry_multi_action_non_atomic_batch_until_success() {
             .unwrap();
 
         assert_eq!(query_med_prio_queue.len(), 1);
+        // Verify the current retry we are at
+        assert_eq!(
+            query_med_prio_queue[0].retry.clone().unwrap().retry_amounts,
+            i + 1
+        );
         setup.app.increase_time(5);
     }
 
@@ -1855,6 +1860,8 @@ fn retry_multi_action_non_atomic_batch_until_success() {
         .unwrap();
 
     assert_eq!(query_med_prio_queue.len(), 1);
+    // Verify that after moving to the next action, the current retries has been reset
+    assert_eq!(query_med_prio_queue[0].retry, None);
 
     // Last tick will process the last message and send the callback
     wasm.execute::<ProcessorExecuteMsg>(

--- a/contracts/processor/src/callback.rs
+++ b/contracts/processor/src/callback.rs
@@ -76,7 +76,7 @@ pub fn handle_successful_non_atomic_callback(
     storage: &mut dyn Storage,
     index: usize,
     execution_id: u64,
-    batch: &MessageBatch,
+    batch: &mut MessageBatch,
     messages: &mut Vec<CosmosMsg>,
     processor_address: &Addr,
 ) -> Result<(), ContractError> {
@@ -98,8 +98,9 @@ pub fn handle_successful_non_atomic_callback(
         EXECUTION_ID_TO_BATCH.remove(storage, execution_id);
     } else {
         // We have more actions to process
-        // Increase the index and re-add batch to the queue
+        // Increase the index, reset retries and re-add batch to the queue
         NON_ATOMIC_BATCH_CURRENT_ACTION_INDEX.save(storage, execution_id, &next_index)?;
+        batch.retry = None;
         let queue = get_queue_map(&batch.priority);
         queue.push_back(storage, batch)?;
     }

--- a/contracts/processor/src/contract.rs
+++ b/contracts/processor/src/contract.rs
@@ -476,7 +476,7 @@ fn process_callback(
             deps.storage,
             index,
             execution_id,
-            &pending_callback.message_batch,
+            &mut pending_callback.message_batch,
             &mut messages,
             &env.contract.address,
         )?;
@@ -645,7 +645,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                             deps.storage,
                             index,
                             msg.id,
-                            &batch,
+                            &mut batch,
                             &mut messages,
                             &env.contract.address,
                         )?;


### PR DESCRIPTION
While updating the spec I found a bug in how we handle the retries for non-atomic actions.
Currently we were not resetting the current retry we are at when we moved from a non-atomic action that succeeded after being retried.
Now, when we move to the next non atomic action in the batch, we remove the retries so that it has a fresh start, like it should)
Fixed this in this PR and added it to tests to catch this in the future.