### PR TITLE
Update logic into services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,6 +4915,7 @@ dependencies = [
  "cw-denom",
  "cw-multi-test",
  "cw-ownable",
+ "cw-storage-plus 2.0.0",
  "cw-utils 2.0.0",
  "cw20 2.0.0",
  "cw20-base",

--- a/contracts/services/astroport-lper/src/bin/schema.rs
+++ b/contracts/services/astroport-lper/src/bin/schema.rs
@@ -1,12 +1,12 @@
 use cosmwasm_schema::write_api;
 
-use valence_astroport_lper::msg::{ActionsMsgs, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use valence_astroport_lper::msg::{ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg<ServiceConfig>,
-        execute: ExecuteMsg<ActionsMsgs,OptionalServiceConfig>,
+        execute: ExecuteMsg<ActionsMsgs,ServiceConfigUpdate>,
         query: QueryMsg,
     }
 }

--- a/contracts/services/astroport-lper/src/bin/schema.rs
+++ b/contracts/services/astroport-lper/src/bin/schema.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::write_api;
 
-use valence_astroport_lper::msg::{ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use valence_astroport_lper::msg::{ActionsMsgs, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 
 fn main() {

--- a/contracts/services/astroport-lper/src/contract.rs
+++ b/contracts/services/astroport-lper/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,7 +27,7 @@ pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg<ActionsMsgs, OptionalServiceConfig>,
+    msg: ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>,
 ) -> Result<Response, ServiceError> {
     valence_service_base::execute(
         deps,
@@ -43,14 +43,14 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, OptionalServiceConfig};
+    use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
         deps: &DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,
-        new_config: OptionalServiceConfig,
+        new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
         new_config.update_config(deps, config)
     }

--- a/contracts/services/astroport-lper/src/contract.rs
+++ b/contracts/services/astroport-lper/src/contract.rs
@@ -340,9 +340,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&config)
         }
         QueryMsg::GetRawServiceConfig {} => {
-            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
-                ServiceConfig,
-            >(deps.storage)?;
+            let raw_config: ServiceConfig =
+                valence_service_utils::raw_config::query_raw_service_config(deps.storage)?;
             to_json_binary(&raw_config)
         }
     }

--- a/contracts/services/astroport-lper/src/contract.rs
+++ b/contracts/services/astroport-lper/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");

--- a/contracts/services/astroport-lper/src/contract.rs
+++ b/contracts/services/astroport-lper/src/contract.rs
@@ -43,16 +43,15 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, ServiceConfigUpdate};
+    use crate::msg::ServiceConfigUpdate;
 
     pub fn update_config(
         deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
-        config: &mut Config,
         new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
-        new_config.update_config(deps, config)
+        new_config.update_config(deps)
     }
 }
 

--- a/contracts/services/astroport-lper/src/contract.rs
+++ b/contracts/services/astroport-lper/src/contract.rs
@@ -46,7 +46,7 @@ mod execute {
     use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
-        deps: &DepsMut,
+        deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,

--- a/contracts/services/astroport-lper/src/contract.rs
+++ b/contracts/services/astroport-lper/src/contract.rs
@@ -339,5 +339,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let config: Config = valence_service_base::load_config(deps.storage)?;
             to_json_binary(&config)
         }
+        QueryMsg::GetRawServiceConfig {} => {
+            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
+                ServiceConfig,
+            >(deps.storage)?;
+            to_json_binary(&raw_config)
+        }
     }
 }

--- a/contracts/services/astroport-lper/src/msg.rs
+++ b/contracts/services/astroport-lper/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{ensure, Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
-use valence_macros::OptionalStruct;
+use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::{
     error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType, ServiceConfigInterface,
 };
@@ -34,15 +34,11 @@ impl DecimalRange {
     }
 }
 
+#[valence_service_query]
 #[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum QueryMsg {
-    #[returns(Addr)]
-    GetProcessor {},
-    #[returns(Config)]
-    GetServiceConfig {},
-}
+pub enum QueryMsg {}
 
 #[cw_serde]
 #[derive(OptionalStruct)]

--- a/contracts/services/astroport-lper/src/msg.rs
+++ b/contracts/services/astroport-lper/src/msg.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{ensure, Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
 use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::{
-    error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType, ServiceConfigInterface,
+    error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType,
 };
 
 #[cw_serde]
@@ -105,13 +105,6 @@ pub struct Config {
     pub output_addr: Addr,
     pub pool_addr: Addr,
     pub lp_config: LiquidityProviderConfig,
-}
-
-impl ServiceConfigInterface<ServiceConfig> for ServiceConfig {
-    /// This function is used to see if 2 configs are different
-    fn is_diff(&self, other: &ServiceConfig) -> bool {
-        !self.eq(other)
-    }
 }
 
 impl ServiceConfigValidation<Config> for ServiceConfig {

--- a/contracts/services/astroport-lper/src/msg.rs
+++ b/contracts/services/astroport-lper/src/msg.rs
@@ -134,7 +134,7 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
         }

--- a/contracts/services/astroport-lper/src/msg.rs
+++ b/contracts/services/astroport-lper/src/msg.rs
@@ -134,7 +134,9 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut) -> Result<(), ServiceError> {
+        let mut config: Config = valence_service_base::load_config(deps.storage)?;
+
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
         }
@@ -158,6 +160,7 @@ impl ServiceConfigUpdate {
             &deps.as_ref(),
         )?;
 
+        valence_service_base::save_config(deps.storage, &config)?;
         Ok(())
     }
 }

--- a/contracts/services/astroport-lper/src/msg.rs
+++ b/contracts/services/astroport-lper/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{ensure, Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
-use valence_macros::{valence_service_query, OptionalStruct};
+use valence_macros::{valence_service_query, ValenceServiceInterface};
 use valence_service_utils::{
     error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType,
 };
@@ -41,7 +41,7 @@ impl DecimalRange {
 pub enum QueryMsg {}
 
 #[cw_serde]
-#[derive(OptionalStruct)]
+#[derive(ValenceServiceInterface)]
 pub struct ServiceConfig {
     pub input_addr: ServiceAccountType,
     pub output_addr: ServiceAccountType,
@@ -133,7 +133,7 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
     }
 }
 
-impl OptionalServiceConfig {
+impl ServiceConfigUpdate {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;

--- a/contracts/services/astroport-lper/src/tests.rs
+++ b/contracts/services/astroport-lper/src/tests.rs
@@ -13,7 +13,7 @@ use valence_service_utils::{
 };
 
 use crate::msg::{
-    ActionsMsgs, AssetData, LiquidityProviderConfig, ServiceConfigUpdate, PoolType, ServiceConfig,
+    ActionsMsgs, AssetData, LiquidityProviderConfig, PoolType, ServiceConfig, ServiceConfigUpdate,
 };
 
 const CONTRACT_PATH: &str = "../../../artifacts";

--- a/contracts/services/astroport-lper/src/tests.rs
+++ b/contracts/services/astroport-lper/src/tests.rs
@@ -13,7 +13,7 @@ use valence_service_utils::{
 };
 
 use crate::msg::{
-    ActionsMsgs, AssetData, LiquidityProviderConfig, OptionalServiceConfig, PoolType, ServiceConfig,
+    ActionsMsgs, AssetData, LiquidityProviderConfig, ServiceConfigUpdate, PoolType, ServiceConfig,
 };
 
 const CONTRACT_PATH: &str = "../../../artifacts";
@@ -187,7 +187,7 @@ pub fn only_owner_can_update_config() {
     let setup = LPerTestSuite::default();
     let wasm = Wasm::new(&setup.inner.app);
 
-    let new_config = OptionalServiceConfig {
+    let new_config = ServiceConfigUpdate {
         input_addr: Some(setup.input_acc.as_str().into()),
         output_addr: Some(setup.output_acc.as_str().into()),
         pool_addr: Some(setup.inner.pool_cw20_addr.clone()),
@@ -204,7 +204,7 @@ pub fn only_owner_can_update_config() {
     };
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.lper_addr,
             &ExecuteMsg::UpdateConfig {
                 new_config: new_config.clone(),
@@ -220,7 +220,7 @@ pub fn only_owner_can_update_config() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::UpdateConfig { new_config },
         &[],
@@ -235,7 +235,7 @@ fn only_owner_can_update_processor() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.lper_addr,
             &ExecuteMsg::UpdateProcessor {
                 processor: setup.inner.owner_acc().address(),
@@ -251,7 +251,7 @@ fn only_owner_can_update_processor() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::UpdateProcessor {
             processor: setup.inner.owner_acc().address(),
@@ -268,7 +268,7 @@ fn only_owner_can_transfer_ownership() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.lper_addr,
             &ExecuteMsg::UpdateOwnership(cw_ownable::Action::TransferOwnership {
                 new_owner: setup.inner.processor_acc().address(),
@@ -285,7 +285,7 @@ fn only_owner_can_transfer_ownership() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::UpdateOwnership(cw_ownable::Action::TransferOwnership {
             new_owner: setup.inner.processor_acc().address(),
@@ -403,7 +403,7 @@ fn only_processor_can_execute_actions() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.lper_addr,
             &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideDoubleSidedLiquidity {
                 expected_pool_ratio_range: None,
@@ -419,7 +419,7 @@ fn only_processor_can_execute_actions() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideDoubleSidedLiquidity {
             expected_pool_ratio_range: None,
@@ -455,7 +455,7 @@ fn provide_double_sided_liquidity_native_lp_token() {
         .iter()
         .any(|c| c.denom == setup.inner.pool_asset2));
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideDoubleSidedLiquidity {
             expected_pool_ratio_range: None,
@@ -517,7 +517,7 @@ fn provide_double_sided_liquidity_cw20_lp_token() {
         .iter()
         .any(|c| c.denom == setup.inner.pool_asset2));
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideDoubleSidedLiquidity {
             expected_pool_ratio_range: None,
@@ -576,7 +576,7 @@ fn provide_single_sided_liquidity_native_lp_token() {
         .iter()
         .any(|c| c.denom == setup.inner.pool_asset2));
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideSingleSidedLiquidity {
             asset: setup.inner.pool_asset1.clone(),
@@ -644,7 +644,7 @@ fn provide_single_sided_liquidity_cw20_lp_token() {
         .iter()
         .any(|c| c.denom == setup.inner.pool_asset2));
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.lper_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideSingleSidedLiquidity {
             asset: setup.inner.pool_asset1.clone(),
@@ -690,7 +690,7 @@ fn test_limit_single_sided_liquidity() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.lper_addr,
             &ExecuteMsg::ProcessAction(ActionsMsgs::ProvideSingleSidedLiquidity {
                 asset: setup.inner.pool_asset1.clone(),

--- a/contracts/services/astroport-withdrawer/src/bin/schema.rs
+++ b/contracts/services/astroport-withdrawer/src/bin/schema.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::write_api;
 
 use valence_astroport_withdrawer::msg::{
-    ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig,
+    ActionsMsgs, QueryMsg, ServiceConfig, ServiceConfigUpdate,
 };
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 

--- a/contracts/services/astroport-withdrawer/src/bin/schema.rs
+++ b/contracts/services/astroport-withdrawer/src/bin/schema.rs
@@ -1,14 +1,14 @@
 use cosmwasm_schema::write_api;
 
 use valence_astroport_withdrawer::msg::{
-    ActionsMsgs, OptionalServiceConfig, QueryMsg, ServiceConfig,
+    ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig,
 };
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg<ServiceConfig>,
-        execute: ExecuteMsg<ActionsMsgs,OptionalServiceConfig>,
+        execute: ExecuteMsg<ActionsMsgs,ServiceConfigUpdate>,
         query: QueryMsg,
     }
 }

--- a/contracts/services/astroport-withdrawer/src/contract.rs
+++ b/contracts/services/astroport-withdrawer/src/contract.rs
@@ -112,9 +112,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&config)
         }
         QueryMsg::GetRawServiceConfig {} => {
-            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
-                ServiceConfig,
-            >(deps.storage)?;
+            let raw_config: ServiceConfig =
+                valence_service_utils::raw_config::query_raw_service_config(deps.storage)?;
             to_json_binary(&raw_config)
         }
     }

--- a/contracts/services/astroport-withdrawer/src/contract.rs
+++ b/contracts/services/astroport-withdrawer/src/contract.rs
@@ -111,5 +111,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let config: Config = valence_service_base::load_config(deps.storage)?;
             to_json_binary(&config)
         }
+        QueryMsg::GetRawServiceConfig {} => {
+            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
+                ServiceConfig,
+            >(deps.storage)?;
+            to_json_binary(&raw_config)
+        }
     }
 }

--- a/contracts/services/astroport-withdrawer/src/contract.rs
+++ b/contracts/services/astroport-withdrawer/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,7 +27,7 @@ pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg<ActionsMsgs, OptionalServiceConfig>,
+    msg: ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>,
 ) -> Result<Response, ServiceError> {
     valence_service_base::execute(
         deps,
@@ -43,14 +43,14 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, OptionalServiceConfig};
+    use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
         deps: &DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,
-        new_config: OptionalServiceConfig,
+        new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
         new_config.update_config(deps, config)
     }

--- a/contracts/services/astroport-withdrawer/src/contract.rs
+++ b/contracts/services/astroport-withdrawer/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");

--- a/contracts/services/astroport-withdrawer/src/contract.rs
+++ b/contracts/services/astroport-withdrawer/src/contract.rs
@@ -43,16 +43,15 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, ServiceConfigUpdate};
+    use crate::msg::ServiceConfigUpdate;
 
     pub fn update_config(
         deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
-        config: &mut Config,
         new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
-        new_config.update_config(deps, config)
+        new_config.update_config(deps)
     }
 }
 

--- a/contracts/services/astroport-withdrawer/src/contract.rs
+++ b/contracts/services/astroport-withdrawer/src/contract.rs
@@ -46,7 +46,7 @@ mod execute {
     use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
-        deps: &DepsMut,
+        deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,

--- a/contracts/services/astroport-withdrawer/src/msg.rs
+++ b/contracts/services/astroport-withdrawer/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
-use valence_macros::OptionalStruct;
+use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::{
     error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType,
 };
@@ -11,15 +11,11 @@ pub enum ActionsMsgs {
     WithdrawLiquidity {},
 }
 
+#[valence_service_query]
 #[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum QueryMsg {
-    #[returns(Addr)]
-    GetProcessor {},
-    #[returns(Config)]
-    GetServiceConfig {},
-}
+pub enum QueryMsg {}
 
 #[cw_serde]
 #[derive(OptionalStruct)]

--- a/contracts/services/astroport-withdrawer/src/msg.rs
+++ b/contracts/services/astroport-withdrawer/src/msg.rs
@@ -92,7 +92,7 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
         }

--- a/contracts/services/astroport-withdrawer/src/msg.rs
+++ b/contracts/services/astroport-withdrawer/src/msg.rs
@@ -92,7 +92,9 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut) -> Result<(), ServiceError> {
+        let mut config: Config = valence_service_base::load_config(deps.storage)?;
+
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
         }
@@ -108,6 +110,8 @@ impl ServiceConfigUpdate {
         if let Some(withdrawer_config) = self.withdrawer_config {
             config.withdrawer_config = withdrawer_config;
         }
+
+        valence_service_base::save_config(deps.storage, &config)?;
         Ok(())
     }
 }

--- a/contracts/services/astroport-withdrawer/src/msg.rs
+++ b/contracts/services/astroport-withdrawer/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
-use valence_macros::{valence_service_query, OptionalStruct};
+use valence_macros::{valence_service_query, ValenceServiceInterface};
 use valence_service_utils::{
     error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType,
 };
@@ -18,7 +18,7 @@ pub enum ActionsMsgs {
 pub enum QueryMsg {}
 
 #[cw_serde]
-#[derive(OptionalStruct)]
+#[derive(ValenceServiceInterface)]
 pub struct ServiceConfig {
     pub input_addr: ServiceAccountType,
     pub output_addr: ServiceAccountType,
@@ -91,7 +91,7 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
     }
 }
 
-impl OptionalServiceConfig {
+impl ServiceConfigUpdate {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;

--- a/contracts/services/astroport-withdrawer/src/tests.rs
+++ b/contracts/services/astroport-withdrawer/src/tests.rs
@@ -14,7 +14,7 @@ use valence_service_utils::{
 };
 
 use crate::msg::{
-    ActionsMsgs, LiquidityWithdrawerConfig, OptionalServiceConfig, PoolType, ServiceConfig,
+    ActionsMsgs, LiquidityWithdrawerConfig, ServiceConfigUpdate, PoolType, ServiceConfig,
 };
 
 const CONTRACT_PATH: &str = "../../../artifacts";
@@ -178,7 +178,7 @@ pub fn only_owner_can_update_config() {
     let setup = WithdrawerTestSuite::default();
     let wasm = Wasm::new(&setup.inner.app);
 
-    let new_config = OptionalServiceConfig {
+    let new_config = ServiceConfigUpdate {
         input_addr: Some(setup.input_acc.as_str().into()),
         output_addr: Some(setup.output_acc.as_str().into()),
         pool_addr: Some(setup.inner.pool_cw20_addr.clone()),
@@ -188,7 +188,7 @@ pub fn only_owner_can_update_config() {
     };
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.withdrawer_addr,
             &ExecuteMsg::UpdateConfig {
                 new_config: new_config.clone(),
@@ -204,7 +204,7 @@ pub fn only_owner_can_update_config() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.withdrawer_addr,
         &ExecuteMsg::UpdateConfig { new_config },
         &[],
@@ -219,7 +219,7 @@ fn only_owner_can_update_processor() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.withdrawer_addr,
             &ExecuteMsg::UpdateProcessor {
                 processor: setup.inner.owner_acc().address(),
@@ -235,7 +235,7 @@ fn only_owner_can_update_processor() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.withdrawer_addr,
         &ExecuteMsg::UpdateProcessor {
             processor: setup.inner.owner_acc().address(),
@@ -252,7 +252,7 @@ fn only_owner_can_transfer_ownership() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.withdrawer_addr,
             &ExecuteMsg::UpdateOwnership(cw_ownable::Action::TransferOwnership {
                 new_owner: setup.inner.processor_acc().address(),
@@ -269,7 +269,7 @@ fn only_owner_can_transfer_ownership() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.withdrawer_addr,
         &ExecuteMsg::UpdateOwnership(cw_ownable::Action::TransferOwnership {
             new_owner: setup.inner.processor_acc().address(),
@@ -287,7 +287,7 @@ fn only_processor_can_execute_actions() {
     let wasm = Wasm::new(&setup.inner.app);
 
     let error = wasm
-        .execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+        .execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
             &setup.withdrawer_addr,
             &ExecuteMsg::ProcessAction(ActionsMsgs::WithdrawLiquidity {}),
             &[],
@@ -301,7 +301,7 @@ fn only_processor_can_execute_actions() {
             .as_str(),
     ),);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.withdrawer_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::WithdrawLiquidity {}),
         &[],
@@ -316,7 +316,7 @@ fn withdraw_liquidity_native_lp_token() {
     let wasm = Wasm::new(&setup.inner.app);
     let bank = Bank::new(&setup.inner.app);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.withdrawer_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::WithdrawLiquidity {}),
         &[],
@@ -350,7 +350,7 @@ fn withdraw_liquidity_cw20_lp_token() {
     let wasm = Wasm::new(&setup.inner.app);
     let bank = Bank::new(&setup.inner.app);
 
-    wasm.execute::<ExecuteMsg<ActionsMsgs, OptionalServiceConfig>>(
+    wasm.execute::<ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>>(
         &setup.withdrawer_addr,
         &ExecuteMsg::ProcessAction(ActionsMsgs::WithdrawLiquidity {}),
         &[],

--- a/contracts/services/astroport-withdrawer/src/tests.rs
+++ b/contracts/services/astroport-withdrawer/src/tests.rs
@@ -14,7 +14,7 @@ use valence_service_utils::{
 };
 
 use crate::msg::{
-    ActionsMsgs, LiquidityWithdrawerConfig, ServiceConfigUpdate, PoolType, ServiceConfig,
+    ActionsMsgs, LiquidityWithdrawerConfig, PoolType, ServiceConfig, ServiceConfigUpdate,
 };
 
 const CONTRACT_PATH: &str = "../../../artifacts";

--- a/contracts/services/forwarder/src/bin/schema.rs
+++ b/contracts/services/forwarder/src/bin/schema.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::write_api;
 
-use valence_forwarder_service::msg::{ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use valence_forwarder_service::msg::{ActionsMsgs, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 
 fn main() {

--- a/contracts/services/forwarder/src/bin/schema.rs
+++ b/contracts/services/forwarder/src/bin/schema.rs
@@ -1,12 +1,12 @@
 use cosmwasm_schema::write_api;
 
-use valence_forwarder_service::msg::{ActionsMsgs, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use valence_forwarder_service::msg::{ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg<ServiceConfig>,
-        execute: ExecuteMsg<ActionsMsgs,OptionalServiceConfig>,
+        execute: ExecuteMsg<ActionsMsgs,ServiceConfigUpdate>,
         query: QueryMsg,
     }
 }

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,7 +27,7 @@ pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg<ActionsMsgs, OptionalServiceConfig>,
+    msg: ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>,
 ) -> Result<Response, ServiceError> {
     valence_service_base::execute(
         deps,
@@ -155,14 +155,14 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, OptionalServiceConfig};
+    use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
         deps: &DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,
-        new_config: OptionalServiceConfig,
+        new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
         new_config.update_config(deps, config)
     }

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -183,9 +183,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&config)
         }
         QueryMsg::GetRawServiceConfig {} => {
-            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
-                ServiceConfig,
-            >(deps.storage)?;
+            let raw_config: ServiceConfig =
+                valence_service_utils::raw_config::query_raw_service_config(deps.storage)?;
             to_json_binary(&raw_config)
         }
     }

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -19,7 +19,6 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg<ServiceConfig>,
 ) -> Result<Response, ServiceError> {
-    // Custom
     valence_service_base::instantiate(deps, CONTRACT_NAME, CONTRACT_VERSION, msg)
 }
 

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -155,16 +155,15 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, ServiceConfigUpdate};
+    use crate::msg::ServiceConfigUpdate;
 
     pub fn update_config(
         deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
-        config: &mut Config,
         new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
-        new_config.update_config(deps, config)
+        new_config.update_config(deps)
     }
 }
 

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -158,7 +158,7 @@ mod execute {
     use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
-        deps: &DepsMut,
+        deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -19,6 +19,7 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg<ServiceConfig>,
 ) -> Result<Response, ServiceError> {
+    // Custom
     valence_service_base::instantiate(deps, CONTRACT_NAME, CONTRACT_VERSION, msg)
 }
 
@@ -180,6 +181,12 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GetServiceConfig {} => {
             let config: Config = valence_service_base::load_config(deps.storage)?;
             to_json_binary(&config)
+        }
+        QueryMsg::GetRawServiceConfig {} => {
+            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
+                ServiceConfig,
+            >(deps.storage)?;
+            to_json_binary(&raw_config)
         }
     }
 }

--- a/contracts/services/forwarder/src/contract.rs
+++ b/contracts/services/forwarder/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");

--- a/contracts/services/forwarder/src/msg.rs
+++ b/contracts/services/forwarder/src/msg.rs
@@ -4,7 +4,7 @@ use cw_ownable::cw_ownable_query;
 use cw_utils::Duration;
 use getset::{Getters, Setters};
 use std::collections::HashMap;
-use valence_macros::{valence_service_query, OptionalStruct};
+use valence_macros::{valence_service_query, ValenceServiceInterface};
 use valence_service_utils::{
     denoms::{CheckedDenom, DenomError, UncheckedDenom},
     error::ServiceError,
@@ -84,10 +84,9 @@ impl From<(UncheckedDenom, u128)> for UncheckedForwardingConfig {
 }
 
 #[cw_serde]
-#[derive(OptionalStruct)]
+#[derive(ValenceServiceInterface)]
 /// Struct representing the service configuration.
 pub struct ServiceConfig {
-    #[ignore_optional]
     /// The input address for the service.
     pub input_addr: ServiceAccountType,
     /// The output address for the service.
@@ -181,11 +180,11 @@ fn convert_to_checked_configs(
         .map_err(|err| ServiceError::ConfigurationError(err.to_string()))
 }
 
-impl OptionalServiceConfig {
+impl ServiceConfigUpdate {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
-        // if let Some(input_addr) = self.input_addr {
-        //     config.input_addr = input_addr.to_addr(deps.api)?;
-        // }
+        if let Some(input_addr) = self.input_addr {
+            config.input_addr = input_addr.to_addr(deps.api)?;
+        }
 
         if let Some(output_addr) = self.output_addr {
             config.output_addr = output_addr.to_addr(deps.api)?;

--- a/contracts/services/forwarder/src/msg.rs
+++ b/contracts/services/forwarder/src/msg.rs
@@ -4,7 +4,7 @@ use cw_ownable::cw_ownable_query;
 use cw_utils::Duration;
 use getset::{Getters, Setters};
 use std::collections::HashMap;
-use valence_macros::OptionalStruct;
+use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::{
     denoms::{CheckedDenom, DenomError, UncheckedDenom},
     error::ServiceError,
@@ -19,18 +19,12 @@ pub enum ActionsMsgs {
     Forward {},
 }
 
+#[valence_service_query]
 #[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 /// Enum representing the different query messages that can be sent.
-pub enum QueryMsg {
-    /// Query to get the processor address.
-    #[returns(Addr)]
-    GetProcessor {},
-    /// Query to get the service configuration.
-    #[returns(Config)]
-    GetServiceConfig {},
-}
+pub enum QueryMsg {}
 
 // Forwarding configuration per denom
 type ForwardingConfigs = Vec<ForwardingConfig>;

--- a/contracts/services/forwarder/src/msg.rs
+++ b/contracts/services/forwarder/src/msg.rs
@@ -181,7 +181,7 @@ fn convert_to_checked_configs(
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
         }

--- a/contracts/services/forwarder/src/msg.rs
+++ b/contracts/services/forwarder/src/msg.rs
@@ -9,7 +9,7 @@ use valence_service_utils::{
     denoms::{CheckedDenom, DenomError, UncheckedDenom},
     error::ServiceError,
     msg::ServiceConfigValidation,
-    ServiceAccountType, ServiceConfigInterface,
+    ServiceAccountType,
 };
 
 #[cw_serde]
@@ -87,6 +87,7 @@ impl From<(UncheckedDenom, u128)> for UncheckedForwardingConfig {
 #[derive(OptionalStruct)]
 /// Struct representing the service configuration.
 pub struct ServiceConfig {
+    #[ignore_optional]
     /// The input address for the service.
     pub input_addr: ServiceAccountType,
     /// The output address for the service.
@@ -180,18 +181,11 @@ fn convert_to_checked_configs(
         .map_err(|err| ServiceError::ConfigurationError(err.to_string()))
 }
 
-impl ServiceConfigInterface<ServiceConfig> for ServiceConfig {
-    /// This function is used to see if 2 configs are different
-    fn is_diff(&self, other: &ServiceConfig) -> bool {
-        !self.eq(other)
-    }
-}
-
 impl OptionalServiceConfig {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
-        if let Some(input_addr) = self.input_addr {
-            config.input_addr = input_addr.to_addr(deps.api)?;
-        }
+        // if let Some(input_addr) = self.input_addr {
+        //     config.input_addr = input_addr.to_addr(deps.api)?;
+        // }
 
         if let Some(output_addr) = self.output_addr {
             config.output_addr = output_addr.to_addr(deps.api)?;

--- a/contracts/services/forwarder/src/msg.rs
+++ b/contracts/services/forwarder/src/msg.rs
@@ -181,7 +181,9 @@ fn convert_to_checked_configs(
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut) -> Result<(), ServiceError> {
+        let mut config: Config = valence_service_base::load_config(deps.storage)?;
+
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
         }
@@ -204,6 +206,8 @@ impl ServiceConfigUpdate {
         if let Some(forwarding_constraints) = self.forwarding_constraints {
             config.forwarding_constraints = forwarding_constraints;
         }
+
+        valence_service_base::save_config(deps.storage, &config)?;
 
         Ok(())
     }

--- a/contracts/services/reverse-splitter/src/bin/schema.rs
+++ b/contracts/services/reverse-splitter/src/bin/schema.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::write_api;
 
 use valence_reverse_splitter_service::msg::{
-    ActionMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig,
+    ActionMsgs, QueryMsg, ServiceConfig, ServiceConfigUpdate,
 };
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 

--- a/contracts/services/reverse-splitter/src/bin/schema.rs
+++ b/contracts/services/reverse-splitter/src/bin/schema.rs
@@ -1,14 +1,14 @@
 use cosmwasm_schema::write_api;
 
 use valence_reverse_splitter_service::msg::{
-    ActionMsgs, OptionalServiceConfig, QueryMsg, ServiceConfig,
+    ActionMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig,
 };
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg<ServiceConfig>,
-        execute: ExecuteMsg<ActionMsgs, OptionalServiceConfig>,
+        execute: ExecuteMsg<ActionMsgs, ServiceConfigUpdate>,
         query: QueryMsg,
     }
 }

--- a/contracts/services/reverse-splitter/src/contract.rs
+++ b/contracts/services/reverse-splitter/src/contract.rs
@@ -271,16 +271,15 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, ServiceConfigUpdate};
+    use crate::msg::ServiceConfigUpdate;
 
     pub fn update_config(
         deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
-        config: &mut Config,
         new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
-        new_config.update_config(deps, config)
+        new_config.update_config(deps)
     }
 }
 

--- a/contracts/services/reverse-splitter/src/contract.rs
+++ b/contracts/services/reverse-splitter/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,7 +27,7 @@ pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg<ActionMsgs, OptionalServiceConfig>,
+    msg: ExecuteMsg<ActionMsgs, ServiceConfigUpdate>,
 ) -> Result<Response, ServiceError> {
     valence_service_base::execute(
         deps,
@@ -271,14 +271,14 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, OptionalServiceConfig};
+    use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
         deps: &DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,
-        new_config: OptionalServiceConfig,
+        new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
         new_config.update_config(deps, config)
     }

--- a/contracts/services/reverse-splitter/src/contract.rs
+++ b/contracts/services/reverse-splitter/src/contract.rs
@@ -297,5 +297,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let config: Config = valence_service_base::load_config(deps.storage)?;
             to_json_binary(&config)
         }
+        QueryMsg::GetRawServiceConfig {} => {
+            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
+                ServiceConfig,
+            >(deps.storage)?;
+            to_json_binary(&raw_config)
+        }
     }
 }

--- a/contracts/services/reverse-splitter/src/contract.rs
+++ b/contracts/services/reverse-splitter/src/contract.rs
@@ -274,7 +274,7 @@ mod execute {
     use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
-        deps: &DepsMut,
+        deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,

--- a/contracts/services/reverse-splitter/src/contract.rs
+++ b/contracts/services/reverse-splitter/src/contract.rs
@@ -298,9 +298,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&config)
         }
         QueryMsg::GetRawServiceConfig {} => {
-            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
-                ServiceConfig,
-            >(deps.storage)?;
+            let raw_config: ServiceConfig =
+                valence_service_utils::raw_config::query_raw_service_config(deps.storage)?;
             to_json_binary(&raw_config)
         }
     }

--- a/contracts/services/reverse-splitter/src/contract.rs
+++ b/contracts/services/reverse-splitter/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");

--- a/contracts/services/reverse-splitter/src/msg.rs
+++ b/contracts/services/reverse-splitter/src/msg.rs
@@ -271,7 +271,7 @@ fn convert_to_checked_split_amount(
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         // First update output_addr & base_denom (if needed)
         if let Some(output_addr) = self.output_addr {
             config.output_addr = output_addr.to_addr(deps.api)?;

--- a/contracts/services/reverse-splitter/src/msg.rs
+++ b/contracts/services/reverse-splitter/src/msg.rs
@@ -271,7 +271,9 @@ fn convert_to_checked_split_amount(
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut) -> Result<(), ServiceError> {
+        let mut config: Config = valence_service_base::load_config(deps.storage)?;
+
         // First update output_addr & base_denom (if needed)
         if let Some(output_addr) = self.output_addr {
             config.output_addr = output_addr.to_addr(deps.api)?;
@@ -297,6 +299,8 @@ impl ServiceConfigUpdate {
 
             config.splits = convert_to_checked_configs(deps.as_ref(), &splits)?;
         }
+
+        valence_service_base::save_config(deps.storage, &config)?;
         Ok(())
     }
 }

--- a/contracts/services/reverse-splitter/src/msg.rs
+++ b/contracts/services/reverse-splitter/src/msg.rs
@@ -6,10 +6,10 @@ use cw_ownable::cw_ownable_query;
 use getset::{Getters, Setters};
 use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::denoms::CheckedDenom;
+use valence_service_utils::ServiceAccountType;
 use valence_service_utils::{
     denoms::UncheckedDenom, error::ServiceError, msg::ServiceConfigValidation,
 };
-use valence_service_utils::{ServiceAccountType, ServiceConfigInterface};
 
 #[cw_serde]
 pub enum ActionMsgs {
@@ -267,13 +267,6 @@ fn convert_to_checked_split_amount(
             contract_addr: api.addr_validate(contract_addr)?,
             params: params.clone(),
         }),
-    }
-}
-
-impl ServiceConfigInterface<ServiceConfig> for ServiceConfig {
-    /// This function is used to see if 2 configs are different
-    fn is_diff(&self, other: &ServiceConfig) -> bool {
-        !self.eq(other)
     }
 }
 

--- a/contracts/services/reverse-splitter/src/msg.rs
+++ b/contracts/services/reverse-splitter/src/msg.rs
@@ -4,7 +4,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
 use getset::{Getters, Setters};
-use valence_macros::{valence_service_query, OptionalStruct};
+use valence_macros::{valence_service_query, ValenceServiceInterface};
 use valence_service_utils::denoms::CheckedDenom;
 use valence_service_utils::ServiceAccountType;
 use valence_service_utils::{
@@ -176,7 +176,7 @@ struct DynamicRatioResponse {
 }
 
 #[cw_serde]
-#[derive(OptionalStruct)]
+#[derive(ValenceServiceInterface)]
 pub struct ServiceConfig {
     pub output_addr: ServiceAccountType,
     pub splits: Vec<UncheckedSplitConfig>,
@@ -270,7 +270,7 @@ fn convert_to_checked_split_amount(
     }
 }
 
-impl OptionalServiceConfig {
+impl ServiceConfigUpdate {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         // First update output_addr & base_denom (if needed)
         if let Some(output_addr) = self.output_addr {

--- a/contracts/services/reverse-splitter/src/msg.rs
+++ b/contracts/services/reverse-splitter/src/msg.rs
@@ -4,7 +4,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
 use getset::{Getters, Setters};
-use valence_macros::OptionalStruct;
+use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::denoms::CheckedDenom;
 use valence_service_utils::{
     denoms::UncheckedDenom, error::ServiceError, msg::ServiceConfigValidation,
@@ -16,18 +16,12 @@ pub enum ActionMsgs {
     Split {},
 }
 
+#[valence_service_query]
 #[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 /// Enum representing the different query messages that can be sent.
-pub enum QueryMsg {
-    /// Query to get the processor address.
-    #[returns(Addr)]
-    GetProcessor {},
-    /// Query to get the service configuration.
-    #[returns(Config)]
-    GetServiceConfig {},
-}
+pub enum QueryMsg {}
 
 pub type SplitConfigs = Vec<SplitConfig>;
 

--- a/contracts/services/splitter/src/bin/schema.rs
+++ b/contracts/services/splitter/src/bin/schema.rs
@@ -1,12 +1,12 @@
 use cosmwasm_schema::write_api;
 
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
-use valence_splitter_service::msg::{ActionMsgs, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use valence_splitter_service::msg::{ActionMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg<ServiceConfig>,
-        execute: ExecuteMsg<ActionMsgs, OptionalServiceConfig>,
+        execute: ExecuteMsg<ActionMsgs, ServiceConfigUpdate>,
         query: QueryMsg,
     }
 }

--- a/contracts/services/splitter/src/bin/schema.rs
+++ b/contracts/services/splitter/src/bin/schema.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::write_api;
 
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
-use valence_splitter_service::msg::{ActionMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use valence_splitter_service::msg::{ActionMsgs, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 fn main() {
     write_api! {

--- a/contracts/services/splitter/src/contract.rs
+++ b/contracts/services/splitter/src/contract.rs
@@ -245,5 +245,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let config: Config = valence_service_base::load_config(deps.storage)?;
             to_json_binary(&config)
         }
+        QueryMsg::GetRawServiceConfig {} => {
+            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
+                ServiceConfig,
+            >(deps.storage)?;
+            to_json_binary(&raw_config)
+        }
     }
 }

--- a/contracts/services/splitter/src/contract.rs
+++ b/contracts/services/splitter/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,7 +27,7 @@ pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg<ActionMsgs, OptionalServiceConfig>,
+    msg: ExecuteMsg<ActionMsgs, ServiceConfigUpdate>,
 ) -> Result<Response, ServiceError> {
     valence_service_base::execute(
         deps,
@@ -219,14 +219,14 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, OptionalServiceConfig};
+    use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
         deps: &DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,
-        new_config: OptionalServiceConfig,
+        new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
         new_config.update_config(deps, config)
     }

--- a/contracts/services/splitter/src/contract.rs
+++ b/contracts/services/splitter/src/contract.rs
@@ -219,16 +219,15 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, ServiceConfigUpdate};
+    use crate::msg::ServiceConfigUpdate;
 
     pub fn update_config(
         deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
-        config: &mut Config,
         new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
-        new_config.update_config(deps, config)
+        new_config.update_config(deps)
     }
 }
 

--- a/contracts/services/splitter/src/contract.rs
+++ b/contracts/services/splitter/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");

--- a/contracts/services/splitter/src/contract.rs
+++ b/contracts/services/splitter/src/contract.rs
@@ -246,9 +246,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&config)
         }
         QueryMsg::GetRawServiceConfig {} => {
-            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
-                ServiceConfig,
-            >(deps.storage)?;
+            let raw_config: ServiceConfig =
+                valence_service_utils::raw_config::query_raw_service_config(deps.storage)?;
             to_json_binary(&raw_config)
         }
     }

--- a/contracts/services/splitter/src/contract.rs
+++ b/contracts/services/splitter/src/contract.rs
@@ -222,7 +222,7 @@ mod execute {
     use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
-        deps: &DepsMut,
+        deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,

--- a/contracts/services/splitter/src/msg.rs
+++ b/contracts/services/splitter/src/msg.rs
@@ -230,7 +230,7 @@ fn convert_to_checked_split_amount(
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         // First update input_addr (if needed)
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;

--- a/contracts/services/splitter/src/msg.rs
+++ b/contracts/services/splitter/src/msg.rs
@@ -6,10 +6,10 @@ use cw_ownable::cw_ownable_query;
 use getset::{Getters, Setters};
 use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::denoms::CheckedDenom;
+use valence_service_utils::ServiceAccountType;
 use valence_service_utils::{
     denoms::UncheckedDenom, error::ServiceError, msg::ServiceConfigValidation,
 };
-use valence_service_utils::{ServiceAccountType, ServiceConfigInterface};
 
 #[cw_serde]
 pub enum ActionMsgs {
@@ -226,13 +226,6 @@ fn convert_to_checked_split_amount(
             contract_addr: api.addr_validate(contract_addr)?,
             params: params.clone(),
         }),
-    }
-}
-
-impl ServiceConfigInterface<ServiceConfig> for ServiceConfig {
-    /// This function is used to see if 2 configs are different
-    fn is_diff(&self, other: &ServiceConfig) -> bool {
-        !self.eq(other)
     }
 }
 

--- a/contracts/services/splitter/src/msg.rs
+++ b/contracts/services/splitter/src/msg.rs
@@ -230,7 +230,9 @@ fn convert_to_checked_split_amount(
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut) -> Result<(), ServiceError> {
+        let mut config: Config = valence_service_base::load_config(deps.storage)?;
+
         // First update input_addr (if needed)
         if let Some(input_addr) = self.input_addr {
             config.input_addr = input_addr.to_addr(deps.api)?;
@@ -242,6 +244,8 @@ impl ServiceConfigUpdate {
 
             config.splits = convert_to_checked_configs(deps.as_ref(), &splits)?;
         }
+
+        valence_service_base::save_config(deps.storage, &config)?;
         Ok(())
     }
 }

--- a/contracts/services/splitter/src/msg.rs
+++ b/contracts/services/splitter/src/msg.rs
@@ -4,7 +4,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
 use getset::{Getters, Setters};
-use valence_macros::OptionalStruct;
+use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::denoms::CheckedDenom;
 use valence_service_utils::{
     denoms::UncheckedDenom, error::ServiceError, msg::ServiceConfigValidation,
@@ -16,18 +16,12 @@ pub enum ActionMsgs {
     Split {},
 }
 
+#[valence_service_query]
 #[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 /// Enum representing the different query messages that can be sent.
-pub enum QueryMsg {
-    /// Query to get the processor address.
-    #[returns(Addr)]
-    GetProcessor {},
-    /// Query to get the service configuration.
-    #[returns(Config)]
-    GetServiceConfig {},
-}
+pub enum QueryMsg {}
 
 pub type SplitConfigs = Vec<SplitConfig>;
 

--- a/contracts/services/splitter/src/msg.rs
+++ b/contracts/services/splitter/src/msg.rs
@@ -4,7 +4,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
 use getset::{Getters, Setters};
-use valence_macros::{valence_service_query, OptionalStruct};
+use valence_macros::{valence_service_query, ValenceServiceInterface};
 use valence_service_utils::denoms::CheckedDenom;
 use valence_service_utils::ServiceAccountType;
 use valence_service_utils::{
@@ -149,7 +149,7 @@ impl UncheckedSplitConfig {
 }
 
 #[cw_serde]
-#[derive(OptionalStruct)]
+#[derive(ValenceServiceInterface)]
 pub struct ServiceConfig {
     pub input_addr: ServiceAccountType,
     pub splits: Vec<UncheckedSplitConfig>,
@@ -229,7 +229,7 @@ fn convert_to_checked_split_amount(
     }
 }
 
-impl OptionalServiceConfig {
+impl ServiceConfigUpdate {
     pub fn update_config(self, deps: &DepsMut, config: &mut Config) -> Result<(), ServiceError> {
         // First update input_addr (if needed)
         if let Some(input_addr) = self.input_addr {

--- a/contracts/services/template/src/bin/schema.rs
+++ b/contracts/services/template/src/bin/schema.rs
@@ -1,12 +1,12 @@
 use cosmwasm_schema::write_api;
 
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
-use valence_template_service::msg::{ActionsMsgs, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use valence_template_service::msg::{ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg<ServiceConfig>,
-        execute: ExecuteMsg<ActionsMsgs,OptionalServiceConfig>,
+        execute: ExecuteMsg<ActionsMsgs,ServiceConfigUpdate>,
         query: QueryMsg,
     }
 }

--- a/contracts/services/template/src/bin/schema.rs
+++ b/contracts/services/template/src/bin/schema.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::write_api;
 
 use valence_service_utils::msg::{ExecuteMsg, InstantiateMsg};
-use valence_template_service::msg::{ActionsMsgs, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use valence_template_service::msg::{ActionsMsgs, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 fn main() {
     write_api! {

--- a/contracts/services/template/src/contract.rs
+++ b/contracts/services/template/src/contract.rs
@@ -6,7 +6,10 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
+use crate::{
+    msg::{ActionsMsgs, Config, Config2, QueryMsg, ServiceConfig, ServiceConfigUpdate},
+    CONFIG2,
+};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -19,6 +22,12 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg<ServiceConfig>,
 ) -> Result<Response, ServiceError> {
+    CONFIG2.save(
+        deps.storage,
+        &Config2 {
+            optional2: msg.config.optional2.clone(),
+        },
+    )?;
     valence_service_base::instantiate(deps, CONTRACT_NAME, CONTRACT_VERSION, msg)
 }
 
@@ -65,7 +74,7 @@ mod execute {
     use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
-        deps: &DepsMut,
+        deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,

--- a/contracts/services/template/src/contract.rs
+++ b/contracts/services/template/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -27,7 +27,7 @@ pub fn execute(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: ExecuteMsg<ActionsMsgs, OptionalServiceConfig>,
+    msg: ExecuteMsg<ActionsMsgs, ServiceConfigUpdate>,
 ) -> Result<Response, ServiceError> {
     valence_service_base::execute(
         deps,
@@ -62,14 +62,14 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, OptionalServiceConfig};
+    use crate::msg::{Config, ServiceConfigUpdate};
 
     pub fn update_config(
         deps: &DepsMut,
         _env: Env,
         _info: MessageInfo,
         config: &mut Config,
-        new_config: OptionalServiceConfig,
+        new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
         new_config.update_config(deps, config)
     }

--- a/contracts/services/template/src/contract.rs
+++ b/contracts/services/template/src/contract.rs
@@ -88,5 +88,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let config: Config = valence_service_base::load_config(deps.storage)?;
             to_json_binary(&config)
         }
+        QueryMsg::GetRawServiceConfig {} => {
+            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
+                ServiceConfig,
+            >(deps.storage)?;
+            to_json_binary(&raw_config)
+        }
     }
 }

--- a/contracts/services/template/src/contract.rs
+++ b/contracts/services/template/src/contract.rs
@@ -71,16 +71,15 @@ mod execute {
     use cosmwasm_std::{DepsMut, Env, MessageInfo};
     use valence_service_utils::error::ServiceError;
 
-    use crate::msg::{Config, ServiceConfigUpdate};
+    use crate::msg::ServiceConfigUpdate;
 
     pub fn update_config(
         deps: DepsMut,
         _env: Env,
         _info: MessageInfo,
-        config: &mut Config,
         new_config: ServiceConfigUpdate,
     ) -> Result<(), ServiceError> {
-        new_config.update_config(deps, config)
+        new_config.update_config(deps)
     }
 }
 

--- a/contracts/services/template/src/contract.rs
+++ b/contracts/services/template/src/contract.rs
@@ -89,9 +89,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&config)
         }
         QueryMsg::GetRawServiceConfig {} => {
-            let raw_config = valence_service_utils::raw_config::query_raw_service_config::<
-                ServiceConfig,
-            >(deps.storage)?;
+            let raw_config: ServiceConfig = valence_service_base::load_raw_config(deps.storage)?;
             to_json_binary(&raw_config)
         }
     }

--- a/contracts/services/template/src/contract.rs
+++ b/contracts/services/template/src/contract.rs
@@ -6,7 +6,7 @@ use valence_service_utils::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");

--- a/contracts/services/template/src/lib.rs
+++ b/contracts/services/template/src/lib.rs
@@ -1,5 +1,10 @@
+use cw_storage_plus::Item;
+use msg::Config2;
+
 pub mod contract;
 pub mod msg;
 
 #[cfg(test)]
 mod tests;
+
+pub(crate) const CONFIG2: Item<Config2> = Item::new("config2");

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -52,7 +52,10 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+    /// Service developer must not forget to update config storage needed
+    pub fn update_config(self, deps: DepsMut) -> Result<(), ServiceError> {
+        let mut config: Config = valence_service_base::load_config(deps.storage)?;
+
         if let OptionUpdate::Set(optional) = self.optional {
             config.optional = optional;
         }
@@ -63,6 +66,7 @@ impl ServiceConfigUpdate {
             config2.optional2 = optional2;
         }
 
+        valence_service_base::save_config(deps.storage, &config)?;
         CONFIG2.save(deps.storage, &config2)?;
 
         Ok(())

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
-use valence_macros::OptionalStruct;
+use valence_macros::{valence_service_query, OptionalStruct};
 use valence_service_utils::{
     error::ServiceError, msg::ServiceConfigValidation, ServiceConfigInterface,
 };
@@ -11,18 +11,12 @@ pub enum ActionsMsgs {
     NoOp {},
 }
 
+#[valence_service_query]
 #[cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 /// Enum representing the different query messages that can be sent.
-pub enum QueryMsg {
-    /// Query to get the processor address.
-    #[returns(Addr)]
-    GetProcessor {},
-    /// Query to get the service configuration.
-    #[returns(Config)]
-    GetServiceConfig {},
-}
+pub enum QueryMsg {}
 
 #[cw_serde]
 #[derive(OptionalStruct)]

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -22,7 +22,8 @@ pub struct ServiceConfig {
     /// We ignore this field when generating the ValenceServiceInterface
     /// This means this field is not updatable
     #[skip_update]
-    pub ignore_optional_admin: String,
+    pub skip_update_admin: String,
+    pub optional: Option<String>
 }
 
 impl ServiceConfigValidation<Config> for ServiceConfig {
@@ -33,7 +34,7 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 
     fn validate(&self, deps: Deps) -> Result<Config, ServiceError> {
         Ok(Config {
-            admin: deps.api.addr_validate(&self.ignore_optional_admin)?,
+            admin: deps.api.addr_validate(&self.skip_update_admin)?,
         })
     }
 }

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -23,7 +23,8 @@ pub struct ServiceConfig {
     /// This means this field is not updatable
     #[skip_update]
     pub skip_update_admin: String,
-    pub optional: Option<String>
+    pub optional: Option<String>,
+    pub optional2: String,
 }
 
 impl ServiceConfigValidation<Config> for ServiceConfig {

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -2,7 +2,11 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
 use valence_macros::{valence_service_query, ValenceServiceInterface};
-use valence_service_utils::{error::ServiceError, msg::ServiceConfigValidation};
+use valence_service_utils::{
+    error::ServiceError, msg::ServiceConfigValidation, ServiceAccountType,
+};
+
+use crate::CONFIG2;
 
 #[cw_serde]
 pub enum ActionsMsgs {
@@ -16,13 +20,19 @@ pub enum ActionsMsgs {
 /// Enum representing the different query messages that can be sent.
 pub enum QueryMsg {}
 
+/// Everything a service needs as a parameter to be instantiated goes into `ServiceConfig`
+/// `ValenceServiceInterface` generates `ServiceConfigUpdate` is used in update method that allows to update the service configuration
+/// `ServiceConfigUpdate` turns all fields <T> from `ServiceConfig` into Option<T>
+///  
+/// Fields that are Option<T>, will be generated as OptionUpdate<T>
+/// If a field cannot or should not be updated, it should be annotated with #[skip_update]
 #[cw_serde]
 #[derive(ValenceServiceInterface)]
 pub struct ServiceConfig {
     /// We ignore this field when generating the ValenceServiceInterface
     /// This means this field is not updatable
     #[skip_update]
-    pub skip_update_admin: String,
+    pub skip_update_admin: ServiceAccountType,
     pub optional: Option<String>,
     pub optional2: String,
 }
@@ -35,13 +45,26 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
 
     fn validate(&self, deps: Deps) -> Result<Config, ServiceError> {
         Ok(Config {
-            admin: deps.api.addr_validate(&self.skip_update_admin)?,
+            admin: self.skip_update_admin.to_addr(deps.api)?,
+            optional: self.optional.clone(),
         })
     }
 }
 
 impl ServiceConfigUpdate {
-    pub fn update_config(self, _deps: &DepsMut, _config: &mut Config) -> Result<(), ServiceError> {
+    pub fn update_config(self, deps: DepsMut, config: &mut Config) -> Result<(), ServiceError> {
+        if let OptionUpdate::Set(optional) = self.optional {
+            config.optional = optional;
+        }
+
+        // While we get &mut Config, we can execute regular storage operations
+        let mut config2 = CONFIG2.load(deps.storage)?;
+        if let Some(optional2) = self.optional2 {
+            config2.optional2 = optional2;
+        }
+
+        CONFIG2.save(deps.storage, &config2)?;
+
         Ok(())
     }
 }
@@ -49,4 +72,12 @@ impl ServiceConfigUpdate {
 #[cw_serde]
 pub struct Config {
     pub admin: Addr,
+    pub optional: Option<String>,
+}
+
+/// While we can save everything in ServiceConfig into Config
+/// The service is free to define its own storage struct
+#[cw_serde]
+pub struct Config2 {
+    pub optional2: String,
 }

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -20,7 +20,12 @@ pub enum QueryMsg {}
 
 #[cw_serde]
 #[derive(OptionalStruct)]
-pub struct ServiceConfig {}
+pub struct ServiceConfig {
+    /// We ignore this field when generating the OptionalServiceConfig
+    /// This means this field is not updatable
+    #[ignore_optional]
+    pub ignore_optional_admin: String,
+}
 
 impl ServiceConfigValidation<Config> for ServiceConfig {
     #[cfg(not(target_arch = "wasm32"))]
@@ -28,8 +33,10 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
         Ok(())
     }
 
-    fn validate(&self, _deps: Deps) -> Result<Config, ServiceError> {
-        Ok(Config {})
+    fn validate(&self, deps: Deps) -> Result<Config, ServiceError> {
+        Ok(Config {
+            admin: deps.api.addr_validate(&self.ignore_optional_admin)?,
+        })
     }
 }
 
@@ -47,4 +54,6 @@ impl OptionalServiceConfig {
 }
 
 #[cw_serde]
-pub struct Config {}
+pub struct Config {
+    pub admin: Addr,
+}

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
-use valence_macros::{valence_service_query, OptionalStruct};
+use valence_macros::{valence_service_query, ValenceServiceInterface};
 use valence_service_utils::{error::ServiceError, msg::ServiceConfigValidation};
 
 #[cw_serde]
@@ -17,11 +17,11 @@ pub enum ActionsMsgs {
 pub enum QueryMsg {}
 
 #[cw_serde]
-#[derive(OptionalStruct)]
+#[derive(ValenceServiceInterface)]
 pub struct ServiceConfig {
-    /// We ignore this field when generating the OptionalServiceConfig
+    /// We ignore this field when generating the ValenceServiceInterface
     /// This means this field is not updatable
-    #[ignore_optional]
+    #[skip_update]
     pub ignore_optional_admin: String,
 }
 
@@ -38,7 +38,7 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
     }
 }
 
-impl OptionalServiceConfig {
+impl ServiceConfigUpdate {
     pub fn update_config(self, _deps: &DepsMut, _config: &mut Config) -> Result<(), ServiceError> {
         Ok(())
     }

--- a/contracts/services/template/src/msg.rs
+++ b/contracts/services/template/src/msg.rs
@@ -2,9 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
 use valence_macros::{valence_service_query, OptionalStruct};
-use valence_service_utils::{
-    error::ServiceError, msg::ServiceConfigValidation, ServiceConfigInterface,
-};
+use valence_service_utils::{error::ServiceError, msg::ServiceConfigValidation};
 
 #[cw_serde]
 pub enum ActionsMsgs {
@@ -37,13 +35,6 @@ impl ServiceConfigValidation<Config> for ServiceConfig {
         Ok(Config {
             admin: deps.api.addr_validate(&self.ignore_optional_admin)?,
         })
-    }
-}
-
-impl ServiceConfigInterface<ServiceConfig> for ServiceConfig {
-    /// This function is used to see if 2 configs are different
-    fn is_diff(&self, other: &ServiceConfig) -> bool {
-        !self.eq(other)
     }
 }
 

--- a/contracts/services/template/src/tests.rs
+++ b/contracts/services/template/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::msg::{ActionsMsgs, Config, OptionalServiceConfig, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
 use cosmwasm_std::Addr;
 use cw_multi_test::{error::AnyResult, App, AppResponse, ContractWrapper, Executor};
 use cw_ownable::Ownership;
@@ -133,8 +133,8 @@ fn instantiate_with_valid_config() {
     );
 
     // Here we just want to make sure that our ignore_optional actually works
-    // Because we ignore the only available field, OptionalServiceConfig expected to have no fields
-    let _ = OptionalServiceConfig {};
+    // Because we ignore the only available field, ServiceConfigUpdate expected to have no fields
+    let _ = ServiceConfigUpdate {};
 }
 
 #[test]

--- a/contracts/services/template/src/tests.rs
+++ b/contracts/services/template/src/tests.rs
@@ -1,12 +1,11 @@
-use crate::msg::{ActionsMsgs, Config, ServiceConfigUpdate, QueryMsg, ServiceConfig};
+use crate::msg::{ActionsMsgs, Config, QueryMsg, ServiceConfig, ServiceConfigUpdate};
 use cosmwasm_std::Addr;
 use cw_multi_test::{error::AnyResult, App, AppResponse, ContractWrapper, Executor};
 use cw_ownable::Ownership;
 use getset::{Getters, Setters};
 use valence_service_utils::{
-    msg::ExecuteMsg,
-    msg::InstantiateMsg,
-    testing::{ServiceTestSuite, ServiceTestSuiteBase},
+    msg::{ExecuteMsg, InstantiateMsg},
+    testing::{ServiceTestSuite, ServiceTestSuiteBase}, OptionUpdate,
 };
 
 #[derive(Getters, Setters)]
@@ -54,7 +53,8 @@ impl TemplateTestSuite {
 
     fn template_config(&self, admin: String) -> ServiceConfig {
         ServiceConfig {
-            ignore_optional_admin: admin,
+            skip_update_admin: admin,
+            optional: None,
         }
     }
 
@@ -128,13 +128,14 @@ fn instantiate_with_valid_config() {
     assert_eq!(
         raw_svc_cfg,
         ServiceConfig {
-            ignore_optional_admin: suite.owner().clone().to_string(),
+            skip_update_admin: suite.owner().clone().to_string(),
+            optional: None
         }
     );
 
     // Here we just want to make sure that our ignore_optional actually works
     // Because we ignore the only available field, ServiceConfigUpdate expected to have no fields
-    let _ = ServiceConfigUpdate {};
+    let _ = ServiceConfigUpdate { optional: OptionUpdate::Set(None) };
 }
 
 #[test]

--- a/contracts/services/template/src/tests.rs
+++ b/contracts/services/template/src/tests.rs
@@ -54,7 +54,7 @@ impl TemplateTestSuite {
 
     fn template_config(&self, admin: String) -> ServiceConfig {
         ServiceConfig {
-            skip_update_admin: admin,
+            skip_update_admin: valence_service_utils::ServiceAccountType::Addr(admin),
             optional: None,
             optional2: "s".to_string(),
         }
@@ -124,13 +124,21 @@ fn instantiate_with_valid_config() {
 
     // Verify service config
     let svc_cfg: Config = suite.query_wasm(&svc, &QueryMsg::GetServiceConfig {});
-    assert_eq!(svc_cfg, Config { admin: admin_addr });
+    assert_eq!(
+        svc_cfg,
+        Config {
+            admin: admin_addr,
+            optional: None
+        }
+    );
 
     let raw_svc_cfg: ServiceConfig = suite.query_wasm(&svc, &QueryMsg::GetRawServiceConfig {});
     assert_eq!(
         raw_svc_cfg,
         ServiceConfig {
-            skip_update_admin: suite.owner().clone().to_string(),
+            skip_update_admin: valence_service_utils::ServiceAccountType::Addr(
+                suite.owner().to_string()
+            ),
             optional: None,
             optional2: "s".to_string(),
         }

--- a/packages/service-base/src/lib.rs
+++ b/packages/service-base/src/lib.rs
@@ -49,7 +49,7 @@ pub fn execute<T, U, V>(
     info: MessageInfo,
     msg: ExecuteMsg<T, V>,
     process_action: fn(DepsMut, Env, MessageInfo, T, U) -> Result<Response, ServiceError>,
-    update_config: fn(DepsMut, Env, MessageInfo, &mut U, V) -> Result<(), ServiceError>,
+    update_config: fn(DepsMut, Env, MessageInfo, V) -> Result<(), ServiceError>,
 ) -> Result<Response, ServiceError>
 where
     U: Serialize + DeserializeOwned,
@@ -65,10 +65,7 @@ where
             cw_ownable::assert_owner(deps.as_ref().storage, &info.sender)?;
             // We update the raw storage
             new_config.update_raw(deps.storage)?;
-
-            let config = &mut load_config(deps.storage)?;
-            update_config(deps.branch(), env, info, config, new_config)?;
-            save_config(deps.storage, config)?;
+            update_config(deps.branch(), env, info, new_config)?;
             Ok(Response::new().add_attribute("method", "update_config"))
         }
         ExecuteMsg::UpdateProcessor { processor } => {

--- a/packages/service-base/src/lib.rs
+++ b/packages/service-base/src/lib.rs
@@ -14,7 +14,7 @@ use valence_service_utils::{
 pub mod helpers;
 pub mod state;
 
-pub use crate::state::{get_ownership, get_processor, load_config, save_config};
+pub use crate::state::{get_ownership, get_processor, load_config, load_raw_config, save_config};
 
 pub fn instantiate<T, U>(
     deps: DepsMut,

--- a/packages/service-base/src/lib.rs
+++ b/packages/service-base/src/lib.rs
@@ -8,7 +8,7 @@ use valence_service_utils::{
     error::ServiceError,
     msg::{ExecuteMsg, InstantiateMsg, ServiceConfigValidation},
     raw_config::save_raw_service_config,
-    OptionalServiceConfigTrait,
+    ServiceConfigUpdateTrait,
 };
 
 pub mod helpers;
@@ -53,7 +53,7 @@ pub fn execute<T, U, V>(
 ) -> Result<Response, ServiceError>
 where
     U: Serialize + DeserializeOwned,
-    V: OptionalServiceConfigTrait + Serialize + DeserializeOwned,
+    V: ServiceConfigUpdateTrait + Serialize + DeserializeOwned,
 {
     match msg {
         ExecuteMsg::ProcessAction(action) => {

--- a/packages/service-base/src/lib.rs
+++ b/packages/service-base/src/lib.rs
@@ -44,12 +44,12 @@ where
 }
 
 pub fn execute<T, U, V>(
-    deps: DepsMut,
+    mut deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg<T, V>,
     process_action: fn(DepsMut, Env, MessageInfo, T, U) -> Result<Response, ServiceError>,
-    update_config: fn(&DepsMut, Env, MessageInfo, &mut U, V) -> Result<(), ServiceError>,
+    update_config: fn(DepsMut, Env, MessageInfo, &mut U, V) -> Result<(), ServiceError>,
 ) -> Result<Response, ServiceError>
 where
     U: Serialize + DeserializeOwned,
@@ -67,7 +67,7 @@ where
             new_config.update_raw(deps.storage)?;
 
             let config = &mut load_config(deps.storage)?;
-            update_config(&deps, env, info, config, new_config)?;
+            update_config(deps.branch(), env, info, config, new_config)?;
             save_config(deps.storage, config)?;
             Ok(Response::new().add_attribute("method", "update_config"))
         }

--- a/packages/service-base/src/state.rs
+++ b/packages/service-base/src/state.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{from_json, to_json_vec, Addr, StdError, StdResult, Storage};
 use cw_ownable::Ownership;
 use cw_storage_plus::Item;
 use serde::{de::DeserializeOwned, Serialize};
+use valence_service_utils::raw_config::load_raw_service_config;
 
 pub const CONFIG_KEY: &[u8] = b"config";
 pub const PROCESSOR: Item<Addr> = Item::new("processor");
@@ -34,6 +35,13 @@ where
         let object_info = not_found_object_info::<T>(CONFIG_KEY);
         Err(StdError::not_found(object_info))
     }
+}
+
+pub fn load_raw_config<T>(store: &dyn Storage) -> StdResult<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    load_raw_service_config(store)
 }
 
 fn not_found_object_info<T>(key: &[u8]) -> String {

--- a/packages/service-utils/Cargo.toml
+++ b/packages/service-utils/Cargo.toml
@@ -13,7 +13,7 @@ testing = [
     "dep:cw20",
     "dep:cw20-base",
     "dep:sha2",
-    "dep:valence-base-account"
+    "dep:valence-base-account",
 ]
 
 [dependencies]
@@ -27,6 +27,7 @@ serde_json            = { workspace = true }
 thiserror             = { workspace = true }
 valence-account-utils = { workspace = true }
 valence-macros        = { workspace = true }
+cw-storage-plus       = { workspace = true }
 
 # Testing dependencies
 cw-multi-test        = { workspace = true, optional = true }

--- a/packages/service-utils/src/lib.rs
+++ b/packages/service-utils/src/lib.rs
@@ -18,6 +18,14 @@ pub trait ServiceConfigUpdateTrait {
     fn update_raw(&self, storage: &mut dyn Storage) -> StdResult<()>;
 }
 
+#[cw_serde]
+#[derive(Default)]
+pub enum OptionUpdate<T> {
+    #[default]
+    None,
+    Set(Option<T>),
+}
+
 /// An account type that is used in the service configs
 /// It can either be an Id or Addr
 /// The config that will be passed to the service must be of Addr veriant
@@ -30,12 +38,6 @@ pub enum ServiceAccountType {
     AccountId(Id),
     #[serde(rename = "|service_id|", alias = "service_id")]
     ServiceId(Id),
-}
-
-#[cw_serde]
-pub enum OptionUpdate<T> {
-    None,
-    Set(Option<T>),
 }
 
 impl From<&Addr> for ServiceAccountType {

--- a/packages/service-utils/src/lib.rs
+++ b/packages/service-utils/src/lib.rs
@@ -14,12 +14,7 @@ pub mod testing;
 
 pub type Id = u64;
 
-pub trait ServiceConfigInterface<T, O> {
-    /// T is the config type
-    fn get_diff(&self, other: &T) -> Option<O>;
-}
-
-pub trait OptionalServiceConfigTrait {
+pub trait ServiceConfigUpdateTrait {
     fn update_raw(&self, storage: &mut dyn Storage) -> StdResult<()>;
 }
 
@@ -35,6 +30,12 @@ pub enum ServiceAccountType {
     AccountId(Id),
     #[serde(rename = "|service_id|", alias = "service_id")]
     ServiceId(Id),
+}
+
+#[cw_serde]
+pub enum UpdateOption<T> {
+    None,
+    Set(Option<T>),
 }
 
 impl From<&Addr> for ServiceAccountType {

--- a/packages/service-utils/src/lib.rs
+++ b/packages/service-utils/src/lib.rs
@@ -33,7 +33,7 @@ pub enum ServiceAccountType {
 }
 
 #[cw_serde]
-pub enum UpdateOption<T> {
+pub enum OptionUpdate<T> {
     None,
     Set(Option<T>),
 }

--- a/packages/service-utils/src/lib.rs
+++ b/packages/service-utils/src/lib.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_json_binary, Addr, CosmosMsg, StdError, StdResult, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, CosmosMsg, StdError, StdResult, Storage, WasmMsg};
 
 pub mod denoms {
     pub use cw_denom::{CheckedDenom, DenomError, UncheckedDenom};
@@ -7,6 +7,7 @@ pub mod denoms {
 
 pub mod error;
 pub mod msg;
+pub mod raw_config;
 
 #[cfg(feature = "testing")]
 pub mod testing;
@@ -16,6 +17,10 @@ pub type Id = u64;
 pub trait ServiceConfigInterface<T> {
     /// T is the config type
     fn is_diff(&self, other: &T) -> bool;
+}
+
+pub trait OptionalServiceConfigTrait {
+    fn update_raw(&self, storage: &mut dyn Storage) -> StdResult<()>;
 }
 
 /// An account type that is used in the service configs

--- a/packages/service-utils/src/lib.rs
+++ b/packages/service-utils/src/lib.rs
@@ -14,9 +14,9 @@ pub mod testing;
 
 pub type Id = u64;
 
-pub trait ServiceConfigInterface<T> {
+pub trait ServiceConfigInterface<T, O> {
     /// T is the config type
-    fn is_diff(&self, other: &T) -> bool;
+    fn get_diff(&self, other: &T) -> Option<O>;
 }
 
 pub trait OptionalServiceConfigTrait {

--- a/packages/service-utils/src/raw_config.rs
+++ b/packages/service-utils/src/raw_config.rs
@@ -1,0 +1,38 @@
+use cosmwasm_std::{StdError, StdResult, Storage};
+use cw_storage_plus::Item;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Get the Item helper for the raw service config
+pub fn get_service_config_item<T: Serialize + DeserializeOwned>() -> Item<T> {
+    Item::new("raw_service_config")
+}
+
+pub fn load_raw_service_config<T: Serialize + DeserializeOwned>(
+    storage: &dyn Storage,
+) -> StdResult<T> {
+    get_service_config_item::<T>().load(storage)
+}
+
+pub fn save_raw_service_config<T: Serialize + DeserializeOwned>(
+    storage: &mut dyn Storage,
+    config: &T,
+) -> StdResult<()> {
+    get_service_config_item::<T>().save(storage, config)
+}
+
+pub fn update_raw_service_config<T: Serialize + DeserializeOwned, F, E>(
+    storage: &mut dyn Storage,
+    action: F,
+) -> Result<T, E>
+where
+    F: FnOnce(T) -> Result<T, E>,
+    E: From<StdError>,
+{
+    get_service_config_item::<T>().update(storage, action)
+}
+
+pub fn query_raw_service_config<T: Serialize + DeserializeOwned>(
+    storage: &dyn Storage,
+) -> StdResult<T> {
+    load_raw_service_config(storage)
+}

--- a/packages/valence-macros/Cargo.toml
+++ b/packages/valence-macros/Cargo.toml
@@ -14,4 +14,4 @@ cosmwasm-schema = { workspace = true }
 cosmwasm-std    = { workspace = true }
 proc-macro2     = "1.0"
 quote           = "1.0"
-syn             = { version = "1.0", features = ["full"] }
+syn             = { version = "1.0", features = ["full", "parsing"] }

--- a/packages/valence-macros/src/helpers.rs
+++ b/packages/valence-macros/src/helpers.rs
@@ -1,0 +1,45 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Attribute, AttributeArgs, DataEnum, DeriveInput};
+
+// Check if theres `ignore_optional` attribute on the field.
+pub(crate) fn has_ignore_optional_attr(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr.path.is_ident("ignore_optional"))
+}
+
+// Merges the variants of two enums.
+pub(crate) fn merge_variants(
+    metadata: TokenStream,
+    left: TokenStream,
+    right: TokenStream,
+) -> TokenStream {
+    use syn::Data::Enum;
+
+    let args = parse_macro_input!(metadata as AttributeArgs);
+    if let Some(first_arg) = args.first() {
+        return syn::Error::new_spanned(first_arg, "macro takes no arguments")
+            .to_compile_error()
+            .into();
+    }
+
+    let mut left: DeriveInput = parse_macro_input!(left);
+    let right: DeriveInput = parse_macro_input!(right);
+
+    if let (
+        Enum(DataEnum { variants, .. }),
+        Enum(DataEnum {
+            variants: to_add, ..
+        }),
+    ) = (&mut left.data, right.data)
+    {
+        variants.extend(to_add);
+
+        quote! { #left }.into()
+    } else {
+        syn::Error::new(left.ident.span(), "variants may only be added for enums")
+            .to_compile_error()
+            .into()
+    }
+}

--- a/packages/valence-macros/src/helpers.rs
+++ b/packages/valence-macros/src/helpers.rs
@@ -2,11 +2,11 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Attribute, AttributeArgs, DataEnum, DeriveInput};
 
-// Check if theres `ignore_optional` attribute on the field.
-pub(crate) fn has_ignore_optional_attr(attrs: &[Attribute]) -> bool {
+// Check if theres `skip_update` attribute on the field.
+pub(crate) fn has_skip_update_attr(attrs: &[Attribute]) -> bool {
     attrs
         .iter()
-        .any(|attr| attr.path.is_ident("ignore_optional"))
+        .any(|attr| attr.path.is_ident("skip_update"))
 }
 
 // Merges the variants of two enums.

--- a/packages/valence-macros/src/helpers.rs
+++ b/packages/valence-macros/src/helpers.rs
@@ -1,12 +1,27 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Attribute, AttributeArgs, DataEnum, DeriveInput};
+use syn::{parse_macro_input, Attribute, AttributeArgs, DataEnum, DeriveInput, GenericArgument, PathArguments, Type, TypePath};
 
 // Check if theres `skip_update` attribute on the field.
 pub(crate) fn has_skip_update_attr(attrs: &[Attribute]) -> bool {
     attrs
         .iter()
         .any(|attr| attr.path.is_ident("skip_update"))
+}
+
+pub(crate) fn get_option_inner_type(ty: &Type) -> Option<&Type> {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        if let Some(segment) = path.segments.last() {
+            if segment.ident == "Option" {
+                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                    if let Some(GenericArgument::Type(inner_type)) = args.args.first() {
+                        return Some(inner_type);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 // Merges the variants of two enums.

--- a/packages/valence-macros/src/helpers.rs
+++ b/packages/valence-macros/src/helpers.rs
@@ -1,12 +1,13 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Attribute, AttributeArgs, DataEnum, DeriveInput, GenericArgument, PathArguments, Type, TypePath};
+use syn::{
+    parse_macro_input, Attribute, AttributeArgs, DataEnum, DeriveInput, GenericArgument,
+    PathArguments, Type, TypePath,
+};
 
 // Check if theres `skip_update` attribute on the field.
 pub(crate) fn has_skip_update_attr(attrs: &[Attribute]) -> bool {
-    attrs
-        .iter()
-        .any(|attr| attr.path.is_ident("skip_update"))
+    attrs.iter().any(|attr| attr.path.is_ident("skip_update"))
 }
 
 pub(crate) fn get_option_inner_type(ty: &Type) -> Option<&Type> {

--- a/packages/valence-macros/src/lib.rs
+++ b/packages/valence-macros/src/lib.rs
@@ -1,12 +1,12 @@
 mod helpers;
 
-use helpers::{has_skip_update_attr, merge_variants};
+use helpers::{has_skip_update_attr, get_option_inner_type, merge_variants};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput, Fields};
 
 #[proc_macro_derive(ValenceServiceInterface, attributes(skip_update))]
-pub fn valecne_service_interface_derive(input: TokenStream) -> TokenStream {
+pub fn valence_service_interface_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let name = &ast.ident;
     let filter_name = format_ident!("{}Update", name);
@@ -30,29 +30,46 @@ pub fn valecne_service_interface_derive(input: TokenStream) -> TokenStream {
         let name = &f.ident;
         let ty = &f.ty;
         let vis = &f.vis;
-        quote! {
-            #vis #name: std::option::Option<#ty>,
+        
+        if let Some(inner_type) = get_option_inner_type(ty) {
+            quote! {
+                #vis #name: OptionUpdate<#inner_type>,
+            }
+        } else {
+            quote! {
+                #vis #name: Option<#ty>,
+            }
         }
     });
 
     let update_fields = filtered_fields.iter().map(|f| {
         let name = &f.ident;
-        quote! {
-            if let Some(#name) = self.#name.clone() {
-                raw_config.#name = #name;
+        
+        if get_option_inner_type(&f.ty).is_some() {
+            quote! {
+                match &self.#name {
+                    OptionUpdate::Set(value) => raw_config.#name = value.clone(),
+                    OptionUpdate::None => {}
+                }
+            }
+        } else {
+            quote! {
+                if let Some(value) = &self.#name {
+                    raw_config.#name = value.clone();
+                }
             }
         }
     });
-
+    
     let expanded = quote! {
-        use valence_service_utils::{ServiceConfigUpdateTrait, raw_config::{save_raw_service_config, load_raw_service_config}};
+        use valence_service_utils::{ServiceConfigUpdateTrait, OptionUpdate, raw_config::{save_raw_service_config, load_raw_service_config}};
         use cosmwasm_std::StdResult;
-
+        
         #[cw_serde]
         #vis struct #filter_name {
             #(#filter_fields)*
         }
-
+        
         impl ServiceConfigUpdateTrait for #filter_name {
             fn update_raw(&self, storage: &mut dyn cosmwasm_std::Storage) -> StdResult<()> {
                 let mut raw_config = load_raw_service_config::<#name>(storage)?;

--- a/packages/valence-macros/src/lib.rs
+++ b/packages/valence-macros/src/lib.rs
@@ -1,12 +1,15 @@
+mod helpers;
+
+use helpers::{has_ignore_optional_attr, merge_variants};
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput, Fields};
 
-#[proc_macro_derive(OptionalStruct)]
+#[proc_macro_derive(OptionalStruct, attributes(ignore_optional))]
 pub fn optional_struct_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let name = &ast.ident;
-    let filter_name = syn::Ident::new(&format!("Optional{}", name), name.span());
+    let filter_name = format_ident!("Optional{}", name);
     let vis = &ast.vis;
 
     let fields = match &ast.data {
@@ -17,22 +20,74 @@ pub fn optional_struct_derive(input: TokenStream) -> TokenStream {
         _ => panic!("OptionalStruct only works on structs"),
     };
 
-    let filter_fields = fields.iter().map(|f| {
+    let filter_fields = fields.iter().filter_map(|f| {
         let name = &f.ident;
         let ty = &f.ty;
         let vis = &f.vis;
+        let ignore = has_ignore_optional_attr(&f.attrs);
+        if ignore {
+            None
+        } else {
+            Some(quote! {
+                #vis #name: std::option::Option<#ty>,
+            })
+        }
+    });
 
-        quote! {
-            #vis #name: std::option::Option<#ty>
+    let update_fields = fields.iter().filter_map(|f| {
+        let name = &f.ident;
+        let ignore = has_ignore_optional_attr(&f.attrs);
+        if ignore {
+            None
+        } else {
+            Some(quote! {
+                if let Some(#name) = self.#name.clone() {
+                    raw_config.#name = #name;
+                }
+            })
         }
     });
 
     let expanded = quote! {
+        use valence_service_utils::{OptionalServiceConfigTrait, raw_config::{save_raw_service_config, load_raw_service_config}};
+        use cosmwasm_std::StdResult;
+
         #[cw_serde]
         #vis struct #filter_name {
-            #(#filter_fields,)*
+            #(#filter_fields)*
+        }
+
+        impl OptionalServiceConfigTrait for #filter_name {
+            fn update_raw(&self, storage: &mut dyn cosmwasm_std::Storage) -> StdResult<()> {
+                let mut raw_config = load_raw_service_config::<#name>(storage)?;
+
+                #(#update_fields)*
+
+                save_raw_service_config(storage, &raw_config)
+            }
         }
     };
 
     TokenStream::from(expanded)
+}
+
+#[proc_macro_attribute]
+pub fn valence_service_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    merge_variants(
+        metadata,
+        input,
+        quote!(
+            enum ValenceServiceQuery {
+                /// Query to get the processor address.
+                #[returns(Addr)]
+                GetProcessor {},
+                /// Query to get the service configuration.
+                #[returns(Config)]
+                GetServiceConfig {},
+                #[returns(ServiceConfig)]
+                GetRawServiceConfig {},
+            }
+        )
+        .into(),
+    )
 }

--- a/packages/valence-macros/src/lib.rs
+++ b/packages/valence-macros/src/lib.rs
@@ -1,29 +1,29 @@
 mod helpers;
 
-use helpers::{has_ignore_optional_attr, merge_variants};
+use helpers::{has_skip_update_attr, merge_variants};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput, Fields};
 
-#[proc_macro_derive(OptionalStruct, attributes(ignore_optional))]
-pub fn optional_struct_derive(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(ValenceServiceInterface, attributes(skip_update))]
+pub fn valecne_service_interface_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let name = &ast.ident;
-    let filter_name = format_ident!("Optional{}", name);
+    let filter_name = format_ident!("{}Update", name);
     let vis = &ast.vis;
 
     let fields = match &ast.data {
         Data::Struct(data) => match &data.fields {
             Fields::Named(fields) => fields,
-            _ => panic!("OptionalStruct only works on structs with named fields"),
+            _ => panic!("ValenceServiceUpdate only works on structs with named fields"),
         },
-        _ => panic!("OptionalStruct only works on structs"),
+        _ => panic!("ValenceServiceUpdate only works on structs"),
     };
 
     let filtered_fields: Vec<_> = fields
         .named
         .iter()
-        .filter(|f| !has_ignore_optional_attr(&f.attrs))
+        .filter(|f| !has_skip_update_attr(&f.attrs))
         .collect();
 
     let filter_fields = filtered_fields.iter().map(|f| {
@@ -44,25 +44,8 @@ pub fn optional_struct_derive(input: TokenStream) -> TokenStream {
         }
     });
 
-    let diff_fields = filtered_fields.iter().map(|f| {
-        let name = &f.ident;
-        quote! {
-            if self.#name != other.#name {
-                diff.#name = Some(other.#name.clone());
-                has_change = true;
-            }
-        }
-    });
-
-    let init_fields = filtered_fields.iter().map(|f| {
-        let name = &f.ident;
-        quote! {
-            #name: None
-        }
-    });
-
     let expanded = quote! {
-        use valence_service_utils::{ServiceConfigInterface, OptionalServiceConfigTrait, raw_config::{save_raw_service_config, load_raw_service_config}};
+        use valence_service_utils::{ServiceConfigUpdateTrait, raw_config::{save_raw_service_config, load_raw_service_config}};
         use cosmwasm_std::StdResult;
 
         #[cw_serde]
@@ -70,30 +53,13 @@ pub fn optional_struct_derive(input: TokenStream) -> TokenStream {
             #(#filter_fields)*
         }
 
-        impl OptionalServiceConfigTrait for #filter_name {
+        impl ServiceConfigUpdateTrait for #filter_name {
             fn update_raw(&self, storage: &mut dyn cosmwasm_std::Storage) -> StdResult<()> {
                 let mut raw_config = load_raw_service_config::<#name>(storage)?;
 
                 #(#update_fields)*
 
                 save_raw_service_config(storage, &raw_config)
-            }
-        }
-
-        impl ServiceConfigInterface<#name, #filter_name> for #name {
-            fn get_diff(&self, other: &#name) -> Option<#filter_name> {
-                let mut diff = #filter_name {
-                    #(#init_fields),*
-                };
-                let mut has_change = false;
-
-                #(#diff_fields)*
-
-                if has_change {
-                    Some(diff)
-                } else {
-                    None
-                }
             }
         }
     };

--- a/workflow-manager/src/account.rs
+++ b/workflow-manager/src/account.rs
@@ -18,7 +18,6 @@ pub enum AccountType {
 /// We need to know what domain we are talking with
 /// and what type of account we should work with.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "'de: 'static"))]
 pub struct AccountInfo {
     pub name: String,
     pub ty: AccountType,

--- a/workflow-manager/src/domain/cosmos_cw.rs
+++ b/workflow-manager/src/domain/cosmos_cw.rs
@@ -767,6 +767,16 @@ impl Connector for CosmosCosmwasmConnector {
             ))
             .into());
         }
+
+        for service in config.services.values() {
+            if service.addr.is_none() {
+                return Err(CosmosCosmwasmError::Error(anyhow::anyhow!(
+                    "Before saving workflow config each service must have an address"
+                ))
+                .into());
+            }
+        }
+
         let registry_addr = GLOBAL_CONFIG.lock().await.get_registry_addr();
 
         let workflow_binary =

--- a/workflow-manager/src/service.rs
+++ b/workflow-manager/src/service.rs
@@ -2,15 +2,14 @@ use std::num::ParseIntError;
 
 use aho_corasick::AhoCorasick;
 
-use cosmwasm_std::{from_json, to_json_binary, Binary, StdResult};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::to_vec;
 use strum::VariantNames;
 use thiserror::Error;
 
 use valence_service_utils::{
     msg::{InstantiateMsg, ServiceConfigValidation},
-    Id, ServiceConfigInterface,
+    Id,
 };
 
 use crate::domain::Domain;
@@ -63,47 +62,9 @@ impl Default for ServiceConfig {
     }
 }
 
-pub fn get_diff<O: Serialize + DeserializeOwned>(
-    service_config: ServiceConfig,
-    other_service_config: ServiceConfig,
-) -> StdResult<Option<O>> {
-    service_config
-        .get_diff(&other_service_config)
-        .unwrap()
-        .map(from_json::<O>)
-        .transpose()
-}
-
 // TODO: create macro for the methods that work the same over all of the configs
 // We are delegating a lot of the methods to the specific config, so most of the methods can be under the macro
 impl ServiceConfig {
-    pub fn get_diff(&self, other: &ServiceConfig) -> ServiceResult<Option<Binary>> {
-        match (self, other) {
-            (
-                ServiceConfig::ValenceForwarderService(config),
-                ServiceConfig::ValenceForwarderService(other_config),
-            ) => Ok(config
-                .get_diff(other_config)
-                .map(|r| to_json_binary(&r).unwrap())),
-            (
-                ServiceConfig::ValenceSplitterService(config),
-                ServiceConfig::ValenceSplitterService(other_config),
-            ) => Ok(config
-                .get_diff(other_config)
-                .map(|r| to_json_binary(&r).unwrap())),
-            (
-                ServiceConfig::ValenceReverseSplitterService(config),
-                ServiceConfig::ValenceReverseSplitterService(other_config),
-            ) => Ok(config
-                .get_diff(other_config)
-                .map(|r| to_json_binary(&r).unwrap())),
-            _ => Err(ServiceError::ConfigsMismatch(
-                self.to_string(),
-                other.to_string(),
-            )),
-        }
-    }
-
     pub fn replace_config(
         &mut self,
         patterns: Vec<String>,

--- a/workflow-manager/src/service.rs
+++ b/workflow-manager/src/service.rs
@@ -47,19 +47,16 @@ pub struct ServiceInfo {
 }
 
 /// This is a list of all our services we support and their configs.
-#[derive(Debug, Clone, strum::Display, Serialize, Deserialize, VariantNames, PartialEq)]
+#[derive(
+    Debug, Clone, strum::Display, Serialize, Deserialize, VariantNames, PartialEq, Default,
+)]
 #[strum(serialize_all = "snake_case")]
 pub enum ServiceConfig {
+    #[default]
     None,
     ValenceForwarderService(valence_forwarder_service::msg::ServiceConfig),
     ValenceSplitterService(valence_splitter_service::msg::ServiceConfig),
     ValenceReverseSplitterService(valence_reverse_splitter_service::msg::ServiceConfig),
-}
-
-impl Default for ServiceConfig {
-    fn default() -> Self {
-        ServiceConfig::None
-    }
 }
 
 // TODO: create macro for the methods that work the same over all of the configs
@@ -121,7 +118,7 @@ impl ServiceConfig {
 
     pub fn soft_validate_config(&self, api: &dyn cosmwasm_std::Api) -> ServiceResult<()> {
         match self {
-            ServiceConfig::None => return Err(ServiceError::NoServiceConfig),
+            ServiceConfig::None => Err(ServiceError::NoServiceConfig),
             ServiceConfig::ValenceForwarderService(config) => {
                 config.pre_validate(api)?;
                 Ok(())
@@ -141,7 +138,7 @@ impl ServiceConfig {
         let ac: AhoCorasick = AhoCorasick::new(["\"|account_id|\":"]).unwrap();
 
         match self {
-            ServiceConfig::None => return Err(ServiceError::NoServiceConfig),
+            ServiceConfig::None => Err(ServiceError::NoServiceConfig),
             ServiceConfig::ValenceForwarderService(config) => {
                 Self::find_account_ids(ac, serde_json::to_string(&config)?)
             }

--- a/workflow-manager/src/tests.rs
+++ b/workflow-manager/src/tests.rs
@@ -6,13 +6,11 @@ mod test {
 
     use crate::{
         account::{AccountInfo, AccountType},
-        config::{Config, GLOBAL_CONFIG},
+        config::GLOBAL_CONFIG,
         domain::Domain,
-        init_workflow,
         service::{ServiceConfig, ServiceInfo},
         workflow_config::{Link, WorkflowConfig},
     };
-    use config::{Config as ConfigHelper, File};
     use serde_json_any_key::MapIterToJson;
     use valence_authorization_utils::{
         action::AtomicAction,
@@ -116,8 +114,12 @@ mod test {
     #[ignore = "internal test"]
     #[tokio::test]
     async fn test_parsing() {
-        let json_string = "{\"input_addr\": {\"|account_id|\": 1}, \"output_addr\": {\"|account_id|\": 2}}";
-        let config = serde_json::from_str::<valence_forwarder_service::msg::OptionalServiceConfig>(json_string).unwrap();
+        let json_string =
+            "{\"input_addr\": {\"|account_id|\": 1}, \"output_addr\": {\"|account_id|\": 2}}";
+        let config = serde_json::from_str::<valence_forwarder_service::msg::ServiceConfigUpdate>(
+            json_string,
+        )
+        .unwrap();
         println!("{:#?}", config);
     }
 
@@ -226,7 +228,6 @@ mod test {
             },
         );
 
-        // TODO: we need the id of the service here in contract_address
         config.authorizations.insert(
             0,
             AuthorizationInfo {
@@ -266,9 +267,15 @@ mod test {
 
         let binary = to_json_binary(&config).unwrap();
         let workflow_config = from_json::<WorkflowConfig>(&binary).unwrap();
-        
+
         // After parsing, workflow config should have no service config
-        let svc = workflow_config.services.first_key_value().unwrap().1.config.clone();
+        let svc = workflow_config
+            .services
+            .first_key_value()
+            .unwrap()
+            .1
+            .config
+            .clone();
         assert_eq!(svc, ServiceConfig::None);
 
         // match timeout(Duration::from_secs(60), ).await {

--- a/workflow-manager/src/workflow_config.rs
+++ b/workflow-manager/src/workflow_config.rs
@@ -28,7 +28,6 @@ pub struct Link {
 /// This struct holds all the data regarding our authorization and processor
 /// contracts and bridge accounts
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(bound(deserialize = "'de: 'static"))]
 pub struct AuthorizationData {
     /// authorization contract address on neutron
     pub authorization_addr: String,
@@ -65,7 +64,6 @@ impl AuthorizationData {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(bound(deserialize = "'de: 'static"))]
 pub struct WorkflowConfig {
     // This is the id of the workflow
     #[serde(default)]
@@ -258,7 +256,7 @@ impl WorkflowConfig {
         // Then we update the service configs with the account predicted addresses
         // for all input accounts we add the service address to the approved services list
         // and then instantiate the services
-        for (link_id, link) in self.links.clone().iter() {
+        for (_, link) in self.links.clone().iter() {
             let mut service = self.get_service(link.service_id)?;
 
             let mut domain_connector = connectors.get_or_create_connector(&service.domain).await?;
@@ -266,7 +264,7 @@ impl WorkflowConfig {
                 .get_address(
                     self.id,
                     &service.config.to_string(),
-                    format!("service_{}", link_id).as_str(),
+                    format!("service_{}", link.service_id).as_str(),
                 )
                 .await?;
 
@@ -278,7 +276,7 @@ impl WorkflowConfig {
             // At this stage we should already have all addresses for all account ids
             for account_id in link.input_accounts_id.iter() {
                 let account_data = account_instantiate_datas.get_mut(account_id).ok_or(
-                    ManagerError::FailedToRetrieveAccountInitData(*account_id, *link_id),
+                    ManagerError::FailedToRetrieveAccountInitData(*account_id, link.service_id),
                 )?;
                 // We add the service address to the approved services list of the input account
                 account_data.add_service(service_addr.to_string());
@@ -292,7 +290,7 @@ impl WorkflowConfig {
 
             for account_id in link.output_accounts_id.iter() {
                 let account_data = account_instantiate_datas.get(account_id).ok_or(
-                    ManagerError::FailedToRetrieveAccountInitData(*account_id, *link_id),
+                    ManagerError::FailedToRetrieveAccountInitData(*account_id, link.service_id),
                 )?;
 
                 patterns.push(format!("|account_id|\":{account_id}"));


### PR DESCRIPTION
Fairly straight forward change that abstract away the need for services to store raw config, this is done for them as long as they are using our methods, if not, they will need to manually calls the needed calls we are doing (which is not a lot):

The summary is:
1. Each service will have a "hidden" (abstracted) storage for the raw service config, and helpers for that can be found in: [packages/service-utils/src/raw_config.rs](https://github.com/timewave-computer/valence-protocol/compare/art3mix/service-update?expand=1#diff-59893be6405e3741306ee4923054fd6999c5cc031be1f73532cf62bf8d808f03)
2. The above is not magic, it is a regular Item storage for the raw service config, our helpers are using that storage to store and get the service config, on instantiation we call the `save_raw_service_config` which can be found here: [packages/service-base/src/lib.rs](https://github.com/timewave-computer/valence-protocol/compare/art3mix/service-update?expand=1#diff-22c2f6f9eac41e236e0d521610067bd8729b8f048fc102c1e5e7e86135c65463)
3. For update its a little bit more complex (not much), we created a trait so all optional service configs can implement, this is basically to expose a helper function: `OptionalServiceConfigTrait` can be found here:  [packages/service-utils/src/lib.rs](https://github.com/timewave-computer/valence-protocol/compare/art3mix/service-update?expand=1#diff-97df4c27d6c09bb58d2fca1d3897a19af778a0d9def52625607a372b95ca9e7f)
4. Our macro, implements this trait and the `update_raw` function, we need to remember that we are talking about `OptionalServiceConfig` here, so everything is an option, so what we do is, we get the saved `serviceConfig` that is in storage, we loop over all fields checking if it is Some, if it is, we are updating the `ServiceConfig` with the value in it, and save the it back to storage.
This allows us to update the raw service config regardless of what the checked config is.
5. All is left to do is to call this `update_raw` method to actually run it, we are doing it in the `updateConfig` execute message: [packages/service-base/src/lib.rs](https://github.com/timewave-computer/valence-protocol/compare/art3mix/service-update?expand=1#diff-22c2f6f9eac41e236e0d521610067bd8729b8f048fc102c1e5e7e86135c65463)
6. The last thing to do is to expose a query that we can query this raw `ServiceConfig`, for that I reused the extend macro we have in the covenant, so now a service can use a macro to get the full list of queries he must implement for a service to be a valence service, there is also a helper to get the raw `ServiceConfig` so no logic need to be done for the service programmer to implement them, can be as east as copy and paste. (probably can even be handled as a service utils helper)

One thing I didn't like is how each service must implement the same default for our queries, I hack I found that will allow us to set this default is by creating our own query function much like we have for execute, the `QueryMsg` we take from the service, we turn into Binary, and try to parse into our own `BaseQueryMsg` which will hold the queries we have, so if the service doesn't implement its own custom queries, and we can't parse the msg into our required queries, we fail, this is hackish but can provide a neat way for us to provide a default for service instead of them doing it by themselves.

Also in the macro I also added `ignore_optional`, so if a `ServiceConfig` has a field that we don't want to update, we can add this attribute on top of it, for example:
```rust
pub struct ServiceConfig {
  #[ignore_optional]
  pub ignore: String,
  pub include: String,
}
```
This will result in: 
```rust
pub struct OptionalServiceConfig {
  include: Option<String>
}
```
