### PR TITLE
Fix Splitter ServiceConfig

### DIFF
--- a/contracts/services/splitter/src/msg.rs
+++ b/contracts/services/splitter/src/msg.rs
@@ -157,17 +157,23 @@ impl UncheckedSplitConfig {
 #[cw_serde]
 #[derive(OptionalStruct)]
 pub struct ServiceConfig {
-    pub input_addr: String,
+    pub input_addr: ServiceAccountType,
     pub splits: Vec<UncheckedSplitConfig>,
 }
 
 impl ServiceConfig {
-    pub fn new(input_addr: String, splits: Vec<UncheckedSplitConfig>) -> Self {
-        ServiceConfig { input_addr, splits }
+    pub fn new(
+        input_addr: impl Into<ServiceAccountType>,
+        splits: Vec<UncheckedSplitConfig>,
+    ) -> Self {
+        ServiceConfig {
+            input_addr: input_addr.into(),
+            splits,
+        }
     }
 
     fn do_validate(&self, api: &dyn cosmwasm_std::Api) -> Result<Addr, ServiceError> {
-        let input_addr = api.addr_validate(&self.input_addr)?;
+        let input_addr = self.input_addr.to_addr(api)?;
         validate_splits(api, &self.splits)?;
         Ok(input_addr)
     }
@@ -240,7 +246,7 @@ impl OptionalServiceConfig {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         // First update input_addr (if needed)
         if let Some(input_addr) = self.input_addr {
-            config.input_addr = deps.api.addr_validate(&input_addr)?;
+            config.input_addr = input_addr.to_addr(deps.api)?;
         }
 
         // Then validate & update splits (if needed)

--- a/contracts/services/splitter/src/tests.rs
+++ b/contracts/services/splitter/src/tests.rs
@@ -110,7 +110,7 @@ impl SplitterTestSuite {
     }
 
     fn splitter_config(&self, splits: Vec<UncheckedSplitConfig>) -> ServiceConfig {
-        ServiceConfig::new(self.input_addr.to_string(), splits)
+        ServiceConfig::new(self.input_addr(), splits)
     }
 
     fn cw20_token_init(&mut self, name: &str, symbol: &str, amount: u128, addr: String) -> Addr {
@@ -357,7 +357,7 @@ fn update_config_with_valid_config() {
         STARS,
         &suite.input_addr,
     ));
-    cfg.input_addr = output_addr.to_string();
+    cfg.input_addr = (&output_addr).into();
 
     // Execute update config action
     suite.update_config(svc.clone(), cfg).unwrap();

--- a/local-interchaintest/examples/token_swap.rs
+++ b/local-interchaintest/examples/token_swap.rs
@@ -198,7 +198,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         owner: NEUTRON_CHAIN_ADMIN_ADDR.to_string(),
         processor: processor_contract_address.clone(),
         config: ServiceConfig {
-            input_addr: base_account_1.clone(),
+            input_addr: ServiceAccountType::Addr(base_account_1.clone()),
             splits: vec![UncheckedSplitConfig {
                 denom: UncheckedDenom::Native(token1.clone()),
                 account: ServiceAccountType::Addr(base_account_2.clone()),
@@ -225,7 +225,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         owner: NEUTRON_CHAIN_ADMIN_ADDR.to_string(),
         processor: processor_contract_address.clone(),
         config: ServiceConfig {
-            input_addr: base_account_2.clone(),
+            input_addr: ServiceAccountType::Addr(base_account_2.clone()),
             splits: vec![UncheckedSplitConfig {
                 denom: UncheckedDenom::Native(token2.clone()),
                 account: ServiceAccountType::Addr(base_account_1.clone()),


### PR DESCRIPTION
Fix omission in Splitter's `ServiceConfig`: `input_addr` must be a `ServiceAccountType`.