### PR TITLE
Audit: fix astroport ratio calculation

### DIFF
--- a/contracts/libraries/astroport-lper/src/contract.rs
+++ b/contracts/libraries/astroport-lper/src/contract.rs
@@ -208,7 +208,7 @@ mod functions {
             Ok((required_asset1_amount.u128(), balance2))
         } else {
             // We can't provide all asset2 tokens so we need to determine how many we can provide according to our available asset1
-            let ratio = cosmwasm_std::Decimal::from_ratio(pool_asset1_balance, pool_asset2_balance);
+            let ratio = cosmwasm_std::Decimal::from_ratio(pool_asset2_balance, pool_asset1_balance);
 
             Ok((
                 balance1,

--- a/contracts/libraries/astroport-lper/src/contract.rs
+++ b/contracts/libraries/astroport-lper/src/contract.rs
@@ -103,7 +103,8 @@ mod functions {
 
         // Get the pool asset ratios
         let pool_asset_ratios =
-            cosmwasm_std::Decimal::from_ratio(pool_asset1_balance, pool_asset2_balance);
+            cosmwasm_std::Decimal::checked_from_ratio(pool_asset1_balance, pool_asset2_balance)
+                .map_err(|e| LibraryError::ExecutionError(e.to_string()))?;
 
         // If we have an expected pool ratio range, we need to check if the pool is within that range
         if let Some(range) = expected_pool_ratio_range {
@@ -208,7 +209,9 @@ mod functions {
             Ok((required_asset1_amount.u128(), balance2))
         } else {
             // We can't provide all asset2 tokens so we need to determine how many we can provide according to our available asset1
-            let ratio = cosmwasm_std::Decimal::from_ratio(pool_asset2_balance, pool_asset1_balance);
+            let ratio =
+                cosmwasm_std::Decimal::checked_from_ratio(pool_asset2_balance, pool_asset1_balance)
+                    .map_err(|e| LibraryError::ExecutionError(e.to_string()))?;
 
             Ok((
                 balance1,
@@ -287,7 +290,8 @@ mod functions {
         // Check pool ratio if range is provided
         if let Some(range) = expected_pool_ratio_range {
             let pool_asset_ratios =
-                cosmwasm_std::Decimal::from_ratio(pool_asset1_balance, pool_asset2_balance);
+                cosmwasm_std::Decimal::checked_from_ratio(pool_asset1_balance, pool_asset2_balance)
+                    .map_err(|e| LibraryError::ExecutionError(e.to_string()))?;
             range.is_within_range(pool_asset_ratios)?;
         }
 

--- a/packages/astroport-utils/src/suite.rs
+++ b/packages/astroport-utils/src/suite.rs
@@ -190,7 +190,7 @@ impl AstroportTestAppBuilder {
                         info: crate::astroport_native_lp_token::AssetInfo::NativeToken {
                             denom: denom.to_string(),
                         },
-                        amount: Uint128::new(1_000_000_000),
+                        amount: Uint128::new(2_000_000_000),
                     },
                 ],
                 slippage_tolerance: None,
@@ -199,7 +199,7 @@ impl AstroportTestAppBuilder {
                 min_lp_to_receive: None,
             },
             &[
-                coin(1_000_000_000u128, denom.clone()),
+                coin(2_000_000_000u128, denom.clone()),
                 coin(1_000_000_000u128, FEE_DENOM.to_string()),
             ],
             &accounts[0],
@@ -284,7 +284,7 @@ impl AstroportTestAppBuilder {
                         info: crate::astroport_cw20_lp_token::AssetInfo::NativeToken {
                             denom: denom.clone(),
                         },
-                        amount: Uint128::new(1_000_000_000),
+                        amount: Uint128::new(2_000_000_000),
                     },
                 ],
                 slippage_tolerance: None,
@@ -292,7 +292,7 @@ impl AstroportTestAppBuilder {
                 receiver: None,
             },
             &[
-                coin(1_000_000_000u128, denom.clone()),
+                coin(2_000_000_000u128, denom.clone()),
                 coin(1_000_000_000u128, FEE_DENOM.to_string()),
             ],
             &accounts[0],


### PR DESCRIPTION
fix the ratio calculation that was being done wrong in the double sided liquidity when we didn't have enough tokens of 1 asset as per audit feedback.