### PR TITLE
Process tokenfactory tokens during processor callback

### DIFF
--- a/contracts/authorization/src/contract.rs
+++ b/contracts/authorization/src/contract.rs
@@ -712,7 +712,14 @@ fn process_processor_callback(
     CURRENT_EXECUTIONS.update(
         deps.storage,
         callback.label.clone(),
-        |current| -> StdResult<_> { Ok(current.unwrap_or_default().saturating_sub(1)) },
+        |current| -> Result<u64, ContractError> {
+            let count = current.unwrap_or_default();
+            if count == 0 {
+                Err(ContractError::CurrentExecutionsIsZero {})
+            } else {
+                Ok(count - 1)
+            }
+        },
     )?;
 
     // Check if a token was sent to perform this operation and that it wasn't started by the owner
@@ -812,8 +819,13 @@ fn process_polytone_callback(
                                 CURRENT_EXECUTIONS.update(
                                     deps.storage,
                                     callback_info.label,
-                                    |current| -> StdResult<_> {
-                                        Ok(current.unwrap_or_default().saturating_sub(1))
+                                    |current| -> Result<u64, ContractError> {
+                                        let count = current.unwrap_or_default();
+                                        if count == 0 {
+                                            Err(ContractError::CurrentExecutionsIsZero {})
+                                        } else {
+                                            Ok(count - 1)
+                                        }
                                     },
                                 )?;
                             }
@@ -831,8 +843,13 @@ fn process_polytone_callback(
                     CURRENT_EXECUTIONS.update(
                         deps.storage,
                         callback_info.label,
-                        |current| -> StdResult<_> {
-                            Ok(current.unwrap_or_default().saturating_sub(1))
+                        |current| -> Result<u64, ContractError> {
+                            let count = current.unwrap_or_default();
+                            if count == 0 {
+                                Err(ContractError::CurrentExecutionsIsZero {})
+                            } else {
+                                Ok(count - 1)
+                            }
                         },
                     )?;
                 }

--- a/contracts/authorization/src/domain.rs
+++ b/contracts/authorization/src/domain.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{to_json_binary, Binary, CosmosMsg, DepsMut, Storage, Uint64, WasmMsg};
+use neutron_sdk::bindings::msg::NeutronMsg;
 use valence_authorization_utils::{
     authorization::{ActionsConfig, Authorization},
     callback::PolytoneCallbackMsg,
@@ -17,7 +18,7 @@ pub fn add_domain(
     deps: DepsMut,
     callback_receiver: String,
     domain: &ExternalDomainInfo,
-) -> Result<CosmosMsg, ContractError> {
+) -> Result<CosmosMsg<NeutronMsg>, ContractError> {
     let external_domain = domain.to_external_domain_validated(deps.api)?;
 
     if EXTERNAL_DOMAINS.has(deps.storage, external_domain.name.clone()) {

--- a/contracts/authorization/src/error.rs
+++ b/contracts/authorization/src/error.rs
@@ -35,6 +35,9 @@ pub enum ContractError {
 
     #[error("Execution ID {execution_id} does not exist")]
     ExecutionIDNotFound { execution_id: u64 },
+
+    #[error("Unexpected current executions value, cannot be 0")]
+    CurrentExecutionsIsZero {},
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/contracts/authorization/src/tests/processor.rs
+++ b/contracts/authorization/src/tests/processor.rs
@@ -1,6 +1,9 @@
-use cosmwasm_std::{Addr, Binary};
+use cosmwasm_std::{Addr, Binary, Uint128};
 use cw_utils::Duration;
-use neutron_test_tube::{Account, Module, Wasm};
+use margined_neutron_std::types::cosmos::{
+    bank::v1beta1::QueryBalanceRequest, base::v1beta1::Coin,
+};
+use neutron_test_tube::{Account, Bank, Module, Wasm};
 use valence_authorization_utils::{
     action::{ActionCallback, RetryLogic, RetryTimes},
     authorization::{
@@ -14,6 +17,7 @@ use valence_authorization_utils::{
 use valence_processor_utils::{msg::InternalProcessorMsg, processor::MessageBatch};
 
 use crate::{
+    contract::build_tokenfactory_denom,
     error::{AuthorizationErrorReason, ContractError},
     tests::{
         builders::{
@@ -2626,6 +2630,191 @@ fn reject_and_confirm_non_atomic_action_with_callback() {
         query_callbacks[0].execution_result,
         ExecutionResult::Success
     );
+}
+
+#[test]
+fn refund_and_burn_tokens_after_callback() {
+    let setup = NeutronTestAppBuilder::new().build().unwrap();
+
+    let wasm = Wasm::new(&setup.app);
+    let bank = Bank::new(&setup.app);
+
+    let (authorization_contract, processor_contract) =
+        store_and_instantiate_authorization_with_processor_contract(
+            &setup.app,
+            &setup.owner_accounts[0],
+            setup.owner_addr.to_string(),
+            vec![setup.subowner_addr.to_string()],
+        );
+    let test_service_contract =
+        store_and_instantiate_test_service(&wasm, &setup.owner_accounts[0], None);
+
+    // We'll create an authorization that will we'll force to succeed once and fail another time to check that refund and burning works
+    let authorizations = vec![AuthorizationBuilder::new()
+        .with_label("permissioned-with-limit")
+        .with_mode(AuthorizationModeInfo::Permissioned(
+            PermissionTypeInfo::WithCallLimit(vec![(
+                setup.user_accounts[0].address(),
+                // Mint two tokens to also check concurrent executions
+                Uint128::new(2),
+            )]),
+        ))
+        .with_actions_config(
+            NonAtomicActionsConfigBuilder::new()
+                .with_action(
+                    NonAtomicActionBuilder::new()
+                        .with_contract_address(&test_service_contract)
+                        .with_message_details(MessageDetails {
+                            message_type: MessageType::CosmwasmExecuteMsg,
+                            message: Message {
+                                name: "will_succeed_if_true".to_string(),
+                                params_restrictions: None,
+                            },
+                        })
+                        .build(),
+                )
+                .build(),
+        )
+        .build()];
+
+    // Create the authorization and messages that will be sent
+    wasm.execute::<ExecuteMsg>(
+        &authorization_contract,
+        &ExecuteMsg::PermissionedAction(PermissionedMsg::CreateAuthorizations { authorizations }),
+        &[],
+        &setup.owner_accounts[0],
+    )
+    .unwrap();
+
+    let binary =
+        Binary::from(serde_json::to_vec(&TestServiceExecuteMsg::WillSucceedIfTrue {}).unwrap());
+
+    let message1 = ProcessorMessage::CosmwasmExecuteMsg { msg: binary };
+
+    // The token that was minted to the user
+    let permission_token =
+        build_tokenfactory_denom(&authorization_contract, "permissioned-with-limit");
+
+    // Sending the message will enqueue into the processor
+    wasm.execute::<ExecuteMsg>(
+        &authorization_contract,
+        &ExecuteMsg::PermissionlessAction(PermissionlessMsg::SendMsgs {
+            label: "permissioned-with-limit".to_string(),
+            messages: vec![message1.clone()],
+            ttl: None,
+        }),
+        &[Coin {
+            denom: permission_token.clone(),
+            amount: "1".to_string(),
+        }],
+        &setup.user_accounts[0],
+    )
+    .unwrap();
+
+    // Trying to send again will fail because there's only 1 concurrent execution allowed
+    let error = wasm
+        .execute::<ExecuteMsg>(
+            &authorization_contract,
+            &ExecuteMsg::PermissionlessAction(PermissionlessMsg::SendMsgs {
+                label: "permissioned-with-limit".to_string(),
+                messages: vec![message1.clone()],
+                ttl: None,
+            }),
+            &[Coin {
+                denom: permission_token.clone(),
+                amount: "1".to_string(),
+            }],
+            &setup.user_accounts[0],
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains(
+        ContractError::Authorization(AuthorizationErrorReason::MaxConcurrentExecutionsReached {})
+            .to_string()
+            .as_str()
+    ));
+
+    // Let's balance of the user to verify he only has 1 token left
+    let balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: setup.user_accounts[0].address(),
+            denom: permission_token.clone(),
+        })
+        .unwrap();
+
+    assert_eq!(balance.balance.unwrap().amount, "1");
+
+    // Ticking the processor will make it fail and send a Rejected callback, which should refund the token to the user
+    wasm.execute::<ProcessorExecuteMsg>(
+        &processor_contract,
+        &ProcessorExecuteMsg::PermissionlessAction(ProcessorPermissionlessMsg::Tick {}),
+        &[],
+        &setup.owner_accounts[0],
+    )
+    .unwrap();
+
+    // Check that the user has been refunded
+    let balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: setup.user_accounts[0].address(),
+            denom: permission_token.clone(),
+        })
+        .unwrap();
+
+    assert_eq!(balance.balance.unwrap().amount, "2");
+
+    // Now we should be able to enqueue again
+    wasm.execute::<ExecuteMsg>(
+        &authorization_contract,
+        &ExecuteMsg::PermissionlessAction(PermissionlessMsg::SendMsgs {
+            label: "permissioned-with-limit".to_string(),
+            messages: vec![message1],
+            ttl: None,
+        }),
+        &[Coin {
+            denom: permission_token.clone(),
+            amount: "1".to_string(),
+        }],
+        &setup.user_accounts[0],
+    )
+    .unwrap();
+
+    // Modify the test service to make the message succeed when it eventually executes
+    wasm.execute::<TestServiceExecuteMsg>(
+        &test_service_contract,
+        &TestServiceExecuteMsg::SetCondition { condition: true },
+        &[],
+        &setup.owner_accounts[0],
+    )
+    .unwrap();
+
+    // Ticking the processor will make it succeed and send a Success callback, which should burn the token instead of refunding it
+    wasm.execute::<ProcessorExecuteMsg>(
+        &processor_contract,
+        &ProcessorExecuteMsg::PermissionlessAction(ProcessorPermissionlessMsg::Tick {}),
+        &[],
+        &setup.owner_accounts[0],
+    )
+    .unwrap();
+
+    // Verify that user still has 1 token and contract doesn't have any
+    let user_balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: setup.user_accounts[0].address(),
+            denom: permission_token.clone(),
+        })
+        .unwrap();
+
+    assert_eq!(user_balance.balance.unwrap().amount, "1");
+
+    let contract_balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: authorization_contract.clone(),
+            denom: permission_token.clone(),
+        })
+        .unwrap();
+
+    assert_eq!(contract_balance.balance.unwrap().amount, "0");
 }
 
 #[test]

--- a/contracts/authorization/src/tests/processor.rs
+++ b/contracts/authorization/src/tests/processor.rs
@@ -2649,7 +2649,7 @@ fn refund_and_burn_tokens_after_callback() {
     let test_service_contract =
         store_and_instantiate_test_service(&wasm, &setup.owner_accounts[0], None);
 
-    // We'll create an authorization that we'll force to succeed once and fail another time to check that refund and burning works
+    // We'll create an authorization that we'll force to fail and succeed once to check that refund and burning works
     let authorizations = vec![AuthorizationBuilder::new()
         .with_label("permissioned-with-limit")
         .with_mode(AuthorizationModeInfo::Permissioned(

--- a/contracts/authorization/src/tests/processor.rs
+++ b/contracts/authorization/src/tests/processor.rs
@@ -2649,7 +2649,7 @@ fn refund_and_burn_tokens_after_callback() {
     let test_service_contract =
         store_and_instantiate_test_service(&wasm, &setup.owner_accounts[0], None);
 
-    // We'll create an authorization that will we'll force to succeed once and fail another time to check that refund and burning works
+    // We'll create an authorization that we'll force to succeed once and fail another time to check that refund and burning works
     let authorizations = vec![AuthorizationBuilder::new()
         .with_label("permissioned-with-limit")
         .with_mode(AuthorizationModeInfo::Permissioned(

--- a/packages/authorization-utils/src/callback.rs
+++ b/packages/authorization-utils/src/callback.rs
@@ -8,6 +8,8 @@ use crate::{domain::Domain, msg::ProcessorMessage};
 pub struct ProcessorCallbackInfo {
     // Execution ID that the callback was for
     pub execution_id: u64,
+    // Who started this operation, used for tokenfactory actions
+    pub initiator: OperationInitiator,
     // Address that can send a bridge timeout or success for the message (if applied)
     pub bridge_callback_address: Option<Addr>,
     // Address that will send the callback for the processor
@@ -22,6 +24,13 @@ pub struct ProcessorCallbackInfo {
     pub ttl: Option<Expiration>,
     // Result of the execution
     pub execution_result: ExecutionResult,
+}
+
+#[cw_serde]
+pub enum OperationInitiator {
+    // Owner can execute operations without using tokens
+    Owner,
+    User(Addr),
 }
 
 #[cw_serde]


### PR DESCRIPTION
Closes #19 .

If a user who spent a token to execute a batch (permissioned with limit) couldn't execute anything, his token is given back instead of being consumed.