### PR TITLE
Increase TTL time for polytone test

### DIFF
--- a/local-interchaintest/examples/polytone.rs
+++ b/local-interchaintest/examples/polytone.rs
@@ -706,7 +706,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     std::thread::sleep(Duration::from_secs(3));
 
-    let ttl_time = 60;
+    let ttl_time = 120;
     info!(
         "Sending the messages with TTL (and {} seconds as expire)...",
         ttl_time


### PR DESCRIPTION
Relayer is sometimes too slow due to rate limiting and the packet arrives after the 60 seconds set up as ttl and it makes it not retriable.
Increase TTL time to give more time to the relayer to send the timeout to make sure we don't get false positives for this.