### PR TITLE
Audit: fix PendingResponse state not being saved during polytone proxy creation retry

### DIFF
--- a/contracts/authorization/src/contract.rs
+++ b/contracts/authorization/src/contract.rs
@@ -683,6 +683,7 @@ fn retry_bridge_creation(
                 timeout_seconds,
                 state: PolytoneProxyState::PendingResponse,
             };
+            EXTERNAL_DOMAINS.save(deps.storage, domain_name.clone(), &external_domain)?;
 
             WasmMsg::Execute {
                 contract_addr: address.to_string(),


### PR DESCRIPTION
During proxy creation retry, the PendingResponse state was not being saved, which could lead to spam the relayer with useless retry messages.