### PR TITLE
remove NeutronMsg + wasm bindings and use protobuf directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,7 @@ dependencies = [
 name = "valence-authorization"
 version = "0.1.0"
 dependencies = [
+ "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-ownable",
@@ -4766,7 +4767,6 @@ dependencies = [
  "cosmwasm-std 2.1.4",
  "cw-ownable",
  "cw-utils 2.0.0",
- "neutron-sdk",
  "serde_json",
  "valence-polytone-utils",
  "valence-service-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,14 @@ cw-storage-plus = "2.0.0"
 cw2             = "2.0.0"
 getset          = "0.1.3"
 itertools       = "0.13.0"
-neutron-sdk     = "0.11.0"
-schemars        = "0.8.16"
-serde           = { version = "1.0.207", default-features = false, features = ["derive"] }
-serde_json      = "1.0.125"
-sha2            = "0.10.8"
-thiserror       = "1.0.63"
+# TODO: replace neutron-sdk and cosmos-sdk-proto for neutron-std when we can test with 2.0 (neutron-std adds cosmwasm_2_0 feature)
+neutron-sdk      = "0.11.0"
+cosmos-sdk-proto = { version = "0.20.0", default-features = false }
+schemars         = "0.8.16"
+serde            = { version = "1.0.207", default-features = false, features = ["derive"] }
+serde_json       = "1.0.125"
+sha2             = "0.10.8"
+thiserror        = "1.0.63"
 
 # our contracts
 valence-authorization            = { path = "contracts/authorization", features = ["library"] }

--- a/contracts/authorization/Cargo.toml
+++ b/contracts/authorization/Cargo.toml
@@ -21,9 +21,10 @@ cw-ownable                  = { workspace = true }
 valence-authorization-utils = { workspace = true }
 valence-processor-utils     = { workspace = true }
 valence-polytone-utils      = { workspace = true }
-neutron-sdk                 = { workspace = true }
 cw-utils                    = { workspace = true }
 serde_json                  = { workspace = true }
+neutron-sdk                 = { workspace = true }
+cosmos-sdk-proto            = { workspace = true }
 
 [dev-dependencies]
 neutron-test-tube     = { workspace = true }

--- a/contracts/authorization/src/domain.rs
+++ b/contracts/authorization/src/domain.rs
@@ -1,5 +1,4 @@
 use cosmwasm_std::{to_json_binary, Binary, CosmosMsg, DepsMut, Storage, Uint64, WasmMsg};
-use neutron_sdk::bindings::msg::NeutronMsg;
 use valence_authorization_utils::{
     authorization::{ActionsConfig, Authorization},
     callback::PolytoneCallbackMsg,
@@ -18,7 +17,7 @@ pub fn add_domain(
     deps: DepsMut,
     callback_receiver: String,
     domain: &ExternalDomainInfo,
-) -> Result<CosmosMsg<NeutronMsg>, ContractError> {
+) -> Result<CosmosMsg, ContractError> {
     let external_domain = domain.to_external_domain_validated(deps.api)?;
 
     if EXTERNAL_DOMAINS.has(deps.storage, external_domain.name.clone()) {
@@ -78,7 +77,7 @@ pub fn create_msg_for_processor_or_bridge(
     execute_msg: Binary,
     domain: &Domain,
     callback_request: Option<CallbackRequest>,
-) -> Result<CosmosMsg<NeutronMsg>, ContractError> {
+) -> Result<CosmosMsg, ContractError> {
     // If the domain is the main domain we will use the processor on the main domain, otherwise we will use polytone to send it to the processor on the external domain
     match domain {
         Domain::Main => {

--- a/packages/authorization-utils/Cargo.toml
+++ b/packages/authorization-utils/Cargo.toml
@@ -9,7 +9,6 @@ description = "Helpers for authorization contract"
 cosmwasm-std           = { workspace = true }
 cw-utils               = { workspace = true }
 cosmwasm-schema        = { workspace = true }
-neutron-sdk            = { workspace = true }
 cw-ownable             = { workspace = true }
 valence-polytone-utils = { workspace = true }
 valence-service-utils  = { workspace = true }


### PR DESCRIPTION
Move away from NeutronMsg and wasm bindings which ties the authorization contract to Neutron. With this change we can deploy the authorization contract to any tokenfactory chain and move away from what Neutron is deprecating at the moment.

Note: can't use neutron-std or latest commit of neutron-sdk because they inject cosmwasm_2_0 feature and we can't test with it atm. 
Once we can, we can replace neutron-sdk + cosmos-sdk-proto for neutron-std and Stargate for AnyMsg, added TODOs there. Code would be the same.
