### PR TITLE
json schema ci checks

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --verbose -- -D warnings
 
+      - name: Generate contract schemas
+        run: ./devtools/schema.sh
+
+      - name: Show schema changes
+        run: git status --porcelain
+
+      - name: Validate committed schemas
+        # should fail if any diffs are present
+        run: test -z "$(git status --porcelain)"
+
       - name: Optimize contracts
         run: |
           docker run --user $(id -u):$(id -g) --rm \
@@ -102,7 +112,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Run polytone example
         uses: "./.github/actions/run-local-ic-test"
         with:

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Build artefacts
+      - name: Cache Build artifacts
         uses: Swatinem/rust-cache@v2.7.5
         with:
           cache-on-failure: true
@@ -32,16 +32,6 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --all-targets --verbose -- -D warnings
-
-      - name: Generate contract schemas
-        run: ./devtools/schema.sh
-
-      - name: Show schema changes
-        run: git status --porcelain
-
-      - name: Validate committed schemas
-        # should fail if any diffs are present
-        run: test -z "$(git status --porcelain)"
 
       - name: Optimize contracts
         run: |
@@ -59,6 +49,28 @@ jobs:
           path: ./artifacts/*.wasm
           if-no-files-found: error
 
+  schema-checks:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Build artifacts
+        uses: Swatinem/rust-cache@v2.7.5
+        with:
+          cache-on-failure: true
+          shared-key: ${{ github.event.pull_request.number || github.ref }}
+
+      - name: Generate contract schemas
+        run: ./devtools/schema.sh
+
+      - name: Show schema changes
+        run: git status --porcelain
+
+      - name: Validate committed schemas
+        # should fail if any diffs are present
+        run: test -z "$(git status --porcelain)"
+
   tests:
     needs: build
     runs-on: ubuntu-latest
@@ -68,7 +80,7 @@ jobs:
       - name: Free Disk Space
         uses: "./.github/actions/free-disk-space"
 
-      - name: Cache Build artefacts
+      - name: Cache Build artifacts
         uses: Swatinem/rust-cache@v2.7.5
         with:
           cache-on-failure: true

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 **/.editorconfig
 
 # schemas
-contracts/**/schema
+contracts/**/schema/raw
 
 # local-interchaintest
 local-interchaintest/configs

--- a/contracts/authorization/schema/valence-authorization.json
+++ b/contracts/authorization/schema/valence-authorization.json
@@ -1,0 +1,3456 @@
+{
+  "contract_name": "valence-authorization",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "owner",
+      "processor",
+      "sub_owners"
+    ],
+    "properties": {
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      },
+      "sub_owners": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "owner_action"
+        ],
+        "properties": {
+          "owner_action": {
+            "$ref": "#/definitions/OwnerMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "permissioned_action"
+        ],
+        "properties": {
+          "permissioned_action": {
+            "$ref": "#/definitions/PermissionedMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "permissionless_action"
+        ],
+        "properties": {
+          "permissionless_action": {
+            "$ref": "#/definitions/PermissionlessMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "internal_authorization_action"
+        ],
+        "properties": {
+          "internal_authorization_action": {
+            "$ref": "#/definitions/InternalAuthorizationMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "callback"
+        ],
+        "properties": {
+          "callback": {
+            "$ref": "#/definitions/CallbackMessage"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
+      "AtomicFunction": {
+        "type": "object",
+        "required": [
+          "contract_address",
+          "domain",
+          "message_details"
+        ],
+        "properties": {
+          "contract_address": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "domain": {
+            "$ref": "#/definitions/Domain"
+          },
+          "message_details": {
+            "$ref": "#/definitions/MessageDetails"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AtomicSubroutine": {
+        "type": "object",
+        "required": [
+          "functions"
+        ],
+        "properties": {
+          "functions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AtomicFunction"
+            }
+          },
+          "retry_logic": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RetryLogic"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Attribute": {
+        "description": "An key value pair that is used in the context of event attributes in logs",
+        "type": "object",
+        "required": [
+          "key",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AuthorizationDuration": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "forever"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "seconds"
+            ],
+            "properties": {
+              "seconds": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "blocks"
+            ],
+            "properties": {
+              "blocks": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AuthorizationInfo": {
+        "type": "object",
+        "required": [
+          "duration",
+          "label",
+          "mode",
+          "not_before",
+          "subroutine"
+        ],
+        "properties": {
+          "duration": {
+            "$ref": "#/definitions/AuthorizationDuration"
+          },
+          "label": {
+            "type": "string"
+          },
+          "max_concurrent_executions": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "mode": {
+            "$ref": "#/definitions/AuthorizationModeInfo"
+          },
+          "not_before": {
+            "$ref": "#/definitions/Expiration"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Priority"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subroutine": {
+            "$ref": "#/definitions/Subroutine"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AuthorizationModeInfo": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "permissionless"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "permissioned"
+            ],
+            "properties": {
+              "permissioned": {
+                "$ref": "#/definitions/PermissionTypeInfo"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Callback": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "$ref": "#/definitions/Result_of_Array_of_Binary_or_ErrorResponse"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "execute"
+            ],
+            "properties": {
+              "execute": {
+                "$ref": "#/definitions/Result_of_ExecutionResponse_or_String"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "fatal_error"
+            ],
+            "properties": {
+              "fatal_error": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "CallbackMessage": {
+        "type": "object",
+        "required": [
+          "initiator",
+          "initiator_msg",
+          "result"
+        ],
+        "properties": {
+          "initiator": {
+            "description": "Initaitor on the note chain.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Addr"
+              }
+            ]
+          },
+          "initiator_msg": {
+            "description": "Message sent by the initaitor. This _must_ be base64 encoded or execution will fail.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          },
+          "result": {
+            "description": "Data from the host chain.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "CallbackProxy": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "polytone_proxy"
+            ],
+            "properties": {
+              "polytone_proxy": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Connector": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "polytone_note"
+            ],
+            "properties": {
+              "polytone_note": {
+                "type": "object",
+                "required": [
+                  "address",
+                  "timeout_seconds"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "timeout_seconds": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Domain": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "main"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "external"
+            ],
+            "properties": {
+              "external": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Duration": {
+        "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Time in seconds",
+            "type": "object",
+            "required": [
+              "time"
+            ],
+            "properties": {
+              "time": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "error",
+          "message_index"
+        ],
+        "properties": {
+          "error": {
+            "description": "The error that occured executing the message.",
+            "type": "string"
+          },
+          "message_index": {
+            "description": "The index of the first message who's execution failed.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Event": {
+        "description": "A full [*Cosmos SDK* event].\n\nThis version uses string attributes (similar to [*Cosmos SDK* StringEvent]), which then get magically converted to bytes for Tendermint somewhere between the Rust-Go interface, JSON deserialization and the `NewEvent` call in Cosmos SDK.\n\n[*Cosmos SDK* event]: https://docs.cosmos.network/main/learn/advanced/events [*Cosmos SDK* StringEvent]: https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/base/abci/v1beta1/abci.proto#L56-L70",
+        "type": "object",
+        "required": [
+          "attributes",
+          "type"
+        ],
+        "properties": {
+          "attributes": {
+            "description": "The attributes to be included in the event.\n\nYou can learn more about these from [*Cosmos SDK* docs].\n\n[*Cosmos SDK* docs]: https://docs.cosmos.network/main/learn/advanced/events",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "type": {
+            "description": "The event type. This is renamed to \"ty\" because \"type\" is reserved in Rust. This sucks, we know.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExecutionEnvironment": {
+        "type": "string",
+        "enum": [
+          "cosm_wasm"
+        ]
+      },
+      "ExecutionResponse": {
+        "type": "object",
+        "required": [
+          "executed_by",
+          "result"
+        ],
+        "properties": {
+          "executed_by": {
+            "description": "The address on the remote chain that executed the messages.",
+            "type": "string"
+          },
+          "result": {
+            "description": "Index `i` corresponds to the result of executing the `i`th message.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SubMsgResponse"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExecutionResult": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "in_process",
+              "success",
+              "removed_by_owner"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "rejected"
+            ],
+            "properties": {
+              "rejected": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "partially_executed"
+            ],
+            "properties": {
+              "partially_executed": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0.0
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "timeout"
+            ],
+            "properties": {
+              "timeout": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "unexpected_error"
+            ],
+            "properties": {
+              "unexpected_error": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ExternalDomainInfo": {
+        "type": "object",
+        "required": [
+          "callback_proxy",
+          "connector",
+          "execution_environment",
+          "name",
+          "processor"
+        ],
+        "properties": {
+          "callback_proxy": {
+            "$ref": "#/definitions/CallbackProxy"
+          },
+          "connector": {
+            "$ref": "#/definitions/Connector"
+          },
+          "execution_environment": {
+            "$ref": "#/definitions/ExecutionEnvironment"
+          },
+          "name": {
+            "type": "string"
+          },
+          "processor": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FunctionCallback": {
+        "type": "object",
+        "required": [
+          "callback_message",
+          "contract_address"
+        ],
+        "properties": {
+          "callback_message": {
+            "$ref": "#/definitions/Binary"
+          },
+          "contract_address": {
+            "$ref": "#/definitions/Addr"
+          }
+        },
+        "additionalProperties": false
+      },
+      "InternalAuthorizationMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "processor_callback"
+            ],
+            "properties": {
+              "processor_callback": {
+                "type": "object",
+                "required": [
+                  "execution_id",
+                  "execution_result"
+                ],
+                "properties": {
+                  "execution_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "execution_result": {
+                    "$ref": "#/definitions/ExecutionResult"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Message": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "params_restrictions": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/ParamRestriction"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageDetails": {
+        "type": "object",
+        "required": [
+          "message",
+          "message_type"
+        ],
+        "properties": {
+          "message": {
+            "$ref": "#/definitions/Message"
+          },
+          "message_type": {
+            "$ref": "#/definitions/MessageType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageType": {
+        "type": "string",
+        "enum": [
+          "cosmwasm_execute_msg",
+          "cosmwasm_migrate_msg"
+        ]
+      },
+      "Mint": {
+        "type": "object",
+        "required": [
+          "address",
+          "amount"
+        ],
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MsgResponse": {
+        "type": "object",
+        "required": [
+          "type_url",
+          "value"
+        ],
+        "properties": {
+          "type_url": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/definitions/Binary"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NonAtomicFunction": {
+        "type": "object",
+        "required": [
+          "contract_address",
+          "domain",
+          "message_details"
+        ],
+        "properties": {
+          "callback_confirmation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/FunctionCallback"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contract_address": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "domain": {
+            "$ref": "#/definitions/Domain"
+          },
+          "message_details": {
+            "$ref": "#/definitions/MessageDetails"
+          },
+          "retry_logic": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RetryLogic"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "NonAtomicSubroutine": {
+        "type": "object",
+        "required": [
+          "functions"
+        ],
+        "properties": {
+          "functions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/NonAtomicFunction"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "OwnerMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "add_sub_owner"
+            ],
+            "properties": {
+              "add_sub_owner": {
+                "type": "object",
+                "required": [
+                  "sub_owner"
+                ],
+                "properties": {
+                  "sub_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "remove_sub_owner"
+            ],
+            "properties": {
+              "remove_sub_owner": {
+                "type": "object",
+                "required": [
+                  "sub_owner"
+                ],
+                "properties": {
+                  "sub_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ParamRestriction": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "must_be_included"
+            ],
+            "properties": {
+              "must_be_included": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cannot_be_included"
+            ],
+            "properties": {
+              "cannot_be_included": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "must_be_value"
+            ],
+            "properties": {
+              "must_be_value": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PermissionTypeInfo": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "with_call_limit"
+            ],
+            "properties": {
+              "with_call_limit": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/definitions/Uint128"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "without_call_limit"
+            ],
+            "properties": {
+              "without_call_limit": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PermissionedMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "add_external_domains"
+            ],
+            "properties": {
+              "add_external_domains": {
+                "type": "object",
+                "required": [
+                  "external_domains"
+                ],
+                "properties": {
+                  "external_domains": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/ExternalDomainInfo"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "create_authorizations"
+            ],
+            "properties": {
+              "create_authorizations": {
+                "type": "object",
+                "required": [
+                  "authorizations"
+                ],
+                "properties": {
+                  "authorizations": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/AuthorizationInfo"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "modify_authorization"
+            ],
+            "properties": {
+              "modify_authorization": {
+                "type": "object",
+                "required": [
+                  "label"
+                ],
+                "properties": {
+                  "expiration": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "max_concurrent_executions": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "not_before": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "priority": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Priority"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "disable_authorization"
+            ],
+            "properties": {
+              "disable_authorization": {
+                "type": "object",
+                "required": [
+                  "label"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "enable_authorization"
+            ],
+            "properties": {
+              "enable_authorization": {
+                "type": "object",
+                "required": [
+                  "label"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "mint_authorizations"
+            ],
+            "properties": {
+              "mint_authorizations": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "mints"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "mints": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Mint"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "evict_msgs"
+            ],
+            "properties": {
+              "evict_msgs": {
+                "type": "object",
+                "required": [
+                  "domain",
+                  "priority",
+                  "queue_position"
+                ],
+                "properties": {
+                  "domain": {
+                    "$ref": "#/definitions/Domain"
+                  },
+                  "priority": {
+                    "$ref": "#/definitions/Priority"
+                  },
+                  "queue_position": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "insert_msgs"
+            ],
+            "properties": {
+              "insert_msgs": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "messages",
+                  "priority",
+                  "queue_position"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "messages": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/ProcessorMessage"
+                    }
+                  },
+                  "priority": {
+                    "$ref": "#/definitions/Priority"
+                  },
+                  "queue_position": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "pause_processor"
+            ],
+            "properties": {
+              "pause_processor": {
+                "type": "object",
+                "required": [
+                  "domain"
+                ],
+                "properties": {
+                  "domain": {
+                    "$ref": "#/definitions/Domain"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "resume_processor"
+            ],
+            "properties": {
+              "resume_processor": {
+                "type": "object",
+                "required": [
+                  "domain"
+                ],
+                "properties": {
+                  "domain": {
+                    "$ref": "#/definitions/Domain"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PermissionlessMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "send_msgs"
+            ],
+            "properties": {
+              "send_msgs": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "messages"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "messages": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/ProcessorMessage"
+                    }
+                  },
+                  "ttl": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "retry_msgs"
+            ],
+            "properties": {
+              "retry_msgs": {
+                "type": "object",
+                "required": [
+                  "execution_id"
+                ],
+                "properties": {
+                  "execution_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "retry_bridge_creation"
+            ],
+            "properties": {
+              "retry_bridge_creation": {
+                "type": "object",
+                "required": [
+                  "domain_name"
+                ],
+                "properties": {
+                  "domain_name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Priority": {
+        "type": "string",
+        "enum": [
+          "medium",
+          "high"
+        ]
+      },
+      "ProcessorMessage": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "cosmwasm_execute_msg"
+            ],
+            "properties": {
+              "cosmwasm_execute_msg": {
+                "type": "object",
+                "required": [
+                  "msg"
+                ],
+                "properties": {
+                  "msg": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cosmwasm_migrate_msg"
+            ],
+            "properties": {
+              "cosmwasm_migrate_msg": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "msg"
+                ],
+                "properties": {
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "msg": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Result_of_Array_of_Binary_or_ErrorResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ok"
+            ],
+            "properties": {
+              "Ok": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/Binary"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Err"
+            ],
+            "properties": {
+              "Err": {
+                "$ref": "#/definitions/ErrorResponse"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Result_of_ExecutionResponse_or_String": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ok"
+            ],
+            "properties": {
+              "Ok": {
+                "$ref": "#/definitions/ExecutionResponse"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Err"
+            ],
+            "properties": {
+              "Err": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "RetryLogic": {
+        "type": "object",
+        "required": [
+          "interval",
+          "times"
+        ],
+        "properties": {
+          "interval": {
+            "$ref": "#/definitions/Duration"
+          },
+          "times": {
+            "$ref": "#/definitions/RetryTimes"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RetryTimes": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "indefinitely"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "SubMsgResponse": {
+        "description": "The information we get back from a successful sub message execution, with full Cosmos SDK events.",
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "properties": {
+          "data": {
+            "deprecated": true,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Event"
+            }
+          },
+          "msg_responses": {
+            "description": "The responses from the messages emitted by the submessage. In most cases, this is equivalent to the Cosmos SDK's [MsgResponses], which usually contains a [single message]. However, wasmd allows chains to translate a single contract message into multiple SDK messages. In that case all the MsgResponses from each are concatenated into this flattened `Vec`.\n\n[MsgResponses]: https://github.com/cosmos/cosmos-sdk/blob/316750cc8cd8b3296fa233f4da2e39cbcdc34517/proto/cosmos/base/abci/v1beta1/abci.proto#L106-L109 [single message]: https://github.com/cosmos/cosmos-sdk/blob/v0.50.4/baseapp/baseapp.go#L1020-L1023",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MsgResponse"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Subroutine": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "atomic"
+            ],
+            "properties": {
+              "atomic": {
+                "$ref": "#/definitions/AtomicSubroutine"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "non_atomic"
+            ],
+            "properties": {
+              "non_atomic": {
+                "$ref": "#/definitions/NonAtomicSubroutine"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "sub_owners"
+        ],
+        "properties": {
+          "sub_owners": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "processor"
+        ],
+        "properties": {
+          "processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "external_domains"
+        ],
+        "properties": {
+          "external_domains": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "external_domain"
+        ],
+        "properties": {
+          "external_domain": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "authorizations"
+        ],
+        "properties": {
+          "authorizations": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "processor_callbacks"
+        ],
+        "properties": {
+          "processor_callbacks": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "processor_callback"
+        ],
+        "properties": {
+          "processor_callback": {
+            "type": "object",
+            "required": [
+              "execution_id"
+            ],
+            "properties": {
+              "execution_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "authorizations": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_Authorization",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Authorization"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "AtomicFunction": {
+          "type": "object",
+          "required": [
+            "contract_address",
+            "domain",
+            "message_details"
+          ],
+          "properties": {
+            "contract_address": {
+              "$ref": "#/definitions/LibraryAccountType"
+            },
+            "domain": {
+              "$ref": "#/definitions/Domain"
+            },
+            "message_details": {
+              "$ref": "#/definitions/MessageDetails"
+            }
+          },
+          "additionalProperties": false
+        },
+        "AtomicSubroutine": {
+          "type": "object",
+          "required": [
+            "functions"
+          ],
+          "properties": {
+            "functions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AtomicFunction"
+              }
+            },
+            "retry_logic": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RetryLogic"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Authorization": {
+          "type": "object",
+          "required": [
+            "expiration",
+            "label",
+            "max_concurrent_executions",
+            "mode",
+            "not_before",
+            "priority",
+            "state",
+            "subroutine"
+          ],
+          "properties": {
+            "expiration": {
+              "$ref": "#/definitions/Expiration"
+            },
+            "label": {
+              "type": "string"
+            },
+            "max_concurrent_executions": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "mode": {
+              "$ref": "#/definitions/AuthorizationMode"
+            },
+            "not_before": {
+              "$ref": "#/definitions/Expiration"
+            },
+            "priority": {
+              "$ref": "#/definitions/Priority"
+            },
+            "state": {
+              "$ref": "#/definitions/AuthorizationState"
+            },
+            "subroutine": {
+              "$ref": "#/definitions/Subroutine"
+            }
+          },
+          "additionalProperties": false
+        },
+        "AuthorizationMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "permissionless"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "permissioned"
+              ],
+              "properties": {
+                "permissioned": {
+                  "$ref": "#/definitions/PermissionType"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "AuthorizationState": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Domain": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "main"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "external"
+              ],
+              "properties": {
+                "external": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Duration": {
+          "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Time in seconds",
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "FunctionCallback": {
+          "type": "object",
+          "required": [
+            "callback_message",
+            "contract_address"
+          ],
+          "properties": {
+            "callback_message": {
+              "$ref": "#/definitions/Binary"
+            },
+            "contract_address": {
+              "$ref": "#/definitions/Addr"
+            }
+          },
+          "additionalProperties": false
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Message": {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "params_restrictions": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/ParamRestriction"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "MessageDetails": {
+          "type": "object",
+          "required": [
+            "message",
+            "message_type"
+          ],
+          "properties": {
+            "message": {
+              "$ref": "#/definitions/Message"
+            },
+            "message_type": {
+              "$ref": "#/definitions/MessageType"
+            }
+          },
+          "additionalProperties": false
+        },
+        "MessageType": {
+          "type": "string",
+          "enum": [
+            "cosmwasm_execute_msg",
+            "cosmwasm_migrate_msg"
+          ]
+        },
+        "NonAtomicFunction": {
+          "type": "object",
+          "required": [
+            "contract_address",
+            "domain",
+            "message_details"
+          ],
+          "properties": {
+            "callback_confirmation": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FunctionCallback"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contract_address": {
+              "$ref": "#/definitions/LibraryAccountType"
+            },
+            "domain": {
+              "$ref": "#/definitions/Domain"
+            },
+            "message_details": {
+              "$ref": "#/definitions/MessageDetails"
+            },
+            "retry_logic": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RetryLogic"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "NonAtomicSubroutine": {
+          "type": "object",
+          "required": [
+            "functions"
+          ],
+          "properties": {
+            "functions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/NonAtomicFunction"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ParamRestriction": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "must_be_included"
+              ],
+              "properties": {
+                "must_be_included": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cannot_be_included"
+              ],
+              "properties": {
+                "cannot_be_included": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "must_be_value"
+              ],
+              "properties": {
+                "must_be_value": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PermissionType": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "with_call_limit"
+              ],
+              "properties": {
+                "with_call_limit": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "$ref": "#/definitions/Addr"
+                      },
+                      {
+                        "$ref": "#/definitions/Uint128"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "without_call_limit"
+              ],
+              "properties": {
+                "without_call_limit": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Addr"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Priority": {
+          "type": "string",
+          "enum": [
+            "medium",
+            "high"
+          ]
+        },
+        "RetryLogic": {
+          "type": "object",
+          "required": [
+            "interval",
+            "times"
+          ],
+          "properties": {
+            "interval": {
+              "$ref": "#/definitions/Duration"
+            },
+            "times": {
+              "$ref": "#/definitions/RetryTimes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RetryTimes": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "indefinitely"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "amount"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Subroutine": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "atomic"
+              ],
+              "properties": {
+                "atomic": {
+                  "$ref": "#/definitions/AtomicSubroutine"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "non_atomic"
+              ],
+              "properties": {
+                "non_atomic": {
+                  "$ref": "#/definitions/NonAtomicSubroutine"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "external_domain": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ExternalDomain",
+      "type": "object",
+      "required": [
+        "callback_proxy",
+        "connector",
+        "execution_environment",
+        "name",
+        "processor"
+      ],
+      "properties": {
+        "callback_proxy": {
+          "$ref": "#/definitions/CallbackProxy"
+        },
+        "connector": {
+          "$ref": "#/definitions/Connector"
+        },
+        "execution_environment": {
+          "$ref": "#/definitions/ExecutionEnvironment"
+        },
+        "name": {
+          "type": "string"
+        },
+        "processor": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CallbackProxy": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "polytone_proxy"
+              ],
+              "properties": {
+                "polytone_proxy": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Connector": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "polytone_note"
+              ],
+              "properties": {
+                "polytone_note": {
+                  "type": "object",
+                  "required": [
+                    "address",
+                    "state",
+                    "timeout_seconds"
+                  ],
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    "state": {
+                      "$ref": "#/definitions/PolytoneProxyState"
+                    },
+                    "timeout_seconds": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ExecutionEnvironment": {
+          "type": "string",
+          "enum": [
+            "cosm_wasm"
+          ]
+        },
+        "PolytoneProxyState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "timed_out",
+                "pending_response",
+                "created"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "external_domains": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_ExternalDomain",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExternalDomain"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CallbackProxy": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "polytone_proxy"
+              ],
+              "properties": {
+                "polytone_proxy": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Connector": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "polytone_note"
+              ],
+              "properties": {
+                "polytone_note": {
+                  "type": "object",
+                  "required": [
+                    "address",
+                    "state",
+                    "timeout_seconds"
+                  ],
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    "state": {
+                      "$ref": "#/definitions/PolytoneProxyState"
+                    },
+                    "timeout_seconds": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ExecutionEnvironment": {
+          "type": "string",
+          "enum": [
+            "cosm_wasm"
+          ]
+        },
+        "ExternalDomain": {
+          "type": "object",
+          "required": [
+            "callback_proxy",
+            "connector",
+            "execution_environment",
+            "name",
+            "processor"
+          ],
+          "properties": {
+            "callback_proxy": {
+              "$ref": "#/definitions/CallbackProxy"
+            },
+            "connector": {
+              "$ref": "#/definitions/Connector"
+            },
+            "execution_environment": {
+              "$ref": "#/definitions/ExecutionEnvironment"
+            },
+            "name": {
+              "type": "string"
+            },
+            "processor": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "PolytoneProxyState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "timed_out",
+                "pending_response",
+                "created"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "processor_callback": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProcessorCallbackInfo",
+      "type": "object",
+      "required": [
+        "domain",
+        "execution_id",
+        "execution_result",
+        "initiator",
+        "label",
+        "messages",
+        "processor_callback_address"
+      ],
+      "properties": {
+        "bridge_callback_address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "domain": {
+          "$ref": "#/definitions/Domain"
+        },
+        "execution_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "execution_result": {
+          "$ref": "#/definitions/ExecutionResult"
+        },
+        "initiator": {
+          "$ref": "#/definitions/OperationInitiator"
+        },
+        "label": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProcessorMessage"
+          }
+        },
+        "processor_callback_address": {
+          "$ref": "#/definitions/Addr"
+        },
+        "ttl": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Domain": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "main"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "external"
+              ],
+              "properties": {
+                "external": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ExecutionResult": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "in_process",
+                "success",
+                "removed_by_owner"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "rejected"
+              ],
+              "properties": {
+                "rejected": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "partially_executed"
+              ],
+              "properties": {
+                "partially_executed": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "timeout"
+              ],
+              "properties": {
+                "timeout": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "OperationInitiator": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "owner"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "user"
+              ],
+              "properties": {
+                "user": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ProcessorMessage": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "cosmwasm_execute_msg"
+              ],
+              "properties": {
+                "cosmwasm_execute_msg": {
+                  "type": "object",
+                  "required": [
+                    "msg"
+                  ],
+                  "properties": {
+                    "msg": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cosmwasm_migrate_msg"
+              ],
+              "properties": {
+                "cosmwasm_migrate_msg": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "msg"
+                  ],
+                  "properties": {
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "msg": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "processor_callbacks": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_ProcessorCallbackInfo",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ProcessorCallbackInfo"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Domain": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "main"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "external"
+              ],
+              "properties": {
+                "external": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ExecutionResult": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "in_process",
+                "success",
+                "removed_by_owner"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "rejected"
+              ],
+              "properties": {
+                "rejected": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "partially_executed"
+              ],
+              "properties": {
+                "partially_executed": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "timeout"
+              ],
+              "properties": {
+                "timeout": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "OperationInitiator": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "owner"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "user"
+              ],
+              "properties": {
+                "user": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ProcessorCallbackInfo": {
+          "type": "object",
+          "required": [
+            "domain",
+            "execution_id",
+            "execution_result",
+            "initiator",
+            "label",
+            "messages",
+            "processor_callback_address"
+          ],
+          "properties": {
+            "bridge_callback_address": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "domain": {
+              "$ref": "#/definitions/Domain"
+            },
+            "execution_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "execution_result": {
+              "$ref": "#/definitions/ExecutionResult"
+            },
+            "initiator": {
+              "$ref": "#/definitions/OperationInitiator"
+            },
+            "label": {
+              "type": "string"
+            },
+            "messages": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ProcessorMessage"
+              }
+            },
+            "processor_callback_address": {
+              "$ref": "#/definitions/Addr"
+            },
+            "ttl": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "ProcessorMessage": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "cosmwasm_execute_msg"
+              ],
+              "properties": {
+                "cosmwasm_execute_msg": {
+                  "type": "object",
+                  "required": [
+                    "msg"
+                  ],
+                  "properties": {
+                    "msg": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cosmwasm_migrate_msg"
+              ],
+              "properties": {
+                "cosmwasm_migrate_msg": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "msg"
+                  ],
+                  "properties": {
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "msg": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "sub_owners": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_Addr",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Addr"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/astroport-lper/schema/valence-astroport-lper.json
+++ b/contracts/libraries/astroport-lper/schema/valence-astroport-lper.json
@@ -1,0 +1,1440 @@
+{
+  "contract_name": "valence-astroport-lper",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "lp_config",
+          "output_addr",
+          "pool_addr"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "lp_config": {
+            "$ref": "#/definitions/LiquidityProviderConfig"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "pool_addr": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityProviderConfig": {
+        "type": "object",
+        "required": [
+          "asset_data",
+          "pool_type"
+        ],
+        "properties": {
+          "asset_data": {
+            "description": "Denoms of both native assets we are going to provide liquidity for",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetData"
+              }
+            ]
+          },
+          "pool_type": {
+            "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+            "allOf": [
+              {
+                "$ref": "#/definitions/PoolType"
+              }
+            ]
+          },
+          "slippage_tolerance": {
+            "description": "Slippage tolerance when providing liquidity",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Decimal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PairType": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PairType2": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PoolType": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native_lp_token"
+            ],
+            "properties": {
+              "native_lp_token": {
+                "$ref": "#/definitions/PairType"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20_lp_token"
+            ],
+            "properties": {
+              "cw20_lp_token": {
+                "$ref": "#/definitions/PairType2"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "DecimalRange": {
+        "type": "object",
+        "required": [
+          "max",
+          "min"
+        ],
+        "properties": {
+          "max": {
+            "$ref": "#/definitions/Decimal"
+          },
+          "min": {
+            "$ref": "#/definitions/Decimal"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "provide_double_sided_liquidity"
+            ],
+            "properties": {
+              "provide_double_sided_liquidity": {
+                "type": "object",
+                "properties": {
+                  "expected_pool_ratio_range": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DecimalRange"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "provide_single_sided_liquidity"
+            ],
+            "properties": {
+              "provide_single_sided_liquidity": {
+                "type": "object",
+                "required": [
+                  "asset"
+                ],
+                "properties": {
+                  "asset": {
+                    "type": "string"
+                  },
+                  "expected_pool_ratio_range": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DecimalRange"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "limit": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Uint128"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lp_config": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LiquidityProviderConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pool_addr": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityProviderConfig": {
+        "type": "object",
+        "required": [
+          "asset_data",
+          "pool_type"
+        ],
+        "properties": {
+          "asset_data": {
+            "description": "Denoms of both native assets we are going to provide liquidity for",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetData"
+              }
+            ]
+          },
+          "pool_type": {
+            "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+            "allOf": [
+              {
+                "$ref": "#/definitions/PoolType"
+              }
+            ]
+          },
+          "slippage_tolerance": {
+            "description": "Slippage tolerance when providing liquidity",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Decimal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PairType": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PairType2": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PoolType": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native_lp_token"
+            ],
+            "properties": {
+              "native_lp_token": {
+                "$ref": "#/definitions/PairType"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20_lp_token"
+            ],
+            "properties": {
+              "cw20_lp_token": {
+                "$ref": "#/definitions/PairType2"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Validated library configuration",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lp_config",
+        "output_addr",
+        "pool_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "lp_config": {
+          "$ref": "#/definitions/LiquidityProviderConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "pool_addr": {
+          "$ref": "#/definitions/Addr"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "LiquidityProviderConfig": {
+          "type": "object",
+          "required": [
+            "asset_data",
+            "pool_type"
+          ],
+          "properties": {
+            "asset_data": {
+              "description": "Denoms of both native assets we are going to provide liquidity for",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AssetData"
+                }
+              ]
+            },
+            "pool_type": {
+              "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/PoolType"
+                }
+              ]
+            },
+            "slippage_tolerance": {
+              "description": "Slippage tolerance when providing liquidity",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "PairType": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PairType2": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PoolType": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "native_lp_token"
+              ],
+              "properties": {
+                "native_lp_token": {
+                  "$ref": "#/definitions/PairType"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cw20_lp_token"
+              ],
+              "properties": {
+                "cw20_lp_token": {
+                  "$ref": "#/definitions/PairType2"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lp_config",
+        "output_addr",
+        "pool_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "lp_config": {
+          "$ref": "#/definitions/LiquidityProviderConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "pool_addr": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "LiquidityProviderConfig": {
+          "type": "object",
+          "required": [
+            "asset_data",
+            "pool_type"
+          ],
+          "properties": {
+            "asset_data": {
+              "description": "Denoms of both native assets we are going to provide liquidity for",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AssetData"
+                }
+              ]
+            },
+            "pool_type": {
+              "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/PoolType"
+                }
+              ]
+            },
+            "slippage_tolerance": {
+              "description": "Slippage tolerance when providing liquidity",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "PairType": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PairType2": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PoolType": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "native_lp_token"
+              ],
+              "properties": {
+                "native_lp_token": {
+                  "$ref": "#/definitions/PairType"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cw20_lp_token"
+              ],
+              "properties": {
+                "cw20_lp_token": {
+                  "$ref": "#/definitions/PairType2"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/astroport-withdrawer/schema/valence-astroport-withdrawer.json
+++ b/contracts/libraries/astroport-withdrawer/schema/valence-astroport-withdrawer.json
@@ -1,0 +1,755 @@
+{
+  "contract_name": "valence-astroport-withdrawer",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "output_addr",
+          "pool_addr",
+          "withdrawer_config"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "pool_addr": {
+            "type": "string"
+          },
+          "withdrawer_config": {
+            "$ref": "#/definitions/LiquidityWithdrawerConfig"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityWithdrawerConfig": {
+        "type": "object",
+        "required": [
+          "pool_type"
+        ],
+        "properties": {
+          "pool_type": {
+            "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+            "allOf": [
+              {
+                "$ref": "#/definitions/PoolType"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PoolType": {
+        "type": "string",
+        "enum": [
+          "native_lp_token",
+          "cw20_lp_token"
+        ]
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "withdraw_liquidity"
+            ],
+            "properties": {
+              "withdraw_liquidity": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pool_addr": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "withdrawer_config": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LiquidityWithdrawerConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityWithdrawerConfig": {
+        "type": "object",
+        "required": [
+          "pool_type"
+        ],
+        "properties": {
+          "pool_type": {
+            "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+            "allOf": [
+              {
+                "$ref": "#/definitions/PoolType"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PoolType": {
+        "type": "string",
+        "enum": [
+          "native_lp_token",
+          "cw20_lp_token"
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Validated library configuration",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "output_addr",
+        "pool_addr",
+        "withdrawer_config"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "pool_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "withdrawer_config": {
+          "$ref": "#/definitions/LiquidityWithdrawerConfig"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "LiquidityWithdrawerConfig": {
+          "type": "object",
+          "required": [
+            "pool_type"
+          ],
+          "properties": {
+            "pool_type": {
+              "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/PoolType"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "PoolType": {
+          "type": "string",
+          "enum": [
+            "native_lp_token",
+            "cw20_lp_token"
+          ]
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "output_addr",
+        "pool_addr",
+        "withdrawer_config"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "pool_addr": {
+          "type": "string"
+        },
+        "withdrawer_config": {
+          "$ref": "#/definitions/LiquidityWithdrawerConfig"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "LiquidityWithdrawerConfig": {
+          "type": "object",
+          "required": [
+            "pool_type"
+          ],
+          "properties": {
+            "pool_type": {
+              "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/PoolType"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "PoolType": {
+          "type": "string",
+          "enum": [
+            "native_lp_token",
+            "cw20_lp_token"
+          ]
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/forwarder/schema/valence-forwarder-library.json
+++ b/contracts/libraries/forwarder/schema/valence-forwarder-library.json
@@ -1,0 +1,1180 @@
+{
+  "contract_name": "valence-forwarder-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Duration": {
+        "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Time in seconds",
+            "type": "object",
+            "required": [
+              "time"
+            ],
+            "properties": {
+              "time": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ForwardingConstraints": {
+        "description": "Struct representing the time constraints on forwarding operations.",
+        "type": "object",
+        "properties": {
+          "min_interval": {
+            "description": "The minimum interval between forwarding operations.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Duration"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "description": "Struct representing the library configuration.",
+        "type": "object",
+        "required": [
+          "forwarding_configs",
+          "forwarding_constraints",
+          "input_addr",
+          "output_addr"
+        ],
+        "properties": {
+          "forwarding_configs": {
+            "description": "The forwarding configurations for the library.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/UncheckedForwardingConfig"
+            }
+          },
+          "forwarding_constraints": {
+            "description": "The forwarding constraints for the library.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ForwardingConstraints"
+              }
+            ]
+          },
+          "input_addr": {
+            "description": "The input address for the library.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
+          },
+          "output_addr": {
+            "description": "The output address for the library.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedForwardingConfig": {
+        "description": "Struct representing an unchecked forwarding configuration.",
+        "type": "object",
+        "required": [
+          "denom",
+          "max_amount"
+        ],
+        "properties": {
+          "denom": {
+            "description": "The denom to be forwarded.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/UncheckedDenom"
+              }
+            ]
+          },
+          "max_amount": {
+            "description": "The maximum amount of tokens to be transferred per forward operation.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Duration": {
+        "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Time in seconds",
+            "type": "object",
+            "required": [
+              "time"
+            ],
+            "properties": {
+              "time": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ForwardingConstraints": {
+        "description": "Struct representing the time constraints on forwarding operations.",
+        "type": "object",
+        "properties": {
+          "min_interval": {
+            "description": "The minimum interval between forwarding operations.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Duration"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "FunctionMsgs": {
+        "description": "Enum representing the different function messages that can be sent.",
+        "oneOf": [
+          {
+            "description": "Message to forward tokens.",
+            "type": "object",
+            "required": [
+              "forward"
+            ],
+            "properties": {
+              "forward": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "forwarding_configs": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/UncheckedForwardingConfig"
+            }
+          },
+          "forwarding_constraints": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ForwardingConstraints"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedForwardingConfig": {
+        "description": "Struct representing an unchecked forwarding configuration.",
+        "type": "object",
+        "required": [
+          "denom",
+          "max_amount"
+        ],
+        "properties": {
+          "denom": {
+            "description": "The denom to be forwarded.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/UncheckedDenom"
+              }
+            ]
+          },
+          "max_amount": {
+            "description": "The maximum amount of tokens to be transferred per forward operation.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Struct representing the validated library configuration.",
+      "type": "object",
+      "required": [
+        "forwarding_configs",
+        "forwarding_constraints",
+        "input_addr",
+        "output_addr"
+      ],
+      "properties": {
+        "forwarding_configs": {
+          "description": "The forwarding configurations for the library.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ForwardingConfig"
+          }
+        },
+        "forwarding_constraints": {
+          "description": "The forwarding constraints for the library.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForwardingConstraints"
+            }
+          ]
+        },
+        "input_addr": {
+          "description": "The input address for the library.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
+        },
+        "output_addr": {
+          "description": "The output address for the library.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CheckedDenom": {
+          "description": "A denom that has been checked to point to a valid asset. This enum should never be constructed literally and should always be built by calling `into_checked` on an `UncheckedDenom` instance.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Duration": {
+          "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Time in seconds",
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ForwardingConfig": {
+          "description": "Struct representing the forwarding configuration for a specific denom.",
+          "type": "object",
+          "required": [
+            "denom",
+            "max_amount"
+          ],
+          "properties": {
+            "denom": {
+              "description": "The denom to be forwarded.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CheckedDenom"
+                }
+              ]
+            },
+            "max_amount": {
+              "description": "The maximum amount of tokens to be transferred per forward operation.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "ForwardingConstraints": {
+          "description": "Struct representing the time constraints on forwarding operations.",
+          "type": "object",
+          "properties": {
+            "min_interval": {
+              "description": "The minimum interval between forwarding operations.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Duration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "description": "Struct representing the library configuration.",
+      "type": "object",
+      "required": [
+        "forwarding_configs",
+        "forwarding_constraints",
+        "input_addr",
+        "output_addr"
+      ],
+      "properties": {
+        "forwarding_configs": {
+          "description": "The forwarding configurations for the library.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UncheckedForwardingConfig"
+          }
+        },
+        "forwarding_constraints": {
+          "description": "The forwarding constraints for the library.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForwardingConstraints"
+            }
+          ]
+        },
+        "input_addr": {
+          "description": "The input address for the library.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LibraryAccountType"
+            }
+          ]
+        },
+        "output_addr": {
+          "description": "The output address for the library.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LibraryAccountType"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Duration": {
+          "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Time in seconds",
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ForwardingConstraints": {
+          "description": "Struct representing the time constraints on forwarding operations.",
+          "type": "object",
+          "properties": {
+            "min_interval": {
+              "description": "The minimum interval between forwarding operations.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Duration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "UncheckedDenom": {
+          "description": "A denom that has not been checked to confirm it points to a valid asset.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "UncheckedForwardingConfig": {
+          "description": "Struct representing an unchecked forwarding configuration.",
+          "type": "object",
+          "required": [
+            "denom",
+            "max_amount"
+          ],
+          "properties": {
+            "denom": {
+              "description": "The denom to be forwarded.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/UncheckedDenom"
+                }
+              ]
+            },
+            "max_amount": {
+              "description": "The maximum amount of tokens to be transferred per forward operation.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/generic-ibc-transfer/schema/valence-generic-ibc-transfer-library.json
+++ b/contracts/libraries/generic-ibc-transfer/schema/valence-generic-ibc-transfer-library.json
@@ -1,0 +1,1129 @@
+{
+  "contract_name": "valence-generic-ibc-transfer-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "IbcTransferAmount": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "full_amount"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom",
+          "denom_to_pfm_map",
+          "input_addr",
+          "memo",
+          "output_addr",
+          "remote_chain_info"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/IbcTransferAmount"
+          },
+          "denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          },
+          "denom_to_pfm_map": {
+            "type": "object",
+            "additionalProperties": false
+          },
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "memo": {
+            "type": "string"
+          },
+          "output_addr": {
+            "type": "string"
+          },
+          "remote_chain_info": {
+            "$ref": "#/definitions/RemoteChainInfo"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PacketForwardMiddlewareConfig": {
+        "type": "object",
+        "required": [
+          "hop_chain_receiver_address",
+          "hop_to_destination_chain_channel_id",
+          "local_to_hop_chain_channel_id"
+        ],
+        "properties": {
+          "hop_chain_receiver_address": {
+            "type": "string"
+          },
+          "hop_to_destination_chain_channel_id": {
+            "type": "string"
+          },
+          "local_to_hop_chain_channel_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoteChainInfo": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          },
+          "ibc_transfer_timeout": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "ibc_transfer"
+            ],
+            "properties": {
+              "ibc_transfer": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "IbcTransferAmount": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "full_amount"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/IbcTransferAmount"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "denom": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/UncheckedDenom"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "denom_to_pfm_map": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": false
+          },
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "memo": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "output_addr": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "remote_chain_info": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RemoteChainInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PacketForwardMiddlewareConfig": {
+        "type": "object",
+        "required": [
+          "hop_chain_receiver_address",
+          "hop_to_destination_chain_channel_id",
+          "local_to_hop_chain_channel_id"
+        ],
+        "properties": {
+          "hop_chain_receiver_address": {
+            "type": "string"
+          },
+          "hop_to_destination_chain_channel_id": {
+            "type": "string"
+          },
+          "local_to_hop_chain_channel_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoteChainInfo": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          },
+          "ibc_transfer_timeout": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "amount",
+        "denom",
+        "denom_to_pfm_map",
+        "input_addr",
+        "memo",
+        "output_addr",
+        "remote_chain_info"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/IbcTransferAmount"
+        },
+        "denom": {
+          "$ref": "#/definitions/CheckedDenom"
+        },
+        "denom_to_pfm_map": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "memo": {
+          "type": "string"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "remote_chain_info": {
+          "$ref": "#/definitions/RemoteChainInfo"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CheckedDenom": {
+          "description": "A denom that has been checked to point to a valid asset. This enum should never be constructed literally and should always be built by calling `into_checked` on an `UncheckedDenom` instance.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcTransferAmount": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "full_amount"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PacketForwardMiddlewareConfig": {
+          "type": "object",
+          "required": [
+            "hop_chain_receiver_address",
+            "hop_to_destination_chain_channel_id",
+            "local_to_hop_chain_channel_id"
+          ],
+          "properties": {
+            "hop_chain_receiver_address": {
+              "type": "string"
+            },
+            "hop_to_destination_chain_channel_id": {
+              "type": "string"
+            },
+            "local_to_hop_chain_channel_id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RemoteChainInfo": {
+          "type": "object",
+          "required": [
+            "channel_id"
+          ],
+          "properties": {
+            "channel_id": {
+              "type": "string"
+            },
+            "ibc_transfer_timeout": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "amount",
+        "denom",
+        "denom_to_pfm_map",
+        "input_addr",
+        "memo",
+        "output_addr",
+        "remote_chain_info"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/IbcTransferAmount"
+        },
+        "denom": {
+          "$ref": "#/definitions/UncheckedDenom"
+        },
+        "denom_to_pfm_map": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "memo": {
+          "type": "string"
+        },
+        "output_addr": {
+          "type": "string"
+        },
+        "remote_chain_info": {
+          "$ref": "#/definitions/RemoteChainInfo"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "IbcTransferAmount": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "full_amount"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PacketForwardMiddlewareConfig": {
+          "type": "object",
+          "required": [
+            "hop_chain_receiver_address",
+            "hop_to_destination_chain_channel_id",
+            "local_to_hop_chain_channel_id"
+          ],
+          "properties": {
+            "hop_chain_receiver_address": {
+              "type": "string"
+            },
+            "hop_to_destination_chain_channel_id": {
+              "type": "string"
+            },
+            "local_to_hop_chain_channel_id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RemoteChainInfo": {
+          "type": "object",
+          "required": [
+            "channel_id"
+          ],
+          "properties": {
+            "channel_id": {
+              "type": "string"
+            },
+            "ibc_transfer_timeout": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        },
+        "UncheckedDenom": {
+          "description": "A denom that has not been checked to confirm it points to a valid asset.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/neutron-ibc-transfer/schema/valence-neutron-ibc-transfer-library.json
+++ b/contracts/libraries/neutron-ibc-transfer/schema/valence-neutron-ibc-transfer-library.json
@@ -1,0 +1,1129 @@
+{
+  "contract_name": "valence-neutron-ibc-transfer-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "IbcTransferAmount": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "full_amount"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom",
+          "denom_to_pfm_map",
+          "input_addr",
+          "memo",
+          "output_addr",
+          "remote_chain_info"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/IbcTransferAmount"
+          },
+          "denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          },
+          "denom_to_pfm_map": {
+            "type": "object",
+            "additionalProperties": false
+          },
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "memo": {
+            "type": "string"
+          },
+          "output_addr": {
+            "type": "string"
+          },
+          "remote_chain_info": {
+            "$ref": "#/definitions/RemoteChainInfo"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PacketForwardMiddlewareConfig": {
+        "type": "object",
+        "required": [
+          "hop_chain_receiver_address",
+          "hop_to_destination_chain_channel_id",
+          "local_to_hop_chain_channel_id"
+        ],
+        "properties": {
+          "hop_chain_receiver_address": {
+            "type": "string"
+          },
+          "hop_to_destination_chain_channel_id": {
+            "type": "string"
+          },
+          "local_to_hop_chain_channel_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoteChainInfo": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          },
+          "ibc_transfer_timeout": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "ibc_transfer"
+            ],
+            "properties": {
+              "ibc_transfer": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "IbcTransferAmount": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "full_amount"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/IbcTransferAmount"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "denom": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/UncheckedDenom"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "denom_to_pfm_map": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": false
+          },
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "memo": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "output_addr": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "remote_chain_info": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RemoteChainInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PacketForwardMiddlewareConfig": {
+        "type": "object",
+        "required": [
+          "hop_chain_receiver_address",
+          "hop_to_destination_chain_channel_id",
+          "local_to_hop_chain_channel_id"
+        ],
+        "properties": {
+          "hop_chain_receiver_address": {
+            "type": "string"
+          },
+          "hop_to_destination_chain_channel_id": {
+            "type": "string"
+          },
+          "local_to_hop_chain_channel_id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoteChainInfo": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          },
+          "ibc_transfer_timeout": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "amount",
+        "denom",
+        "denom_to_pfm_map",
+        "input_addr",
+        "memo",
+        "output_addr",
+        "remote_chain_info"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/IbcTransferAmount"
+        },
+        "denom": {
+          "$ref": "#/definitions/CheckedDenom"
+        },
+        "denom_to_pfm_map": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "memo": {
+          "type": "string"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "remote_chain_info": {
+          "$ref": "#/definitions/RemoteChainInfo"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CheckedDenom": {
+          "description": "A denom that has been checked to point to a valid asset. This enum should never be constructed literally and should always be built by calling `into_checked` on an `UncheckedDenom` instance.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "IbcTransferAmount": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "full_amount"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PacketForwardMiddlewareConfig": {
+          "type": "object",
+          "required": [
+            "hop_chain_receiver_address",
+            "hop_to_destination_chain_channel_id",
+            "local_to_hop_chain_channel_id"
+          ],
+          "properties": {
+            "hop_chain_receiver_address": {
+              "type": "string"
+            },
+            "hop_to_destination_chain_channel_id": {
+              "type": "string"
+            },
+            "local_to_hop_chain_channel_id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RemoteChainInfo": {
+          "type": "object",
+          "required": [
+            "channel_id"
+          ],
+          "properties": {
+            "channel_id": {
+              "type": "string"
+            },
+            "ibc_transfer_timeout": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "amount",
+        "denom",
+        "denom_to_pfm_map",
+        "input_addr",
+        "memo",
+        "output_addr",
+        "remote_chain_info"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/IbcTransferAmount"
+        },
+        "denom": {
+          "$ref": "#/definitions/UncheckedDenom"
+        },
+        "denom_to_pfm_map": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "memo": {
+          "type": "string"
+        },
+        "output_addr": {
+          "type": "string"
+        },
+        "remote_chain_info": {
+          "$ref": "#/definitions/RemoteChainInfo"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "IbcTransferAmount": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "full_amount"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PacketForwardMiddlewareConfig": {
+          "type": "object",
+          "required": [
+            "hop_chain_receiver_address",
+            "hop_to_destination_chain_channel_id",
+            "local_to_hop_chain_channel_id"
+          ],
+          "properties": {
+            "hop_chain_receiver_address": {
+              "type": "string"
+            },
+            "hop_to_destination_chain_channel_id": {
+              "type": "string"
+            },
+            "local_to_hop_chain_channel_id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RemoteChainInfo": {
+          "type": "object",
+          "required": [
+            "channel_id"
+          ],
+          "properties": {
+            "channel_id": {
+              "type": "string"
+            },
+            "ibc_transfer_timeout": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        },
+        "UncheckedDenom": {
+          "description": "A denom that has not been checked to confirm it points to a valid asset.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/osmosis-cl-lper/schema/valence-osmosis-cl-lper.json
+++ b/contracts/libraries/osmosis-cl-lper/schema/valence-osmosis-cl-lper.json
@@ -1,0 +1,750 @@
+{
+  "contract_name": "valence-osmosis-cl-lper",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Int64": {
+        "description": "An implementation of i64 that is using strings for JSON encoding/decoding, such that the full i64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `i64` to get the value out:\n\n``` # use cosmwasm_std::Int64; let a = Int64::from(258i64); assert_eq!(a.i64(), 258); ```",
+        "type": "string"
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "lp_config",
+          "output_addr"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "lp_config": {
+            "$ref": "#/definitions/LiquidityProviderConfig"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityProviderConfig": {
+        "type": "object",
+        "required": [
+          "global_tick_range",
+          "pool_asset_1",
+          "pool_asset_2",
+          "pool_id"
+        ],
+        "properties": {
+          "global_tick_range": {
+            "$ref": "#/definitions/TickRange"
+          },
+          "pool_asset_1": {
+            "type": "string"
+          },
+          "pool_asset_2": {
+            "type": "string"
+          },
+          "pool_id": {
+            "$ref": "#/definitions/Uint64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TickRange": {
+        "type": "object",
+        "required": [
+          "lower_tick",
+          "upper_tick"
+        ],
+        "properties": {
+          "lower_tick": {
+            "$ref": "#/definitions/Int64"
+          },
+          "upper_tick": {
+            "$ref": "#/definitions/Int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "provide_liquidity_custom"
+            ],
+            "properties": {
+              "provide_liquidity_custom": {
+                "type": "object",
+                "required": [
+                  "tick_range"
+                ],
+                "properties": {
+                  "tick_range": {
+                    "$ref": "#/definitions/TickRange"
+                  },
+                  "token_min_amount_0": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Uint128"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "token_min_amount_1": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Uint128"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "provide_liquidity_default"
+            ],
+            "properties": {
+              "provide_liquidity_default": {
+                "type": "object",
+                "required": [
+                  "bucket_amount"
+                ],
+                "properties": {
+                  "bucket_amount": {
+                    "$ref": "#/definitions/Uint64"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Int64": {
+        "description": "An implementation of i64 that is using strings for JSON encoding/decoding, such that the full i64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `i64` to get the value out:\n\n``` # use cosmwasm_std::Int64; let a = Int64::from(258i64); assert_eq!(a.i64(), 258); ```",
+        "type": "string"
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lp_config": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LiquidityProviderConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityProviderConfig": {
+        "type": "object",
+        "required": [
+          "global_tick_range",
+          "pool_asset_1",
+          "pool_asset_2",
+          "pool_id"
+        ],
+        "properties": {
+          "global_tick_range": {
+            "$ref": "#/definitions/TickRange"
+          },
+          "pool_asset_1": {
+            "type": "string"
+          },
+          "pool_asset_2": {
+            "type": "string"
+          },
+          "pool_id": {
+            "$ref": "#/definitions/Uint64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TickRange": {
+        "type": "object",
+        "required": [
+          "lower_tick",
+          "upper_tick"
+        ],
+        "properties": {
+          "lower_tick": {
+            "$ref": "#/definitions/Int64"
+          },
+          "upper_tick": {
+            "$ref": "#/definitions/Int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Validated library configuration",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lp_config",
+        "output_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "lp_config": {
+          "$ref": "#/definitions/LiquidityProviderConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Int64": {
+          "description": "An implementation of i64 that is using strings for JSON encoding/decoding, such that the full i64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `i64` to get the value out:\n\n``` # use cosmwasm_std::Int64; let a = Int64::from(258i64); assert_eq!(a.i64(), 258); ```",
+          "type": "string"
+        },
+        "LiquidityProviderConfig": {
+          "type": "object",
+          "required": [
+            "global_tick_range",
+            "pool_asset_1",
+            "pool_asset_2",
+            "pool_id"
+          ],
+          "properties": {
+            "global_tick_range": {
+              "$ref": "#/definitions/TickRange"
+            },
+            "pool_asset_1": {
+              "type": "string"
+            },
+            "pool_asset_2": {
+              "type": "string"
+            },
+            "pool_id": {
+              "$ref": "#/definitions/Uint64"
+            }
+          },
+          "additionalProperties": false
+        },
+        "TickRange": {
+          "type": "object",
+          "required": [
+            "lower_tick",
+            "upper_tick"
+          ],
+          "properties": {
+            "lower_tick": {
+              "$ref": "#/definitions/Int64"
+            },
+            "upper_tick": {
+              "$ref": "#/definitions/Int64"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/osmosis-cl-withdrawer/schema/valence-osmosis-cl-withdrawer.json
+++ b/contracts/libraries/osmosis-cl-withdrawer/schema/valence-osmosis-cl-withdrawer.json
@@ -1,0 +1,666 @@
+{
+  "contract_name": "valence-osmosis-cl-withdrawer",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "output_addr",
+          "pool_id"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "pool_id": {
+            "$ref": "#/definitions/Uint64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "description": "liquidiate CL position by its id. follows the logic of osmosis `osmosis.concentratedliquidity.v1beta1.MsgWithdrawPosition`.",
+            "type": "object",
+            "required": [
+              "withdraw_liquidity"
+            ],
+            "properties": {
+              "withdraw_liquidity": {
+                "type": "object",
+                "required": [
+                  "liquidity_amount",
+                  "position_id"
+                ],
+                "properties": {
+                  "liquidity_amount": {
+                    "type": "string"
+                  },
+                  "position_id": {
+                    "$ref": "#/definitions/Uint64"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pool_id": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Validated library configuration",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "output_addr",
+        "pool_id"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "pool_id": {
+          "$ref": "#/definitions/Uint64"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "output_addr",
+        "pool_id"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "pool_id": {
+          "$ref": "#/definitions/Uint64"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/osmosis-gamm-lper/schema/valence-osmosis-gamm-lper.json
+++ b/contracts/libraries/osmosis-gamm-lper/schema/valence-osmosis-gamm-lper.json
@@ -1,0 +1,800 @@
+{
+  "contract_name": "valence-osmosis-gamm-lper",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "lp_config",
+          "output_addr"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "lp_config": {
+            "$ref": "#/definitions/LiquidityProviderConfig"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityProviderConfig": {
+        "type": "object",
+        "required": [
+          "pool_asset_1",
+          "pool_asset_2",
+          "pool_id"
+        ],
+        "properties": {
+          "pool_asset_1": {
+            "type": "string"
+          },
+          "pool_asset_2": {
+            "type": "string"
+          },
+          "pool_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "DecimalRange": {
+        "type": "object",
+        "required": [
+          "max",
+          "min"
+        ],
+        "properties": {
+          "max": {
+            "$ref": "#/definitions/Decimal"
+          },
+          "min": {
+            "$ref": "#/definitions/Decimal"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "provide_double_sided_liquidity"
+            ],
+            "properties": {
+              "provide_double_sided_liquidity": {
+                "type": "object",
+                "properties": {
+                  "expected_spot_price": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DecimalRange"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "provide_single_sided_liquidity"
+            ],
+            "properties": {
+              "provide_single_sided_liquidity": {
+                "type": "object",
+                "required": [
+                  "asset",
+                  "limit"
+                ],
+                "properties": {
+                  "asset": {
+                    "type": "string"
+                  },
+                  "expected_spot_price": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DecimalRange"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "limit": {
+                    "$ref": "#/definitions/Uint128"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lp_config": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LiquidityProviderConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityProviderConfig": {
+        "type": "object",
+        "required": [
+          "pool_asset_1",
+          "pool_asset_2",
+          "pool_id"
+        ],
+        "properties": {
+          "pool_asset_1": {
+            "type": "string"
+          },
+          "pool_asset_2": {
+            "type": "string"
+          },
+          "pool_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Validated library configuration",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lp_config",
+        "output_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "lp_config": {
+          "$ref": "#/definitions/LiquidityProviderConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "LiquidityProviderConfig": {
+          "type": "object",
+          "required": [
+            "pool_asset_1",
+            "pool_asset_2",
+            "pool_id"
+          ],
+          "properties": {
+            "pool_asset_1": {
+              "type": "string"
+            },
+            "pool_asset_2": {
+              "type": "string"
+            },
+            "pool_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lp_config",
+        "output_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "lp_config": {
+          "$ref": "#/definitions/LiquidityProviderConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "LiquidityProviderConfig": {
+          "type": "object",
+          "required": [
+            "pool_asset_1",
+            "pool_asset_2",
+            "pool_id"
+          ],
+          "properties": {
+            "pool_asset_1": {
+              "type": "string"
+            },
+            "pool_asset_2": {
+              "type": "string"
+            },
+            "pool_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/osmosis-gamm-withdrawer/schema/valence-osmosis-gamm-withdrawer.json
+++ b/contracts/libraries/osmosis-gamm-withdrawer/schema/valence-osmosis-gamm-withdrawer.json
@@ -1,0 +1,697 @@
+{
+  "contract_name": "valence-osmosis-gamm-withdrawer",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "lw_config",
+          "output_addr"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "lw_config": {
+            "$ref": "#/definitions/LiquidityWithdrawerConfig"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityWithdrawerConfig": {
+        "type": "object",
+        "required": [
+          "pool_id"
+        ],
+        "properties": {
+          "pool_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "withdraw_liquidity"
+            ],
+            "properties": {
+              "withdraw_liquidity": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lw_config": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LiquidityWithdrawerConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "LiquidityWithdrawerConfig": {
+        "type": "object",
+        "required": [
+          "pool_id"
+        ],
+        "properties": {
+          "pool_id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "Validated library configuration",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lw_config",
+        "output_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "lw_config": {
+          "$ref": "#/definitions/LiquidityWithdrawerConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "LiquidityWithdrawerConfig": {
+          "type": "object",
+          "required": [
+            "pool_id"
+          ],
+          "properties": {
+            "pool_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "lw_config",
+        "output_addr"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "lw_config": {
+          "$ref": "#/definitions/LiquidityWithdrawerConfig"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "LiquidityWithdrawerConfig": {
+          "type": "object",
+          "required": [
+            "pool_id"
+          ],
+          "properties": {
+            "pool_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/reverse-splitter/schema/valence-reverse-splitter-library.json
+++ b/contracts/libraries/reverse-splitter/schema/valence-reverse-splitter-library.json
@@ -1,0 +1,1129 @@
+{
+  "contract_name": "valence-reverse-splitter-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "base_denom",
+          "output_addr",
+          "splits"
+        ],
+        "properties": {
+          "base_denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          },
+          "output_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "splits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/UncheckedSplitConfig"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitAmount": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_ratio"
+            ],
+            "properties": {
+              "fixed_ratio": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "dynamic_ratio"
+            ],
+            "properties": {
+              "dynamic_ratio": {
+                "type": "object",
+                "required": [
+                  "contract_addr",
+                  "params"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  },
+                  "params": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitConfig": {
+        "type": "object",
+        "required": [
+          "account",
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "account": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "amount": {
+            "$ref": "#/definitions/UncheckedSplitAmount"
+          },
+          "denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          },
+          "factor": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "split"
+            ],
+            "properties": {
+              "split": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "base_denom": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/UncheckedDenom"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "splits": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/UncheckedSplitConfig"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitAmount": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_ratio"
+            ],
+            "properties": {
+              "fixed_ratio": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "dynamic_ratio"
+            ],
+            "properties": {
+              "dynamic_ratio": {
+                "type": "object",
+                "required": [
+                  "contract_addr",
+                  "params"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  },
+                  "params": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitConfig": {
+        "type": "object",
+        "required": [
+          "account",
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "account": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "amount": {
+            "$ref": "#/definitions/UncheckedSplitAmount"
+          },
+          "denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          },
+          "factor": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "base_denom",
+        "output_addr",
+        "splits"
+      ],
+      "properties": {
+        "base_denom": {
+          "$ref": "#/definitions/CheckedDenom"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "splits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SplitConfig"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CheckedDenom": {
+          "description": "A denom that has been checked to point to a valid asset. This enum should never be constructed literally and should always be built by calling `into_checked` on an `UncheckedDenom` instance.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "SplitAmount": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_ratio"
+              ],
+              "properties": {
+                "fixed_ratio": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "dynamic_ratio"
+              ],
+              "properties": {
+                "dynamic_ratio": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "params"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    "params": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "SplitConfig": {
+          "type": "object",
+          "required": [
+            "account",
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "account": {
+              "$ref": "#/definitions/Addr"
+            },
+            "amount": {
+              "$ref": "#/definitions/SplitAmount"
+            },
+            "denom": {
+              "$ref": "#/definitions/CheckedDenom"
+            },
+            "factor": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "base_denom",
+        "output_addr",
+        "splits"
+      ],
+      "properties": {
+        "base_denom": {
+          "$ref": "#/definitions/UncheckedDenom"
+        },
+        "output_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "splits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UncheckedSplitConfig"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "UncheckedDenom": {
+          "description": "A denom that has not been checked to confirm it points to a valid asset.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "UncheckedSplitAmount": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_ratio"
+              ],
+              "properties": {
+                "fixed_ratio": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "dynamic_ratio"
+              ],
+              "properties": {
+                "dynamic_ratio": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "params"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "params": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "UncheckedSplitConfig": {
+          "type": "object",
+          "required": [
+            "account",
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "account": {
+              "$ref": "#/definitions/LibraryAccountType"
+            },
+            "amount": {
+              "$ref": "#/definitions/UncheckedSplitAmount"
+            },
+            "denom": {
+              "$ref": "#/definitions/UncheckedDenom"
+            },
+            "factor": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/splitter/schema/valence-splitter-library.json
+++ b/contracts/libraries/splitter/schema/valence-splitter-library.json
@@ -1,0 +1,1075 @@
+{
+  "contract_name": "valence-splitter-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "input_addr",
+          "splits"
+        ],
+        "properties": {
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "splits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/UncheckedSplitConfig"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitAmount": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_ratio"
+            ],
+            "properties": {
+              "fixed_ratio": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "dynamic_ratio"
+            ],
+            "properties": {
+              "dynamic_ratio": {
+                "type": "object",
+                "required": [
+                  "contract_addr",
+                  "params"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  },
+                  "params": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitConfig": {
+        "type": "object",
+        "required": [
+          "account",
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "account": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "amount": {
+            "$ref": "#/definitions/UncheckedSplitAmount"
+          },
+          "denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "split"
+            ],
+            "properties": {
+              "split": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "splits": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/UncheckedSplitConfig"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "UncheckedDenom": {
+        "description": "A denom that has not been checked to confirm it points to a valid asset.",
+        "oneOf": [
+          {
+            "description": "A native (bank module) asset.",
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "A cw20 asset.",
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitAmount": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "fixed_amount"
+            ],
+            "properties": {
+              "fixed_amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "fixed_ratio"
+            ],
+            "properties": {
+              "fixed_ratio": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "dynamic_ratio"
+            ],
+            "properties": {
+              "dynamic_ratio": {
+                "type": "object",
+                "required": [
+                  "contract_addr",
+                  "params"
+                ],
+                "properties": {
+                  "contract_addr": {
+                    "type": "string"
+                  },
+                  "params": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "UncheckedSplitConfig": {
+        "type": "object",
+        "required": [
+          "account",
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "account": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "amount": {
+            "$ref": "#/definitions/UncheckedSplitAmount"
+          },
+          "denom": {
+            "$ref": "#/definitions/UncheckedDenom"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "splits"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "splits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SplitConfig"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "CheckedDenom": {
+          "description": "A denom that has been checked to point to a valid asset. This enum should never be constructed literally and should always be built by calling `into_checked` on an `UncheckedDenom` instance.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "$ref": "#/definitions/Addr"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "SplitAmount": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_ratio"
+              ],
+              "properties": {
+                "fixed_ratio": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "dynamic_ratio"
+              ],
+              "properties": {
+                "dynamic_ratio": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "params"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    "params": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "SplitConfig": {
+          "type": "object",
+          "required": [
+            "account",
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "account": {
+              "$ref": "#/definitions/Addr"
+            },
+            "amount": {
+              "$ref": "#/definitions/SplitAmount"
+            },
+            "denom": {
+              "$ref": "#/definitions/CheckedDenom"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "input_addr",
+        "splits"
+      ],
+      "properties": {
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "splits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UncheckedSplitConfig"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "UncheckedDenom": {
+          "description": "A denom that has not been checked to confirm it points to a valid asset.",
+          "oneOf": [
+            {
+              "description": "A native (bank module) asset.",
+              "type": "object",
+              "required": [
+                "native"
+              ],
+              "properties": {
+                "native": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "A cw20 asset.",
+              "type": "object",
+              "required": [
+                "cw20"
+              ],
+              "properties": {
+                "cw20": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "UncheckedSplitAmount": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "fixed_amount"
+              ],
+              "properties": {
+                "fixed_amount": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "fixed_ratio"
+              ],
+              "properties": {
+                "fixed_ratio": {
+                  "$ref": "#/definitions/Decimal"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "dynamic_ratio"
+              ],
+              "properties": {
+                "dynamic_ratio": {
+                  "type": "object",
+                  "required": [
+                    "contract_addr",
+                    "params"
+                  ],
+                  "properties": {
+                    "contract_addr": {
+                      "type": "string"
+                    },
+                    "params": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "UncheckedSplitConfig": {
+          "type": "object",
+          "required": [
+            "account",
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "account": {
+              "$ref": "#/definitions/LibraryAccountType"
+            },
+            "amount": {
+              "$ref": "#/definitions/UncheckedSplitAmount"
+            },
+            "denom": {
+              "$ref": "#/definitions/UncheckedDenom"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/template/schema/valence-template-library.json
+++ b/contracts/libraries/template/schema/valence-template-library.json
@@ -1,0 +1,617 @@
+{
+  "contract_name": "valence-template-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "description": "Everything a library needs as a parameter to be instantiated goes into `LibraryConfig` `ValenceLibraryInterface` generates `LibraryConfigUpdate` is used in update method that allows to update the library configuration `LibraryConfigUpdate` turns all fields <T> from `LibraryConfig` into Option<T>\n\nFields that are Option<T>, will be generated as OptionUpdate<T> If a field cannot or should not be updated, it should be annotated with #[skip_update]",
+        "type": "object",
+        "required": [
+          "optional2",
+          "skip_update_admin"
+        ],
+        "properties": {
+          "optional": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "optional2": {
+            "type": "string"
+          },
+          "skip_update_admin": {
+            "description": "We ignore this field when generating the ValenceLibraryInterface This means this field is not updatable",
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "no_op"
+            ],
+            "properties": {
+              "no_op": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "required": [
+          "optional"
+        ],
+        "properties": {
+          "optional": {
+            "$ref": "#/definitions/OptionUpdate_for_String"
+          },
+          "optional2": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "OptionUpdate_for_String": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "none"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "set"
+            ],
+            "properties": {
+              "set": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "admin"
+      ],
+      "properties": {
+        "admin": {
+          "$ref": "#/definitions/Addr"
+        },
+        "optional": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "description": "Everything a library needs as a parameter to be instantiated goes into `LibraryConfig` `ValenceLibraryInterface` generates `LibraryConfigUpdate` is used in update method that allows to update the library configuration `LibraryConfigUpdate` turns all fields <T> from `LibraryConfig` into Option<T>\n\nFields that are Option<T>, will be generated as OptionUpdate<T> If a field cannot or should not be updated, it should be annotated with #[skip_update]",
+      "type": "object",
+      "required": [
+        "optional2",
+        "skip_update_admin"
+      ],
+      "properties": {
+        "optional": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "optional2": {
+          "type": "string"
+        },
+        "skip_update_admin": {
+          "description": "We ignore this field when generating the ValenceLibraryInterface This means this field is not updatable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LibraryAccountType"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/processor/schema/valence-processor.json
+++ b/contracts/processor/schema/valence-processor.json
@@ -1,0 +1,2256 @@
+{
+  "contract_name": "valence-processor",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "authorization_contract"
+    ],
+    "properties": {
+      "authorization_contract": {
+        "type": "string"
+      },
+      "polytone_contracts": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/PolytoneContracts"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "PolytoneContracts": {
+        "type": "object",
+        "required": [
+          "polytone_note_address",
+          "polytone_proxy_address",
+          "timeout_seconds"
+        ],
+        "properties": {
+          "polytone_note_address": {
+            "type": "string"
+          },
+          "polytone_proxy_address": {
+            "type": "string"
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "authorization_module_action"
+        ],
+        "properties": {
+          "authorization_module_action": {
+            "$ref": "#/definitions/AuthorizationMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "permissionless_action"
+        ],
+        "properties": {
+          "permissionless_action": {
+            "$ref": "#/definitions/PermissionlessMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "internal_processor_action"
+        ],
+        "properties": {
+          "internal_processor_action": {
+            "$ref": "#/definitions/InternalProcessorMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "callback"
+        ],
+        "properties": {
+          "callback": {
+            "$ref": "#/definitions/CallbackMessage"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
+      "AtomicFunction": {
+        "type": "object",
+        "required": [
+          "contract_address",
+          "domain",
+          "message_details"
+        ],
+        "properties": {
+          "contract_address": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "domain": {
+            "$ref": "#/definitions/Domain"
+          },
+          "message_details": {
+            "$ref": "#/definitions/MessageDetails"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AtomicSubroutine": {
+        "type": "object",
+        "required": [
+          "functions"
+        ],
+        "properties": {
+          "functions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AtomicFunction"
+            }
+          },
+          "retry_logic": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RetryLogic"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Attribute": {
+        "description": "An key value pair that is used in the context of event attributes in logs",
+        "type": "object",
+        "required": [
+          "key",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AuthorizationMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "enqueue_msgs"
+            ],
+            "properties": {
+              "enqueue_msgs": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "msgs",
+                  "priority",
+                  "subroutine"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "msgs": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/ProcessorMessage"
+                    }
+                  },
+                  "priority": {
+                    "$ref": "#/definitions/Priority"
+                  },
+                  "subroutine": {
+                    "$ref": "#/definitions/Subroutine"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "evict_msgs"
+            ],
+            "properties": {
+              "evict_msgs": {
+                "type": "object",
+                "required": [
+                  "priority",
+                  "queue_position"
+                ],
+                "properties": {
+                  "priority": {
+                    "$ref": "#/definitions/Priority"
+                  },
+                  "queue_position": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "insert_msgs"
+            ],
+            "properties": {
+              "insert_msgs": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "msgs",
+                  "priority",
+                  "queue_position",
+                  "subroutine"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "msgs": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/ProcessorMessage"
+                    }
+                  },
+                  "priority": {
+                    "$ref": "#/definitions/Priority"
+                  },
+                  "queue_position": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "subroutine": {
+                    "$ref": "#/definitions/Subroutine"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "pause"
+            ],
+            "properties": {
+              "pause": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "resume"
+            ],
+            "properties": {
+              "resume": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Callback": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "$ref": "#/definitions/Result_of_Array_of_Binary_or_ErrorResponse"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "execute"
+            ],
+            "properties": {
+              "execute": {
+                "$ref": "#/definitions/Result_of_ExecutionResponse_or_String"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "fatal_error"
+            ],
+            "properties": {
+              "fatal_error": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "CallbackMessage": {
+        "type": "object",
+        "required": [
+          "initiator",
+          "initiator_msg",
+          "result"
+        ],
+        "properties": {
+          "initiator": {
+            "description": "Initaitor on the note chain.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Addr"
+              }
+            ]
+          },
+          "initiator_msg": {
+            "description": "Message sent by the initaitor. This _must_ be base64 encoded or execution will fail.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          },
+          "result": {
+            "description": "Data from the host chain.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "CurrentRetry": {
+        "type": "object",
+        "required": [
+          "retry_amounts",
+          "retry_cooldown"
+        ],
+        "properties": {
+          "retry_amounts": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "retry_cooldown": {
+            "$ref": "#/definitions/Expiration"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Domain": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "main"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "external"
+            ],
+            "properties": {
+              "external": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Duration": {
+        "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Time in seconds",
+            "type": "object",
+            "required": [
+              "time"
+            ],
+            "properties": {
+              "time": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "error",
+          "message_index"
+        ],
+        "properties": {
+          "error": {
+            "description": "The error that occured executing the message.",
+            "type": "string"
+          },
+          "message_index": {
+            "description": "The index of the first message who's execution failed.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Event": {
+        "description": "A full [*Cosmos SDK* event].\n\nThis version uses string attributes (similar to [*Cosmos SDK* StringEvent]), which then get magically converted to bytes for Tendermint somewhere between the Rust-Go interface, JSON deserialization and the `NewEvent` call in Cosmos SDK.\n\n[*Cosmos SDK* event]: https://docs.cosmos.network/main/learn/advanced/events [*Cosmos SDK* StringEvent]: https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/base/abci/v1beta1/abci.proto#L56-L70",
+        "type": "object",
+        "required": [
+          "attributes",
+          "type"
+        ],
+        "properties": {
+          "attributes": {
+            "description": "The attributes to be included in the event.\n\nYou can learn more about these from [*Cosmos SDK* docs].\n\n[*Cosmos SDK* docs]: https://docs.cosmos.network/main/learn/advanced/events",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "type": {
+            "description": "The event type. This is renamed to \"ty\" because \"type\" is reserved in Rust. This sucks, we know.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExecutionResponse": {
+        "type": "object",
+        "required": [
+          "executed_by",
+          "result"
+        ],
+        "properties": {
+          "executed_by": {
+            "description": "The address on the remote chain that executed the messages.",
+            "type": "string"
+          },
+          "result": {
+            "description": "Index `i` corresponds to the result of executing the `i`th message.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SubMsgResponse"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionCallback": {
+        "type": "object",
+        "required": [
+          "callback_message",
+          "contract_address"
+        ],
+        "properties": {
+          "callback_message": {
+            "$ref": "#/definitions/Binary"
+          },
+          "contract_address": {
+            "$ref": "#/definitions/Addr"
+          }
+        },
+        "additionalProperties": false
+      },
+      "InternalProcessorMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "library_callback"
+            ],
+            "properties": {
+              "library_callback": {
+                "type": "object",
+                "required": [
+                  "execution_id",
+                  "msg"
+                ],
+                "properties": {
+                  "execution_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "msg": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "execute_atomic"
+            ],
+            "properties": {
+              "execute_atomic": {
+                "type": "object",
+                "required": [
+                  "batch"
+                ],
+                "properties": {
+                  "batch": {
+                    "$ref": "#/definitions/MessageBatch"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Message": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "params_restrictions": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/ParamRestriction"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageBatch": {
+        "type": "object",
+        "required": [
+          "id",
+          "msgs",
+          "priority",
+          "subroutine"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "msgs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ProcessorMessage"
+            }
+          },
+          "priority": {
+            "$ref": "#/definitions/Priority"
+          },
+          "retry": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/CurrentRetry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subroutine": {
+            "$ref": "#/definitions/Subroutine"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageDetails": {
+        "type": "object",
+        "required": [
+          "message",
+          "message_type"
+        ],
+        "properties": {
+          "message": {
+            "$ref": "#/definitions/Message"
+          },
+          "message_type": {
+            "$ref": "#/definitions/MessageType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageType": {
+        "type": "string",
+        "enum": [
+          "cosmwasm_execute_msg",
+          "cosmwasm_migrate_msg"
+        ]
+      },
+      "MsgResponse": {
+        "type": "object",
+        "required": [
+          "type_url",
+          "value"
+        ],
+        "properties": {
+          "type_url": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/definitions/Binary"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NonAtomicFunction": {
+        "type": "object",
+        "required": [
+          "contract_address",
+          "domain",
+          "message_details"
+        ],
+        "properties": {
+          "callback_confirmation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/FunctionCallback"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contract_address": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "domain": {
+            "$ref": "#/definitions/Domain"
+          },
+          "message_details": {
+            "$ref": "#/definitions/MessageDetails"
+          },
+          "retry_logic": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RetryLogic"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "NonAtomicSubroutine": {
+        "type": "object",
+        "required": [
+          "functions"
+        ],
+        "properties": {
+          "functions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/NonAtomicFunction"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParamRestriction": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "must_be_included"
+            ],
+            "properties": {
+              "must_be_included": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cannot_be_included"
+            ],
+            "properties": {
+              "cannot_be_included": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "must_be_value"
+            ],
+            "properties": {
+              "must_be_value": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PermissionlessMsg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "tick"
+            ],
+            "properties": {
+              "tick": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "retry_callback"
+            ],
+            "properties": {
+              "retry_callback": {
+                "type": "object",
+                "required": [
+                  "execution_id"
+                ],
+                "properties": {
+                  "execution_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "retry_bridge_creation"
+            ],
+            "properties": {
+              "retry_bridge_creation": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Priority": {
+        "type": "string",
+        "enum": [
+          "medium",
+          "high"
+        ]
+      },
+      "ProcessorMessage": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "cosmwasm_execute_msg"
+            ],
+            "properties": {
+              "cosmwasm_execute_msg": {
+                "type": "object",
+                "required": [
+                  "msg"
+                ],
+                "properties": {
+                  "msg": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cosmwasm_migrate_msg"
+            ],
+            "properties": {
+              "cosmwasm_migrate_msg": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "msg"
+                ],
+                "properties": {
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "msg": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Result_of_Array_of_Binary_or_ErrorResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ok"
+            ],
+            "properties": {
+              "Ok": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/Binary"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Err"
+            ],
+            "properties": {
+              "Err": {
+                "$ref": "#/definitions/ErrorResponse"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Result_of_ExecutionResponse_or_String": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Ok"
+            ],
+            "properties": {
+              "Ok": {
+                "$ref": "#/definitions/ExecutionResponse"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Err"
+            ],
+            "properties": {
+              "Err": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "RetryLogic": {
+        "type": "object",
+        "required": [
+          "interval",
+          "times"
+        ],
+        "properties": {
+          "interval": {
+            "$ref": "#/definitions/Duration"
+          },
+          "times": {
+            "$ref": "#/definitions/RetryTimes"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RetryTimes": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "indefinitely"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "SubMsgResponse": {
+        "description": "The information we get back from a successful sub message execution, with full Cosmos SDK events.",
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "properties": {
+          "data": {
+            "deprecated": true,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Event"
+            }
+          },
+          "msg_responses": {
+            "description": "The responses from the messages emitted by the submessage. In most cases, this is equivalent to the Cosmos SDK's [MsgResponses], which usually contains a [single message]. However, wasmd allows chains to translate a single contract message into multiple SDK messages. In that case all the MsgResponses from each are concatenated into this flattened `Vec`.\n\n[MsgResponses]: https://github.com/cosmos/cosmos-sdk/blob/316750cc8cd8b3296fa233f4da2e39cbcdc34517/proto/cosmos/base/abci/v1beta1/abci.proto#L106-L109 [single message]: https://github.com/cosmos/cosmos-sdk/blob/v0.50.4/baseapp/baseapp.go#L1020-L1023",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MsgResponse"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Subroutine": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "atomic"
+            ],
+            "properties": {
+              "atomic": {
+                "$ref": "#/definitions/AtomicSubroutine"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "non_atomic"
+            ],
+            "properties": {
+              "non_atomic": {
+                "$ref": "#/definitions/NonAtomicSubroutine"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_queue"
+        ],
+        "properties": {
+          "get_queue": {
+            "type": "object",
+            "required": [
+              "priority"
+            ],
+            "properties": {
+              "from": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "priority": {
+                "$ref": "#/definitions/Priority"
+              },
+              "to": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "is_queue_empty"
+        ],
+        "properties": {
+          "is_queue_empty": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "pending_polytone_callbacks"
+        ],
+        "properties": {
+          "pending_polytone_callbacks": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "pending_polytone_callback"
+        ],
+        "properties": {
+          "pending_polytone_callback": {
+            "type": "object",
+            "required": [
+              "execution_id"
+            ],
+            "properties": {
+              "execution_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Priority": {
+        "type": "string",
+        "enum": [
+          "medium",
+          "high"
+        ]
+      }
+    }
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "authorization_contract",
+        "processor_domain",
+        "state"
+      ],
+      "properties": {
+        "authorization_contract": {
+          "type": "string"
+        },
+        "processor_domain": {
+          "$ref": "#/definitions/ProcessorDomain"
+        },
+        "state": {
+          "$ref": "#/definitions/State"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Polytone": {
+          "type": "object",
+          "required": [
+            "polytone_note_address",
+            "polytone_proxy_address",
+            "proxy_on_main_domain_state",
+            "timeout_seconds"
+          ],
+          "properties": {
+            "polytone_note_address": {
+              "$ref": "#/definitions/Addr"
+            },
+            "polytone_proxy_address": {
+              "$ref": "#/definitions/Addr"
+            },
+            "proxy_on_main_domain_state": {
+              "$ref": "#/definitions/PolytoneProxyState"
+            },
+            "timeout_seconds": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "PolytoneProxyState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "timed_out",
+                "pending_response",
+                "created"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ProcessorDomain": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "main"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "external"
+              ],
+              "properties": {
+                "external": {
+                  "$ref": "#/definitions/Polytone"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "State": {
+          "type": "string",
+          "enum": [
+            "paused",
+            "active"
+          ]
+        }
+      }
+    },
+    "get_queue": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_MessageBatch",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MessageBatch"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "AtomicFunction": {
+          "type": "object",
+          "required": [
+            "contract_address",
+            "domain",
+            "message_details"
+          ],
+          "properties": {
+            "contract_address": {
+              "$ref": "#/definitions/LibraryAccountType"
+            },
+            "domain": {
+              "$ref": "#/definitions/Domain"
+            },
+            "message_details": {
+              "$ref": "#/definitions/MessageDetails"
+            }
+          },
+          "additionalProperties": false
+        },
+        "AtomicSubroutine": {
+          "type": "object",
+          "required": [
+            "functions"
+          ],
+          "properties": {
+            "functions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AtomicFunction"
+              }
+            },
+            "retry_logic": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RetryLogic"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "CurrentRetry": {
+          "type": "object",
+          "required": [
+            "retry_amounts",
+            "retry_cooldown"
+          ],
+          "properties": {
+            "retry_amounts": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "retry_cooldown": {
+              "$ref": "#/definitions/Expiration"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Domain": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "main"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "external"
+              ],
+              "properties": {
+                "external": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Duration": {
+          "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "height"
+              ],
+              "properties": {
+                "height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Time in seconds",
+              "type": "object",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "FunctionCallback": {
+          "type": "object",
+          "required": [
+            "callback_message",
+            "contract_address"
+          ],
+          "properties": {
+            "callback_message": {
+              "$ref": "#/definitions/Binary"
+            },
+            "contract_address": {
+              "$ref": "#/definitions/Addr"
+            }
+          },
+          "additionalProperties": false
+        },
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Message": {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "params_restrictions": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/ParamRestriction"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "MessageBatch": {
+          "type": "object",
+          "required": [
+            "id",
+            "msgs",
+            "priority",
+            "subroutine"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "msgs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ProcessorMessage"
+              }
+            },
+            "priority": {
+              "$ref": "#/definitions/Priority"
+            },
+            "retry": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/CurrentRetry"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "subroutine": {
+              "$ref": "#/definitions/Subroutine"
+            }
+          },
+          "additionalProperties": false
+        },
+        "MessageDetails": {
+          "type": "object",
+          "required": [
+            "message",
+            "message_type"
+          ],
+          "properties": {
+            "message": {
+              "$ref": "#/definitions/Message"
+            },
+            "message_type": {
+              "$ref": "#/definitions/MessageType"
+            }
+          },
+          "additionalProperties": false
+        },
+        "MessageType": {
+          "type": "string",
+          "enum": [
+            "cosmwasm_execute_msg",
+            "cosmwasm_migrate_msg"
+          ]
+        },
+        "NonAtomicFunction": {
+          "type": "object",
+          "required": [
+            "contract_address",
+            "domain",
+            "message_details"
+          ],
+          "properties": {
+            "callback_confirmation": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FunctionCallback"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contract_address": {
+              "$ref": "#/definitions/LibraryAccountType"
+            },
+            "domain": {
+              "$ref": "#/definitions/Domain"
+            },
+            "message_details": {
+              "$ref": "#/definitions/MessageDetails"
+            },
+            "retry_logic": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RetryLogic"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "NonAtomicSubroutine": {
+          "type": "object",
+          "required": [
+            "functions"
+          ],
+          "properties": {
+            "functions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/NonAtomicFunction"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ParamRestriction": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "must_be_included"
+              ],
+              "properties": {
+                "must_be_included": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cannot_be_included"
+              ],
+              "properties": {
+                "cannot_be_included": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "must_be_value"
+              ],
+              "properties": {
+                "must_be_value": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Priority": {
+          "type": "string",
+          "enum": [
+            "medium",
+            "high"
+          ]
+        },
+        "ProcessorMessage": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "cosmwasm_execute_msg"
+              ],
+              "properties": {
+                "cosmwasm_execute_msg": {
+                  "type": "object",
+                  "required": [
+                    "msg"
+                  ],
+                  "properties": {
+                    "msg": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cosmwasm_migrate_msg"
+              ],
+              "properties": {
+                "cosmwasm_migrate_msg": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "msg"
+                  ],
+                  "properties": {
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "msg": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "RetryLogic": {
+          "type": "object",
+          "required": [
+            "interval",
+            "times"
+          ],
+          "properties": {
+            "interval": {
+              "$ref": "#/definitions/Duration"
+            },
+            "times": {
+              "$ref": "#/definitions/RetryTimes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RetryTimes": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "indefinitely"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "amount"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Subroutine": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "atomic"
+              ],
+              "properties": {
+                "atomic": {
+                  "$ref": "#/definitions/AtomicSubroutine"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "non_atomic"
+              ],
+              "properties": {
+                "non_atomic": {
+                  "$ref": "#/definitions/NonAtomicSubroutine"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "is_queue_empty": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    },
+    "pending_polytone_callback": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "PendingPolytoneCallbackInfo",
+      "type": "object",
+      "required": [
+        "execution_result",
+        "state"
+      ],
+      "properties": {
+        "execution_result": {
+          "$ref": "#/definitions/ExecutionResult"
+        },
+        "state": {
+          "$ref": "#/definitions/PolytoneCallbackState"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ExecutionResult": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "in_process",
+                "success",
+                "removed_by_owner"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "rejected"
+              ],
+              "properties": {
+                "rejected": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "partially_executed"
+              ],
+              "properties": {
+                "partially_executed": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "timeout"
+              ],
+              "properties": {
+                "timeout": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PolytoneCallbackState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "pending",
+                "timed_out"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "pending_polytone_callbacks": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_PendingPolytoneCallbackInfo",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PendingPolytoneCallbackInfo"
+      },
+      "definitions": {
+        "ExecutionResult": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "in_process",
+                "success",
+                "removed_by_owner"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "rejected"
+              ],
+              "properties": {
+                "rejected": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "partially_executed"
+              ],
+              "properties": {
+                "partially_executed": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "timeout"
+              ],
+              "properties": {
+                "timeout": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PendingPolytoneCallbackInfo": {
+          "type": "object",
+          "required": [
+            "execution_result",
+            "state"
+          ],
+          "properties": {
+            "execution_result": {
+              "$ref": "#/definitions/ExecutionResult"
+            },
+            "state": {
+              "$ref": "#/definitions/PolytoneCallbackState"
+            }
+          },
+          "additionalProperties": false
+        },
+        "PolytoneCallbackState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "pending",
+                "timed_out"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "unexpected_error"
+              ],
+              "properties": {
+                "unexpected_error": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/program-registry/schema/valence-program-registry.json
+++ b/contracts/program-registry/schema/valence-program-registry.json
@@ -1,0 +1,344 @@
+{
+  "contract_name": "valence-program-registry",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "admin"
+    ],
+    "properties": {
+      "admin": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "description": "\"Lock\" an id for a program to avoid race conditions",
+        "type": "object",
+        "required": [
+          "reserve_id"
+        ],
+        "properties": {
+          "reserve_id": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Save a new program config for the id",
+        "type": "object",
+        "required": [
+          "save_program"
+        ],
+        "properties": {
+          "save_program": {
+            "type": "object",
+            "required": [
+              "id",
+              "program_config"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "program_config": {
+                "$ref": "#/definitions/Binary"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update a program config for the id",
+        "type": "object",
+        "required": [
+          "update_program"
+        ],
+        "properties": {
+          "update_program": {
+            "type": "object",
+            "required": [
+              "id",
+              "program_config"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "program_config": {
+                "$ref": "#/definitions/Binary"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Gets the most up to date program config for the id",
+        "type": "object",
+        "required": [
+          "get_config"
+        ],
+        "properties": {
+          "get_config": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Gets the previous program config for the id returns None if there is no backup",
+        "type": "object",
+        "required": [
+          "get_config_backup"
+        ],
+        "properties": {
+          "get_config_backup": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProgramResponse",
+      "type": "object",
+      "required": [
+        "id",
+        "program_config"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "program_config": {
+          "$ref": "#/definitions/Binary"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        }
+      }
+    },
+    "get_config_backup": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Nullable_ProgramResponse",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ProgramResponse"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "definitions": {
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "ProgramResponse": {
+          "type": "object",
+          "required": [
+            "id",
+            "program_config"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "program_config": {
+              "$ref": "#/definitions/Binary"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/contracts/testing/test-library/schema/valence-test-library.json
+++ b/contracts/testing/test-library/schema/valence-test-library.json
@@ -1,0 +1,180 @@
+{
+  "contract_name": "valence-test-library",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "will_error"
+        ],
+        "properties": {
+          "will_error": {
+            "type": "object",
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "will_succeed"
+        ],
+        "properties": {
+          "will_succeed": {
+            "type": "object",
+            "properties": {
+              "execution_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "will_succeed_if_true"
+        ],
+        "properties": {
+          "will_succeed_if_true": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "set_condition"
+        ],
+        "properties": {
+          "set_condition": {
+            "type": "object",
+            "required": [
+              "condition"
+            ],
+            "properties": {
+              "condition": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "send_callback"
+        ],
+        "properties": {
+          "send_callback": {
+            "type": "object",
+            "required": [
+              "callback",
+              "to"
+            ],
+            "properties": {
+              "callback": {
+                "$ref": "#/definitions/Binary"
+              },
+              "to": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "condition"
+        ],
+        "properties": {
+          "condition": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MigrateMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "migrate"
+        ],
+        "properties": {
+          "migrate": {
+            "type": "object",
+            "required": [
+              "new_condition"
+            ],
+            "properties": {
+              "new_condition": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "sudo": null,
+  "responses": {
+    "condition": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    }
+  }
+}

--- a/program-manager/schema/valence-program-manager.json
+++ b/program-manager/schema/valence-program-manager.json
@@ -280,6 +280,7 @@
         "additionalProperties": false
       },
       "AuthorizationInfoUpdate": {
+        "description": "The enum that represent all possible changes that can be done on an authorization",
         "oneOf": [
           {
             "type": "object",
@@ -1372,7 +1373,7 @@
         "additionalProperties": false
       },
       "ProgramConfigUpdate": {
-        "description": "The job of the update, is to output a set of instructions to the user to update the program configuration. The user can only update library configs and authorizations.",
+        "description": "The job of the update, is to output a set of instructions to the user to update the program configuration. The user can only update library configs and authorizations. You can set the owner to change the owner of the program You can provide a list of library updates to perform You can provide a list of authorizations to update",
         "type": "object",
         "required": [
           "authorizations",


### PR DESCRIPTION
closes #95 

works by generating the schemas in the CI, and asserting that it results in no changes to the file tree.
this way, if any of our contracts api in a given pr had changed, but schemas were not regenerated, the assertion will fail because the up to date schema generated in the job will result in a diff.