### PR TITLE
switch to default light theme to match valence site.

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,9 +7,9 @@ title        = "Valence Protocol Documentation"
 
 [output.html]
 git-repository-url    = "https://github.com/timewave-computer/valence-protocol"
-default-theme         = "navy"
-preferred-dark-theme  = "navy"
+default-theme         = "light"
 preferred-light-theme = "light"
+preferred-dark-theme  = "ayu"
 additional-js         = ["mermaid.min.js", "mermaid-init.js"]
 
 [preprocessor.mermaid]


### PR DESCRIPTION
making our docs resemble the valence site a little more closely