### PR TITLE
EVM LiteProcessor

### DIFF
--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -42,6 +42,11 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
             revert ProcessorErrors.UnauthorizedAccess();
         }
 
+        // Verify origin is the expected domain
+        if (_origin != originDomain) {
+            revert ProcessorErrors.InvalidOriginDomain();
+        }
+
         // Verify message is from authorized contract
         if (_sender != authorizationContract) {
             revert ProcessorErrors.NotAuthorizationContract();

--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -12,7 +12,7 @@ import {ProcessorEvents} from "./libs/ProcessorEvents.sol";
 /**
  * @title LiteProcessor
  * @notice A lightweight processor for handling cross-chain messages with atomic and non-atomic execution
- * @dev Implements IMessageRecipient for Hyperlane message handling
+ * @dev Implements IMessageRecipient for Hyperlane message handling and ProcessorBase for core shared processor logic
  */
 contract LiteProcessor is IMessageRecipient, ProcessorBase {
     // ============ Constructor ============

--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -67,6 +67,7 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
             _handleSendMsgs(decodedMessage);
             emit ProcessorEvents.ProcessedSendMsgsOperation();
         } else {
+            // InsertMsgs and EvictMsgs are not supported in LiteProcessor because there are no queues
             revert ProcessorErrors.UnsupportedOperationError();
         }
     }

--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {IMessageRecipient} from "hyperlane/interfaces/IMessageRecipient.sol";
+
+contract LiteProcessor is IMessageRecipient {
+    // Authorization contract will be the sender of the messages on the main domain
+    // It's the hex representation of the address in the main domain
+    bytes32 public authorizationContract;
+
+    // Add mailbox address which will be the only address that can send messages to the processor
+    address public mailbox;
+
+    // Flag to check if the processor is paused
+    bool public paused;
+
+    event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
+
+    // Custom errors
+    error UnauthorizedAccess();
+    error NotAuthorizationContract();
+    error InvalidAddress();
+    error ProcessorPaused();
+    error UnsupportedOperation();
+
+    constructor(bytes32 _authorizationContract, address _mailbox) {
+        // Check for zero addresses
+        if (_mailbox == address(0)) {
+            revert InvalidAddress();
+        }
+
+        // Set authorization contract and mailbox
+        authorizationContract = _authorizationContract;
+        mailbox = _mailbox;
+    }
+
+    // Implement the handle function
+    function handle(uint32 _origin, bytes32 _sender, bytes calldata _body) external payable override {
+        // Only mailbox can call this function
+        if (msg.sender != mailbox) {
+            revert UnauthorizedAccess();
+        }
+
+        // Check that the sender of the message is the authorization contract
+        if (_sender != authorizationContract) {
+            revert NotAuthorizationContract();
+        }
+
+        emit MessageReceived(_origin, _sender, _body);
+    }
+}

--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -39,12 +39,12 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
     function handle(uint32 _origin, bytes32 _sender, bytes calldata _body) external payable override {
         // Verify sender is authorized mailbox
         if (msg.sender != address(mailbox)) {
-            revert ProcessorErrors.UnauthorizedAccessError();
+            revert ProcessorErrors.UnauthorizedAccess();
         }
 
         // Verify message is from authorized contract
         if (_sender != authorizationContract) {
-            revert ProcessorErrors.NotAuthorizationContractError();
+            revert ProcessorErrors.NotAuthorizationContract();
         }
 
         // Emit reception before processing
@@ -71,7 +71,7 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
             emit ProcessorEvents.ProcessedSendMsgsOperation();
         } else {
             // InsertMsgs and EvictMsgs are not supported in LiteProcessor because there are no queues
-            revert ProcessorErrors.UnsupportedOperationError();
+            revert ProcessorErrors.UnsupportedOperation();
         }
     }
 
@@ -83,7 +83,7 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
     function _handleSendMsgs(IProcessorMessageTypes.ProcessorMessage memory decodedMessage) internal {
         // Check if the processor is paused
         if (paused) {
-            revert ProcessorErrors.ProcessorPausedError();
+            revert ProcessorErrors.ProcessorPaused();
         }
 
         IProcessorMessageTypes.SendMsgs memory sendMsgs =

--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -5,65 +5,285 @@ import {IMessageRecipient} from "hyperlane/interfaces/IMessageRecipient.sol";
 import {ProcessorMessageDecoder} from "./libs/ProcessorMessageDecoder.sol";
 import {IProcessorMessageTypes} from "./interfaces/IProcessorMessageTypes.sol";
 
+/**
+ * @title LiteProcessor
+ * @notice A lightweight processor for handling cross-chain messages with atomic and non-atomic execution
+ * @dev Implements IMessageRecipient for Hyperlane message handling
+ */
 contract LiteProcessor is IMessageRecipient {
-    // Authorization contract will be the sender of the messages on the main domain
-    // It's the hex representation of the address in the main domain
-    bytes32 public authorizationContract;
+    // ============ State Variables ============
 
-    // Add mailbox address which will be the only address that can send messages to the processor
-    address public mailbox;
+    /**
+     * @notice The authorized contract that can send messages from the main domain
+     * @dev Stored as bytes32 to handle cross-chain address representation
+     */
+    bytes32 public immutable authorizationContract;
 
-    // Flag to check if the processor is paused
+    /**
+     * @notice The only address allowed to deliver messages to this processor
+     * @dev This should be the Hyperlane mailbox contract
+     */
+    address public immutable mailbox;
+
+    /**
+     * @notice Indicates if the processor is currently paused
+     */
     bool public paused;
 
+    // ============ Events ============
+
+    /**
+     * @notice Emitted when a message is received by the processor
+     * @param origin The domain ID where the message originated
+     * @param sender The sender's address in bytes32 format
+     * @param body The raw message bytes
+     */
     event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
+
+    /**
+     * @notice Event emitted after a subroutine is processed
+     * @dev This event provides complete information about the execution result,
+     *      allowing external systems to track and respond to subroutine execution outcomes
+     * @param isAtomic Whether this was an atomic subroutine (true) or non-atomic (false)
+     * @param succeeded Overall execution success status
+     *        - For atomic: true if all functions succeeded, false if any failed
+     *        - For non-atomic: true if all executed, false if stopped due to failure
+     * @param executedCount Number of successfully executed functions
+     *        - For atomic: Will be 0 if failed, total count if succeeded
+     *        - For non-atomic: Number of functions that executed before any failure
+     * @param errorData Raw error data from the failed execution
+     *        - Empty bytes if execution succeeded
+     *        - Contains the error data from the first failed function if execution failed
+     *        - Format depends on how the called contract reverted (custom error, string, etc.)
+     */
+    event SubroutineProcessed(bool isAtomic, bool succeeded, uint256 executedCount, bytes errorData);
+
+    /**
+     * @notice Emitted when the processor is paused
+     */
     event ProcessorPaused();
+
+    /**
+     * @notice Emitted when the processor is resumed
+     */
     event ProcessorResumed();
 
-    // Custom errors
+    /**
+     * @notice Emitted when a SendMsgs operation is processed
+     */
+    event ProcessedSendMsgsOperation();
+
+    // ============ Custom Errors ============
+
     error UnauthorizedAccessError();
     error NotAuthorizationContractError();
     error InvalidAddressError();
     error ProcessorPausedError();
     error UnsupportedOperationError();
 
+    // ============ Constructor ============
+
+    /**
+     * @notice Initializes the LiteProcessor
+     * @param _authorizationContract The authorized contract address in bytes32
+     * @param _mailbox The Hyperlane mailbox address
+     */
     constructor(bytes32 _authorizationContract, address _mailbox) {
-        // Check for zero addresses
         if (_mailbox == address(0)) {
             revert InvalidAddressError();
         }
 
-        // Set authorization contract and mailbox
         authorizationContract = _authorizationContract;
         mailbox = _mailbox;
     }
 
-    // Implement the handle function
+    // ============ External Functions ============
+
+    /**
+     * @notice Handles incoming messages from the Hyperlane mailbox
+     * @param _origin The origin domain ID
+     * @param _sender The sender's address in bytes32
+     * @param _body The message payload
+     */
     function handle(uint32 _origin, bytes32 _sender, bytes calldata _body) external payable override {
-        // Only mailbox can call this function
+        // Verify sender is authorized mailbox
         if (msg.sender != mailbox) {
             revert UnauthorizedAccessError();
         }
 
-        // Check that the sender of the message is the authorization contract
+        // Verify message is from authorized contract
         if (_sender != authorizationContract) {
             revert NotAuthorizationContractError();
         }
 
-        IProcessorMessageTypes.ProcessorMessage memory decodedMessage = ProcessorMessageDecoder.decode(_body);
+        // Emit reception before processing
+        emit MessageReceived(_origin, _sender, _body);
 
+        // Decode and route message to appropriate handler
+        IProcessorMessageTypes.ProcessorMessage memory decodedMessage = ProcessorMessageDecoder.decode(_body);
+        _handleMessageType(decodedMessage);
+    }
+
+    // ============ Internal Functions ============
+
+    /**
+     * @notice Routes the message to appropriate handler based on message type
+     * @param decodedMessage The decoded processor message
+     */
+    function _handleMessageType(IProcessorMessageTypes.ProcessorMessage memory decodedMessage) internal {
         if (decodedMessage.messageType == IProcessorMessageTypes.ProcessorMessageType.Pause) {
-            paused = true;
-            emit ProcessorPaused();
+            _handlePause();
         } else if (decodedMessage.messageType == IProcessorMessageTypes.ProcessorMessageType.Resume) {
-            paused = false;
-            emit ProcessorResumed();
+            _handleResume();
         } else if (decodedMessage.messageType == IProcessorMessageTypes.ProcessorMessageType.SendMsgs) {
-            revert UnsupportedOperationError();
+            _handleSendMsgs(decodedMessage);
+            emit ProcessedSendMsgsOperation();
         } else {
             revert UnsupportedOperationError();
         }
+    }
 
-        emit MessageReceived(_origin, _sender, _body);
+    /**
+     * @notice Result of a subroutine execution
+     * @param succeeded Whether all functions executed successfully
+     * @param executedCount Number of successfully executed functions before failure or completion. For atomic subroutines, this will be the total count if all succeeded
+     * @param errorData The error data from the last failed function, empty if all succeeded
+     */
+    struct SubroutineResult {
+        bool succeeded;
+        uint256 executedCount;
+        bytes errorData;
+    }
+
+    /**
+     * @notice Handles pause messages
+     */
+    function _handlePause() internal {
+        paused = true;
+        emit ProcessorPaused();
+    }
+
+    /**
+     * @notice Handles resume messages
+     */
+    function _handleResume() internal {
+        paused = false;
+        emit ProcessorResumed();
+    }
+
+    /**
+     * @notice Processes SendMsgs operations based on subroutine type
+     * @dev Decodes and routes to appropriate subroutine handler
+     * @param decodedMessage The decoded processor message
+     */
+    function _handleSendMsgs(IProcessorMessageTypes.ProcessorMessage memory decodedMessage) internal {
+        // Check if the processor is paused
+        if (paused) {
+            revert ProcessorPausedError();
+        }
+
+        IProcessorMessageTypes.SendMsgs memory sendMsgs =
+            abi.decode(decodedMessage.message, (IProcessorMessageTypes.SendMsgs));
+
+        if (sendMsgs.subroutine.subroutineType == IProcessorMessageTypes.SubroutineType.Atomic) {
+            SubroutineResult memory result = _handleAtomicSubroutine(sendMsgs);
+            emit SubroutineProcessed(true, result.succeeded, result.executedCount, result.errorData);
+        } else {
+            SubroutineResult memory result = _handleNonAtomicSubroutine(sendMsgs);
+            emit SubroutineProcessed(false, result.succeeded, result.executedCount, result.errorData);
+        }
+    }
+
+    /**
+     * @notice Executes all functions in an atomic subroutine
+     * @dev Either all functions succeed or no state changes are committed
+     * @param sendMsgs The SendMsgs operation containing the atomic subroutine
+     * @return result Contains execution success status, executed function count (all or 0), and error data if any failed
+     */
+    function _handleAtomicSubroutine(IProcessorMessageTypes.SendMsgs memory sendMsgs)
+        internal
+        returns (SubroutineResult memory)
+    {
+        try this._executeAtomicSubroutine(sendMsgs) returns (uint256 totalExecuted) {
+            return SubroutineResult({succeeded: true, executedCount: totalExecuted, errorData: ""});
+        } catch (bytes memory err) {
+            return SubroutineResult({succeeded: false, executedCount: 0, errorData: err});
+        }
+    }
+
+    /**
+     * @notice Executes functions in a non-atomic subroutine until one fails
+     * @dev Processes functions one by one, stopping at first failure
+     * @param sendMsgs The SendMsgs operation containing the non-atomic subroutine
+     * @return result Contains execution count and error data if any failed
+     */
+    function _handleNonAtomicSubroutine(IProcessorMessageTypes.SendMsgs memory sendMsgs)
+        internal
+        returns (SubroutineResult memory)
+    {
+        IProcessorMessageTypes.NonAtomicSubroutine memory nonAtomicSubroutine =
+            abi.decode(sendMsgs.subroutine.subroutine, (IProcessorMessageTypes.NonAtomicSubroutine));
+
+        uint256 executedCount = 0;
+        bytes memory errorData;
+        bool succeeded = true;
+
+        // Execute each function until one fails
+        for (uint256 i = 0; i < nonAtomicSubroutine.functions.length; i++) {
+            (bool success, bytes memory err) =
+                nonAtomicSubroutine.functions[i].contractAddress.call(sendMsgs.messages[i]);
+
+            if (success) {
+                executedCount++;
+            } else {
+                succeeded = false;
+                errorData = err;
+                break;
+            }
+        }
+
+        return SubroutineResult({succeeded: succeeded, executedCount: executedCount, errorData: errorData});
+    }
+
+    /**
+     * @notice External function that executes the atomic subroutine and reverts if any fail
+     * @dev External to allow try-catch pattern for atomicity
+     * @param sendMsgs The SendMsgs operation containing the atomic subroutine
+     * @return totalExecuted Number of functions executed
+     */
+    function _executeAtomicSubroutine(IProcessorMessageTypes.SendMsgs memory sendMsgs) external returns (uint256) {
+        // Only allow calls from the contract itself, need this extra protection to prevent external access
+        // This is necessary because the function is external and can be called by anyone
+        // It's external to allow try-catch pattern for atomicity
+        if (msg.sender != address(this)) {
+            revert UnauthorizedAccessError();
+        }
+
+        IProcessorMessageTypes.AtomicSubroutine memory atomicSubroutine =
+            abi.decode(sendMsgs.subroutine.subroutine, (IProcessorMessageTypes.AtomicSubroutine));
+
+        for (uint256 i = 0; i < atomicSubroutine.functions.length; i++) {
+            /**
+             * @notice Executes a contract call and forwards any error if the call fails
+             * @dev When a contract call fails, Solidity captures the revert data (error)
+             *      in a bytes array with a 32-byte length prefix. To correctly propagate
+             *      the original error, we need to:
+             *      1. Capture both success status and error data from the call
+             *      2. If call failed, use assembly to revert with the original error:
+             *         - Skip the 32-byte length prefix in memory (add(err, 32))
+             *         - Use the length value at the start of err (mload(err))
+             *         - Revert with exactly the original error data
+             */
+            (bool success, bytes memory err) = atomicSubroutine.functions[i].contractAddress.call(sendMsgs.messages[i]);
+            if (!success) {
+                // Forward the original error data
+                assembly {
+                    revert(add(err, 32), mload(err))
+                }
+            }
+        }
+
+        // Return the total number of executed functions
+        return atomicSubroutine.functions.length;
     }
 }

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -33,7 +33,7 @@ contract Processor is IMessageRecipient, ProcessorBase {
     }
 
     // Implement the handle function
-    function handle(uint32 _origin, bytes32 _sender, bytes calldata _body) external payable override {
+    function handle(uint32 _origin, bytes32 _sender, bytes calldata /*_body*/) external payable override {
         // Only mailbox can call this function
         if (msg.sender != address(mailbox)) {
             revert ProcessorErrors.UnauthorizedAccess();
@@ -48,7 +48,5 @@ contract Processor is IMessageRecipient, ProcessorBase {
         if (_sender != authorizationContract) {
             revert ProcessorErrors.NotAuthorizationContract();
         }
-
-        emit ProcessorEvents.MessageReceived(_origin, _sender, _body);
     }
 }

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -39,6 +39,11 @@ contract Processor is IMessageRecipient, ProcessorBase {
             revert ProcessorErrors.UnauthorizedAccess();
         }
 
+        // Verify origin is the expected domain
+        if (_origin != originDomain) {
+            revert ProcessorErrors.InvalidOriginDomain();
+        }
+
         // Check that the sender of the message is the authorization contract
         if (_sender != authorizationContract) {
             revert ProcessorErrors.NotAuthorizationContract();

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -28,15 +28,15 @@ contract Processor is IMessageRecipient {
     event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
 
     // Custom errors
-    error UnauthorizedAccess();
-    error NotAuthorizationContract();
-    error InvalidAddress();
-    error ProcessorPaused();
+    error UnauthorizedAccessError();
+    error NotAuthorizationContractError();
+    error InvalidAddressError();
+    error ProcessorPausedError();
 
     constructor(bytes32 _authorizationContract, address _mailbox) {
         // Check for zero addresses
         if (_mailbox == address(0)) {
-            revert InvalidAddress();
+            revert InvalidAddressError();
         }
 
         // Set authorization contract and mailbox
@@ -52,12 +52,12 @@ contract Processor is IMessageRecipient {
     function handle(uint32 _origin, bytes32 _sender, bytes calldata _body) external payable override {
         // Only mailbox can call this function
         if (msg.sender != mailbox) {
-            revert UnauthorizedAccess();
+            revert UnauthorizedAccessError();
         }
 
         // Check that the sender of the message is the authorization contract
         if (_sender != authorizationContract) {
-            revert NotAuthorizationContract();
+            revert NotAuthorizationContractError();
         }
 
         emit MessageReceived(_origin, _sender, _body);

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -19,14 +19,18 @@ contract Processor is IMessageRecipient, ProcessorBase {
     /**
      * @notice Initializes the LiteProcessor contract
      * @dev The constructor initializes the LiteProcessor by calling the base contract constructor
-     *      and passing the necessary parameters for the authorized contract and mailbox.
-     * @param _authorizationContract The address of the authorized contract, represented as a bytes32 value.
+     *      and passing the necessary parameters for the authorization contract and mailbox.
+     * @param _authorizationContract The address of the authorization contract, represented as a bytes32 value.
      * @param _mailbox The address of the Hyperlane mailbox contract.
      * @param _originDomain The origin domain ID for sending the callbacks via Hyperlane.
+     * @param _authorizedAddresses The list of authorized addresses that can call the processor directly.
      */
-    constructor(bytes32 _authorizationContract, address _mailbox, uint32 _originDomain)
-        ProcessorBase(_authorizationContract, _mailbox, _originDomain)
-    {
+    constructor(
+        bytes32 _authorizationContract,
+        address _mailbox,
+        uint32 _originDomain,
+        address[] memory _authorizedAddresses
+    ) ProcessorBase(_authorizationContract, _mailbox, _originDomain, _authorizedAddresses) {
         // Initialize both queues with unique namespaces
         mediumPriorityQueue = QueueMap.createQueue("MED");
         highPriorityQueue = QueueMap.createQueue("HIGH");
@@ -48,5 +52,13 @@ contract Processor is IMessageRecipient, ProcessorBase {
         if (_sender != authorizationContract) {
             revert ProcessorErrors.NotAuthorizationContract();
         }
+    }
+
+    /**
+     * @notice Handles incoming messages from an authorized addresses
+     * @param _body The message payload
+     */
+    function execute(bytes calldata _body) external payable override {
+        // TODO: Implement the execute function
     }
 }

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -26,7 +26,11 @@ contract Processor is IMessageRecipient, ProcessorBase {
      */
     constructor(bytes32 _authorizationContract, address _mailbox, uint32 _originDomain)
         ProcessorBase(_authorizationContract, _mailbox, _originDomain)
-    {}
+    {
+        // Initialize both queues with unique namespaces
+        mediumPriorityQueue = QueueMap.createQueue("MED");
+        highPriorityQueue = QueueMap.createQueue("HIGH");
+    }
 
     // Implement the handle function
     function handle(uint32 _origin, bytes32 _sender, bytes calldata _body) external payable override {

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -33,7 +33,7 @@ contract Processor is IMessageRecipient, ProcessorBase {
     }
 
     // Implement the handle function
-    function handle(uint32 _origin, bytes32 _sender, bytes calldata /*_body*/) external payable override {
+    function handle(uint32 _origin, bytes32 _sender, bytes calldata /*_body*/ ) external payable override {
         // Only mailbox can call this function
         if (msg.sender != address(mailbox)) {
             revert ProcessorErrors.UnauthorizedAccess();

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -35,6 +35,7 @@ abstract contract ProcessorBase {
      * @notice Initializes the state variables
      * @param _authorizationContract The authorized contract address in bytes32
      * @param _mailbox The Hyperlane mailbox address
+     * @param _originDomain The origin domain ID for sending callbacks
      */
     constructor(bytes32 _authorizationContract, address _mailbox, uint32 _originDomain) {
         if (_mailbox == address(0)) {

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -217,6 +217,5 @@ abstract contract ProcessorBase {
     function _sendCallback(bytes memory callback) internal {
         // Send the callback to the mailbox
         mailbox.dispatch(originDomain, authorizationContract, callback);
-        emit ProcessorEvents.CallbackSent();
     }
 }

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -217,6 +217,6 @@ abstract contract ProcessorBase {
         // Send the encoded callback to the mailbox
         mailbox.dispatch(originDomain, authorizationContract, encodedCallback);
         // Emit an event to track the callback transmission
-        emit ProcessorEvents.CallbackSent(callback.executionId, callback.executionResult);
+        emit ProcessorEvents.CallbackSent(callback.executionId, callback.executionResult, callback.executedCount);
     }
 }

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {ProcessorErrors} from "./libs/ProcessorErrors.sol";
+import {IProcessorMessageTypes} from "./interfaces/IProcessorMessageTypes.sol";
+import {IProcessor} from "./interfaces/IProcessor.sol";
+import {ProcessorEvents} from "./libs/ProcessorEvents.sol";
+
+abstract contract ProcessorBase {
+    /**
+     * @notice The authorized contract that can send messages from the main domain
+     * @dev Stored as bytes32 to handle cross-chain address representation
+     */
+    bytes32 public immutable authorizationContract;
+
+    /**
+     * @notice The only address allowed to deliver messages to this processor
+     * @dev This should be the Hyperlane mailbox contract
+     */
+    address public immutable mailbox;
+
+    /**
+     * @notice Indicates if the processor is currently paused
+     */
+    bool public paused;
+
+    /**
+     * @notice Initializes the state variables
+     * @param _authorizationContract The authorized contract address in bytes32
+     * @param _mailbox The Hyperlane mailbox address
+     */
+    constructor(bytes32 _authorizationContract, address _mailbox) {
+        if (_mailbox == address(0)) {
+            revert ProcessorErrors.InvalidAddressError();
+        }
+        authorizationContract = _authorizationContract;
+        mailbox = _mailbox;
+    }
+
+    /**
+     * @notice Handles pause messages
+     */
+    function _handlePause() internal {
+        paused = true;
+        emit ProcessorEvents.ProcessorPaused();
+    }
+
+    /**
+     * @notice Handles resume messages
+     */
+    function _handleResume() internal {
+        paused = false;
+        emit ProcessorEvents.ProcessorResumed();
+    }
+
+    /**
+     * @notice Executes all functions in an atomic subroutine
+     * @dev Either all functions succeed or no state changes are committed
+     * @param atomicSubroutine The atomic subroutine to execute
+     * @param messages The messages to be sent for each contract call
+     * @return result Contains execution success status, executed function count (all or 0), and error data if any failed
+     */
+    function _handleAtomicSubroutine(
+        IProcessorMessageTypes.AtomicSubroutine memory atomicSubroutine,
+        bytes[] memory messages
+    ) internal returns (IProcessor.SubroutineResult memory) {
+        try this._executeAtomicSubroutine(atomicSubroutine, messages) returns (uint256 totalExecuted) {
+            return IProcessor.SubroutineResult({succeeded: true, executedCount: totalExecuted, errorData: ""});
+        } catch (bytes memory err) {
+            return IProcessor.SubroutineResult({succeeded: false, executedCount: 0, errorData: err});
+        }
+    }
+
+    /**
+     * @notice Executes functions in a non-atomic subroutine until one fails
+     * @dev Processes functions one by one, stopping at first failure
+     * @param nonAtomicSubroutine The non-atomic subroutine to execute
+     * @param messages The messages to be sent for each contract call
+     * @return result Contains execution count and error data if any failed
+     */
+    function _handleNonAtomicSubroutine(
+        IProcessorMessageTypes.NonAtomicSubroutine memory nonAtomicSubroutine,
+        bytes[] memory messages
+    ) internal returns (IProcessor.SubroutineResult memory) {
+        uint256 executedCount = 0;
+        bytes memory errorData;
+        bool succeeded = true;
+
+        // Execute each function until one fails
+        for (uint256 i = 0; i < nonAtomicSubroutine.functions.length; i++) {
+            (bool success, bytes memory err) = nonAtomicSubroutine.functions[i].contractAddress.call(messages[i]);
+
+            if (success) {
+                executedCount++;
+            } else {
+                succeeded = false;
+                errorData = err;
+                break;
+            }
+        }
+
+        return IProcessor.SubroutineResult({succeeded: succeeded, executedCount: executedCount, errorData: errorData});
+    }
+
+    /**
+     * @notice External function that executes the atomic subroutine and reverts if any fail
+     * @dev External to allow try-catch pattern for atomicity
+     * @param atomicSubroutine The atomic subroutine to execute
+     * @param messages The messages to be sent for each contract call
+     * @return totalExecuted Number of functions executed
+     */
+    function _executeAtomicSubroutine(
+        IProcessorMessageTypes.AtomicSubroutine memory atomicSubroutine,
+        bytes[] memory messages
+    ) external returns (uint256) {
+        // Only allow calls from the contract itself, need this extra protection to prevent external access
+        // This is necessary because the function is external and can be called by anyone
+        // It's external to allow try-catch pattern for atomicity
+        if (msg.sender != address(this)) {
+            revert ProcessorErrors.UnauthorizedAccessError();
+        }
+
+        for (uint256 i = 0; i < atomicSubroutine.functions.length; i++) {
+            /**
+             * @notice Executes a contract call and forwards any error if the call fails
+             * @dev When a contract call fails, Solidity captures the revert data (error)
+             *      in a bytes array with a 32-byte length prefix. To correctly propagate
+             *      the original error, we need to:
+             *      1. Capture both success status and error data from the call
+             *      2. If call failed, use assembly to revert with the original error:
+             *         - Skip the 32-byte length prefix in memory (add(err, 32))
+             *         - Use the length value at the start of err (mload(err))
+             *         - Revert with exactly the original error data
+             */
+            (bool success, bytes memory err) = atomicSubroutine.functions[i].contractAddress.call(messages[i]);
+            if (!success) {
+                // Forward the original error data
+                assembly {
+                    revert(add(err, 32), mload(err))
+                }
+            }
+        }
+
+        // Return the total number of executed functions
+        return atomicSubroutine.functions.length;
+    }
+}

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -177,7 +177,6 @@ abstract contract ProcessorBase {
      */
     function _buildCallback(uint64 executionId, IProcessor.SubroutineResult memory subroutineResult)
         internal
-        pure
         returns (bytes memory)
     {
         // Determine the execution result based on the following rules:
@@ -200,6 +199,9 @@ abstract contract ProcessorBase {
             executedCount: subroutineResult.executedCount,
             data: subroutineResult.errorData
         });
+
+        // Emit callback event to keep track of execution results
+        emit ProcessorEvents.CallbackBuilt(executionId, executionResult);
 
         // Encode the entire callback structure into bytes for transmission
         // Using abi.encode ensures proper encoding of all struct members

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -38,7 +38,7 @@ abstract contract ProcessorBase {
      */
     constructor(bytes32 _authorizationContract, address _mailbox, uint32 _originDomain) {
         if (_mailbox == address(0)) {
-            revert ProcessorErrors.InvalidAddressError();
+            revert ProcessorErrors.InvalidAddress();
         }
         authorizationContract = _authorizationContract;
         mailbox = IMailbox(_mailbox);
@@ -125,7 +125,7 @@ abstract contract ProcessorBase {
         // This is necessary because the function is external and can be called by anyone
         // It's external to allow try-catch pattern for atomicity
         if (msg.sender != address(this)) {
-            revert ProcessorErrors.UnauthorizedAccessError();
+            revert ProcessorErrors.UnauthorizedAccess();
         }
 
         for (uint256 i = 0; i < atomicSubroutine.functions.length; i++) {

--- a/solidity/src/processor/interfaces/ICallback.sol
+++ b/solidity/src/processor/interfaces/ICallback.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 /// @title Callback Interface
 /// @notice Interface for handling processor callbacks
-/// @dev Must be implemented by contracts receiving callbacks
+/// @dev Must be implemented by contracts if they want to handle processor callbacks
 interface ICallback {
     /// @notice Handles incoming callback data from the processor
     /// @param callbackData ABI encoded callback parameters

--- a/solidity/src/processor/interfaces/ICallback.sol
+++ b/solidity/src/processor/interfaces/ICallback.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+/// @title Callback Interface
+/// @notice Interface for handling processor callbacks
+/// @dev Must be implemented by contracts receiving callbacks
+interface ICallback {
+    /// @notice Handles incoming callback data from the processor
+    /// @param callbackData ABI encoded callback parameters
+    /// @dev Validate and process callback data appropriately
+    function handleCallback(bytes memory callbackData) external;
+}

--- a/solidity/src/processor/interfaces/IProcessor.sol
+++ b/solidity/src/processor/interfaces/IProcessor.sol
@@ -13,4 +13,47 @@ interface IProcessor {
         uint256 executedCount;
         bytes errorData;
     }
+
+    /**
+     * @notice Represents the callback after a subroutine execution
+     * @param executionResult The outcome of the execution (Success, Rejected, or PartiallyExecuted)
+     * @param data Additional data related to the callback execution, if any
+     */
+    struct Callback {
+        ExecutionResult executionResult;
+        bytes data;
+    }
+
+    /**
+     * @notice Enum representing the possible results of a subroutine execution
+     * @dev Used in Callback struct to indicate the overall status of the execution
+     * @param Success Indicates that all functions were executed
+     * @param Rejected Indicates that nothing was executed
+     * @param PartiallyExecuted Indicates that the execution was partially successful (some functions executed, only for non-atomic subroutines)
+     */
+    enum ExecutionResult {
+        Success,
+        Rejected,
+        PartiallyExecuted
+    }
+
+    /**
+     * @notice Represents the details of a rejected execution result
+     * @dev This struct is used to store the error data in case of rejection during subroutine execution
+     * @param errorData Contains the raw error data from the failed execution
+     */
+    struct RejectedResult {
+        bytes errorData;
+    }
+
+    /**
+     * @notice Represents the details of a partially executed result (only for non-atomic subroutines)
+     * @dev This struct stores information about the partial success of the execution
+     * @param executedCount The number of functions that were executed successfully before failure
+     * @param errorData Contains the error data from the first failed function
+     */
+    struct PartiallyExecutedResult {
+        uint256 executedCount;
+        bytes errorData;
+    }
 }

--- a/solidity/src/processor/interfaces/IProcessor.sol
+++ b/solidity/src/processor/interfaces/IProcessor.sol
@@ -16,11 +16,14 @@ interface IProcessor {
 
     /**
      * @notice Represents the callback after a subroutine execution
+     * @param executionId The Execution ID of the message(s) that triggered the callback
      * @param executionResult The outcome of the execution (Success, Rejected, or PartiallyExecuted)
      * @param data Additional data related to the callback execution, if any
      */
     struct Callback {
+        uint64 executionId;
         ExecutionResult executionResult;
+        uint256 executedCount;
         bytes data;
     }
 

--- a/solidity/src/processor/interfaces/IProcessor.sol
+++ b/solidity/src/processor/interfaces/IProcessor.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+interface IProcessor {
+    /**
+     * @notice Result of a subroutine execution
+     * @param succeeded Whether all functions executed successfully
+     * @param executedCount Number of successfully executed functions before failure or completion. For atomic subroutines, this will be the total count if all succeeded
+     * @param errorData The error data from the last failed function, empty if all succeeded
+     */
+    struct SubroutineResult {
+        bool succeeded;
+        uint256 executedCount;
+        bytes errorData;
+    }
+}

--- a/solidity/src/processor/libs/ProcessorErrors.sol
+++ b/solidity/src/processor/libs/ProcessorErrors.sol
@@ -7,4 +7,5 @@ library ProcessorErrors {
     error InvalidAddress();
     error ProcessorPaused();
     error UnsupportedOperation();
+    error InvalidOriginDomain();
 }

--- a/solidity/src/processor/libs/ProcessorErrors.sol
+++ b/solidity/src/processor/libs/ProcessorErrors.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+library ProcessorErrors {
+    error UnauthorizedAccessError();
+    error NotAuthorizationContractError();
+    error InvalidAddressError();
+    error ProcessorPausedError();
+    error UnsupportedOperationError();
+}

--- a/solidity/src/processor/libs/ProcessorErrors.sol
+++ b/solidity/src/processor/libs/ProcessorErrors.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.28;
 
 library ProcessorErrors {
-    error UnauthorizedAccessError();
-    error NotAuthorizationContractError();
-    error InvalidAddressError();
-    error ProcessorPausedError();
-    error UnsupportedOperationError();
+    error UnauthorizedAccess();
+    error NotAuthorizationContract();
+    error InvalidAddress();
+    error ProcessorPaused();
+    error UnsupportedOperation();
 }

--- a/solidity/src/processor/libs/ProcessorEvents.sol
+++ b/solidity/src/processor/libs/ProcessorEvents.sol
@@ -18,6 +18,7 @@ library ProcessorEvents {
      * @notice Emitted when a callback is sent to the hyperlane mailbox
      * @param executionId The Execution ID of the message(s) that triggered the callback
      * @param result The outcome of the execution
+     * @param executedCount The number of functions that were executed successfully before failure or completion
      */
-    event CallbackSent(uint256 indexed executionId, IProcessor.ExecutionResult result);
+    event CallbackSent(uint64 indexed executionId, IProcessor.ExecutionResult result, uint256 executedCount);
 }

--- a/solidity/src/processor/libs/ProcessorEvents.sol
+++ b/solidity/src/processor/libs/ProcessorEvents.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+library ProcessorEvents {
+    /**
+     * @notice Emitted when a message is received by the processor
+     * @param origin The domain ID where the message originated
+     * @param sender The sender's address in bytes32 format
+     * @param body The raw message bytes
+     */
+    event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
+
+    /**
+     * @notice Event emitted after a subroutine is processed
+     * @dev This event provides complete information about the execution result,
+     *      allowing external systems to track and respond to subroutine execution outcomes
+     * @param isAtomic Whether this was an atomic subroutine (true) or non-atomic (false)
+     * @param succeeded Overall execution success status
+     *        - For atomic: true if all functions succeeded, false if any failed
+     *        - For non-atomic: true if all executed, false if stopped due to failure
+     * @param executedCount Number of successfully executed functions
+     *        - For atomic: Will be 0 if failed, total count if succeeded
+     *        - For non-atomic: Number of functions that executed before any failure
+     * @param errorData Raw error data from the failed execution
+     *        - Empty bytes if execution succeeded
+     *        - Contains the error data from the first failed function if execution failed
+     *        - Format depends on how the called contract reverted (custom error, string, etc.)
+     */
+    event SubroutineProcessed(bool isAtomic, bool succeeded, uint256 executedCount, bytes errorData);
+
+    /**
+     * @notice Emitted when the processor is paused
+     */
+    event ProcessorPaused();
+
+    /**
+     * @notice Emitted when the processor is resumed
+     */
+    event ProcessorResumed();
+
+    /**
+     * @notice Emitted when a SendMsgs operation is processed
+     */
+    event ProcessedSendMsgsOperation();
+}

--- a/solidity/src/processor/libs/ProcessorEvents.sol
+++ b/solidity/src/processor/libs/ProcessorEvents.sol
@@ -42,4 +42,9 @@ library ProcessorEvents {
      * @notice Emitted when a SendMsgs operation is processed
      */
     event ProcessedSendMsgsOperation();
+
+    /**
+     * @notice Emitted when a callback is sent to the hyperlane mailbox
+     */
+    event CallbackSent();
 }

--- a/solidity/src/processor/libs/ProcessorEvents.sol
+++ b/solidity/src/processor/libs/ProcessorEvents.sol
@@ -5,14 +5,6 @@ import {IProcessor} from "../interfaces/IProcessor.sol";
 
 library ProcessorEvents {
     /**
-     * @notice Emitted when a message is received by the processor
-     * @param origin The domain ID where the message originated
-     * @param sender The sender's address in bytes32 format
-     * @param body The raw message bytes
-     */
-    event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
-
-    /**
      * @notice Emitted when the processor is paused
      */
     event ProcessorPaused();

--- a/solidity/src/processor/libs/ProcessorEvents.sol
+++ b/solidity/src/processor/libs/ProcessorEvents.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
+import {IProcessor} from "../interfaces/IProcessor.sol";
+
 library ProcessorEvents {
     /**
      * @notice Emitted when a message is received by the processor
@@ -9,24 +11,6 @@ library ProcessorEvents {
      * @param body The raw message bytes
      */
     event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
-
-    /**
-     * @notice Event emitted after a subroutine is processed
-     * @dev This event provides complete information about the execution result,
-     *      allowing external systems to track and respond to subroutine execution outcomes
-     * @param isAtomic Whether this was an atomic subroutine (true) or non-atomic (false)
-     * @param succeeded Overall execution success status
-     *        - For atomic: true if all functions succeeded, false if any failed
-     *        - For non-atomic: true if all executed, false if stopped due to failure
-     * @param executedCount Number of successfully executed functions
-     *        - For atomic: Will be 0 if failed, total count if succeeded
-     *        - For non-atomic: Number of functions that executed before any failure
-     * @param errorData Raw error data from the failed execution
-     *        - Empty bytes if execution succeeded
-     *        - Contains the error data from the first failed function if execution failed
-     *        - Format depends on how the called contract reverted (custom error, string, etc.)
-     */
-    event SubroutineProcessed(bool isAtomic, bool succeeded, uint256 executedCount, bytes errorData);
 
     /**
      * @notice Emitted when the processor is paused
@@ -39,12 +23,9 @@ library ProcessorEvents {
     event ProcessorResumed();
 
     /**
-     * @notice Emitted when a SendMsgs operation is processed
+     * @notice Emitted when a callback is built for the hyperlane mailbox
+     * @param executionId The Execution ID of the message(s) that triggered the callback
+     * @param result The outcome of the execution
      */
-    event ProcessedSendMsgsOperation();
-
-    /**
-     * @notice Emitted when a callback is sent to the hyperlane mailbox
-     */
-    event CallbackSent();
+    event CallbackBuilt(uint256 indexed executionId, IProcessor.ExecutionResult result);
 }

--- a/solidity/src/processor/libs/ProcessorEvents.sol
+++ b/solidity/src/processor/libs/ProcessorEvents.sol
@@ -23,9 +23,9 @@ library ProcessorEvents {
     event ProcessorResumed();
 
     /**
-     * @notice Emitted when a callback is built for the hyperlane mailbox
+     * @notice Emitted when a callback is sent to the hyperlane mailbox
      * @param executionId The Execution ID of the message(s) that triggered the callback
      * @param result The outcome of the execution
      */
-    event CallbackBuilt(uint256 indexed executionId, IProcessor.ExecutionResult result);
+    event CallbackSent(uint256 indexed executionId, IProcessor.ExecutionResult result);
 }

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -37,7 +37,7 @@ contract LiteProcessorTest is Test {
 
     /// @notice Test that constructor reverts when given zero address for mailbox
     function test_Constructor_RevertOnZeroMailbox() public {
-        vm.expectRevert(ProcessorErrors.InvalidAddressError.selector);
+        vm.expectRevert(ProcessorErrors.InvalidAddress.selector);
         new LiteProcessor(AUTH_CONTRACT, address(0), ORIGIN_DOMAIN);
     }
 
@@ -45,7 +45,7 @@ contract LiteProcessorTest is Test {
     function test_Handle_RevertOnUnauthorizedSender() public {
         bytes memory message = _encodePauseMessage();
 
-        vm.expectRevert(ProcessorErrors.UnauthorizedAccessError.selector);
+        vm.expectRevert(ProcessorErrors.UnauthorizedAccess.selector);
         processor.handle(1, AUTH_CONTRACT, message);
     }
 
@@ -55,7 +55,7 @@ contract LiteProcessorTest is Test {
         bytes32 unauthorizedSender = bytes32(uint256(1));
 
         vm.prank(MAILBOX);
-        vm.expectRevert(ProcessorErrors.NotAuthorizationContractError.selector);
+        vm.expectRevert(ProcessorErrors.NotAuthorizationContract.selector);
         processor.handle(1, unauthorizedSender, message);
     }
 
@@ -101,7 +101,7 @@ contract LiteProcessorTest is Test {
         bytes memory message = _encodeInsertMsgsMessage();
 
         vm.prank(MAILBOX);
-        vm.expectRevert(ProcessorErrors.UnsupportedOperationError.selector);
+        vm.expectRevert(ProcessorErrors.UnsupportedOperation.selector);
         processor.handle(1, AUTH_CONTRACT, message);
     }
 

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -29,20 +29,20 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test that the constructor properly initializes state variables
-    function test_Constructor() public view {
+    function testConstructor() public view {
         assertEq(address(processor.mailbox()), MAILBOX);
         assertEq(processor.authorizationContract(), AUTH_CONTRACT);
         assertFalse(processor.paused());
     }
 
     /// @notice Test that constructor reverts when given zero address for mailbox
-    function test_Constructor_RevertOnZeroMailbox() public {
+    function testConstructorRevertOnZeroMailbox() public {
         vm.expectRevert(ProcessorErrors.InvalidAddress.selector);
         new LiteProcessor(AUTH_CONTRACT, address(0), ORIGIN_DOMAIN);
     }
 
     /// @notice Test that handle() reverts when called by non-mailbox address
-    function test_Handle_RevertOnUnauthorizedSender() public {
+    function testHandleRevertOnUnauthorizedSender() public {
         bytes memory message = _encodePauseMessage();
 
         vm.expectRevert(ProcessorErrors.UnauthorizedAccess.selector);
@@ -50,7 +50,7 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test that handle() reverts when receiving a message from an invalid origin domain
-    function test_Handle_RevertOnInvalidOriginDomain() public {
+    function testHandleRevertOnInvalidOriginDomain() public {
         bytes memory message = _encodePauseMessage();
 
         vm.expectRevert(ProcessorErrors.UnauthorizedAccess.selector);
@@ -58,7 +58,7 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test that handle() reverts when message is from unauthorized sender
-    function test_Handle_RevertOnUnauthorizedContract() public {
+    function testHandleRevertOnUnauthorizedContract() public {
         bytes memory message = _encodePauseMessage();
         bytes32 unauthorizedSender = bytes32(uint256(1));
 
@@ -68,14 +68,11 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test successful pause message handling and event emission
-    function test_Handle_PauseMessage() public {
+    function testHandlePauseMessage() public {
         bytes memory message = _encodePauseMessage();
 
         vm.prank(MAILBOX);
-        // Check for both MessageReceived and ProcessorPaused events
-        vm.expectEmit(true, true, false, true);
-        emit ProcessorEvents.MessageReceived(ORIGIN_DOMAIN, AUTH_CONTRACT, message);
-        vm.expectEmit(true, true, false, true);
+        // Check for ProcessorPaused event
         emit ProcessorEvents.ProcessorPaused();
 
         processor.handle(ORIGIN_DOMAIN, AUTH_CONTRACT, message);
@@ -83,7 +80,7 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test successful resume message handling and event emission
-    function test_Handle_ResumeMessage() public {
+    function testHandleResumeMessage() public {
         // First pause the processor to test resume functionality
         bytes memory pauseMessage = _encodePauseMessage();
         vm.prank(MAILBOX);
@@ -94,10 +91,7 @@ contract LiteProcessorTest is Test {
         bytes memory resumeMessage = _encodeResumeMessage();
 
         vm.prank(MAILBOX);
-        // Check for both MessageReceived and ProcessorResumed events
-        vm.expectEmit(true, true, false, true);
-        emit ProcessorEvents.MessageReceived(ORIGIN_DOMAIN, AUTH_CONTRACT, resumeMessage);
-        vm.expectEmit(true, true, false, true);
+        // Check for ProcessorResumed event
         emit ProcessorEvents.ProcessorResumed();
 
         processor.handle(1, AUTH_CONTRACT, resumeMessage);
@@ -105,7 +99,7 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test that unsupported operations revert as expected
-    function test_Handle_RevertOnUnsupportedOperation() public {
+    function testHandleRevertOnUnsupportedOperation() public {
         bytes memory message = _encodeInsertMsgsMessage();
 
         vm.prank(MAILBOX);

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -60,7 +60,7 @@ contract LiteProcessorTest is Test {
     /// @notice Test that handle() reverts when message is from unauthorized sender
     function test_Handle_RevertOnUnauthorizedContract() public {
         bytes memory message = _encodePauseMessage();
-        bytes32 unauthorizedSender = bytes32(uint256(ORIGIN_DOMAIN));
+        bytes32 unauthorizedSender = bytes32(uint256(1));
 
         vm.prank(MAILBOX);
         vm.expectRevert(ProcessorErrors.NotAuthorizationContract.selector);

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+/**
+ * @title LiteProcessorTest
+ * @notice Test suite for the LiteProcessor contract
+ * @dev Tests contract deployment, authorization checks, and message handling functionality
+ */
+import {Test} from "forge-std/src/Test.sol";
+import {LiteProcessor} from "../src/processor/LiteProcessor.sol";
+import {IProcessorMessageTypes} from "../src/processor/interfaces/IProcessorMessageTypes.sol";
+import {ProcessorMessageDecoder} from "../src/processor/libs/ProcessorMessageDecoder.sol";
+
+contract LiteProcessorTest is Test {
+    // Main contract instance to be tested
+    LiteProcessor public processor;
+    // Mock mailbox address that will be authorized to call the processor
+    address public constant MAILBOX = address(0x1234);
+    // Mock authorization contract address converted to bytes32 for cross-chain representation
+    bytes32 public constant AUTH_CONTRACT =
+        bytes32(uint256(uint160(address(0x5678))));
+
+    // Events that we expect the contract to emit
+    event MessageReceived(
+        uint32 indexed origin,
+        bytes32 indexed sender,
+        bytes body
+    );
+    event ProcessorPaused();
+    event ProcessorResumed();
+
+    /// @notice Deploy a fresh instance of the processor before each test
+    function setUp() public {
+        processor = new LiteProcessor(AUTH_CONTRACT, MAILBOX);
+    }
+
+    /// @notice Test that the constructor properly initializes state variables
+    function test_Constructor() view public {
+        assertEq(address(processor.mailbox()), MAILBOX);
+        assertEq(processor.authorizationContract(), AUTH_CONTRACT);
+        assertFalse(processor.paused());
+    }
+
+    /// @notice Test that constructor reverts when given zero address for mailbox
+    function test_Constructor_RevertOnZeroMailbox() public {
+        vm.expectRevert(LiteProcessor.InvalidAddressError.selector);
+        new LiteProcessor(AUTH_CONTRACT, address(0));
+    }
+
+    /// @notice Test that handle() reverts when called by non-mailbox address
+    function test_Handle_RevertOnUnauthorizedSender() public {
+        bytes memory message = _encodePauseMessage();
+
+        vm.expectRevert(LiteProcessor.UnauthorizedAccessError.selector);
+        processor.handle(1, AUTH_CONTRACT, message);
+    }
+
+    /// @notice Test that handle() reverts when message is from unauthorized sender
+    function test_Handle_RevertOnUnauthorizedContract() public {
+        bytes memory message = _encodePauseMessage();
+        bytes32 unauthorizedSender = bytes32(uint256(1));
+
+        vm.prank(MAILBOX);
+        vm.expectRevert(LiteProcessor.NotAuthorizationContractError.selector);
+        processor.handle(1, unauthorizedSender, message);
+    }
+
+    /// @notice Test successful pause message handling and event emission
+    function test_Handle_PauseMessage() public {
+        bytes memory message = _encodePauseMessage();
+
+        vm.prank(MAILBOX);
+        // Check for both ProcessorPaused and MessageReceived events
+        vm.expectEmit(true, true, false, true);
+        emit ProcessorPaused();
+        vm.expectEmit(true, true, false, true);
+        emit MessageReceived(1, AUTH_CONTRACT, message);
+
+        processor.handle(1, AUTH_CONTRACT, message);
+        assertTrue(processor.paused());
+    }
+
+    /// @notice Test successful resume message handling and event emission
+    function test_Handle_ResumeMessage() public {
+        // First pause the processor to test resume functionality
+        bytes memory pauseMessage = _encodePauseMessage();
+        vm.prank(MAILBOX);
+        processor.handle(1, AUTH_CONTRACT, pauseMessage);
+        assertTrue(processor.paused());
+
+        // Then test resume message
+        bytes memory resumeMessage = _encodeResumeMessage();
+
+        vm.prank(MAILBOX);
+        // Check for both ProcessorResumed and MessageReceived events
+        vm.expectEmit(true, true, false, true);
+        emit ProcessorResumed();
+        vm.expectEmit(true, true, false, true);
+        emit MessageReceived(1, AUTH_CONTRACT, resumeMessage);
+
+        processor.handle(1, AUTH_CONTRACT, resumeMessage);
+        assertFalse(processor.paused());
+    }
+
+    /// @notice Test that unsupported operations revert as expected
+    function test_Handle_RevertOnUnsupportedOperation() public {
+        bytes memory message = _encodeInsertMsgsMessage();
+
+        vm.prank(MAILBOX);
+        vm.expectRevert(LiteProcessor.UnsupportedOperationError.selector);
+        processor.handle(1, AUTH_CONTRACT, message);
+    }
+
+    // Helper functions to create encoded messages for testing
+
+    /// @notice Creates an encoded pause message
+    /// @return bytes The ABI encoded pause message
+    function _encodePauseMessage() internal pure returns (bytes memory) {
+        IProcessorMessageTypes.ProcessorMessage
+            memory message = IProcessorMessageTypes.ProcessorMessage({
+                messageType: IProcessorMessageTypes.ProcessorMessageType.Pause,
+                message: bytes("")
+            });
+        return abi.encode(message);
+    }
+
+    /// @notice Creates an encoded resume message
+    /// @return bytes The ABI encoded resume message
+    function _encodeResumeMessage() internal pure returns (bytes memory) {
+        IProcessorMessageTypes.ProcessorMessage
+            memory message = IProcessorMessageTypes.ProcessorMessage({
+                messageType: IProcessorMessageTypes.ProcessorMessageType.Resume,
+                message: bytes("")
+            });
+        return abi.encode(message);
+    }
+
+    /// @notice Creates an encoded InsertMsgs message for testing unsupported operations
+    /// @return bytes The ABI encoded InsertMsgs message
+    function _encodeInsertMsgsMessage() internal pure returns (bytes memory) {
+        IProcessorMessageTypes.InsertMsgs memory insertMsgs = IProcessorMessageTypes
+            .InsertMsgs({
+                executionId: 1,
+                queuePosition: 0,
+                priority: IProcessorMessageTypes.Priority.Medium,
+                subroutine: IProcessorMessageTypes.Subroutine({
+                    subroutineType: IProcessorMessageTypes
+                        .SubroutineType
+                        .Atomic,
+                    subroutine: bytes("")
+                }),
+                messages: new bytes[](0)
+            });
+
+        IProcessorMessageTypes.ProcessorMessage
+            memory message = IProcessorMessageTypes.ProcessorMessage({
+                messageType: IProcessorMessageTypes
+                    .ProcessorMessageType
+                    .SendMsgs,
+                message: abi.encode(insertMsgs)
+            });
+
+        return abi.encode(message);
+    }
+}

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -20,10 +20,12 @@ contract LiteProcessorTest is Test {
     address public constant MAILBOX = address(0x1234);
     // Mock authorization contract address converted to bytes32 for cross-chain representation
     bytes32 public constant AUTH_CONTRACT = bytes32(uint256(uint160(address(0x5678))));
+    // Domain ID of the origin domain
+    uint32 public constant ORIGIN_DOMAIN = 1;
 
     /// @notice Deploy a fresh instance of the processor before each test
     function setUp() public {
-        processor = new LiteProcessor(AUTH_CONTRACT, MAILBOX);
+        processor = new LiteProcessor(AUTH_CONTRACT, MAILBOX, ORIGIN_DOMAIN);
     }
 
     /// @notice Test that the constructor properly initializes state variables
@@ -36,7 +38,7 @@ contract LiteProcessorTest is Test {
     /// @notice Test that constructor reverts when given zero address for mailbox
     function test_Constructor_RevertOnZeroMailbox() public {
         vm.expectRevert(ProcessorErrors.InvalidAddressError.selector);
-        new LiteProcessor(AUTH_CONTRACT, address(0));
+        new LiteProcessor(AUTH_CONTRACT, address(0), ORIGIN_DOMAIN);
     }
 
     /// @notice Test that handle() reverts when called by non-mailbox address

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -62,7 +62,7 @@ contract LiteProcessorTest is Test {
         bytes memory message = _encodePauseMessage();
 
         vm.prank(MAILBOX);
-        // Check for both ProcessorPaused and MessageReceived events
+        // Check for both MessageReceived and ProcessorPaused events
         vm.expectEmit(true, true, false, true);
         emit ProcessorEvents.MessageReceived(1, AUTH_CONTRACT, message);
         vm.expectEmit(true, true, false, true);
@@ -84,7 +84,7 @@ contract LiteProcessorTest is Test {
         bytes memory resumeMessage = _encodeResumeMessage();
 
         vm.prank(MAILBOX);
-        // Check for both ProcessorResumed and MessageReceived events
+        // Check for both MessageReceived and ProcessorResumed events
         vm.expectEmit(true, true, false, true);
         emit ProcessorEvents.MessageReceived(1, AUTH_CONTRACT, resumeMessage);
         vm.expectEmit(true, true, false, true);

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -17,15 +17,10 @@ contract LiteProcessorTest is Test {
     // Mock mailbox address that will be authorized to call the processor
     address public constant MAILBOX = address(0x1234);
     // Mock authorization contract address converted to bytes32 for cross-chain representation
-    bytes32 public constant AUTH_CONTRACT =
-        bytes32(uint256(uint160(address(0x5678))));
+    bytes32 public constant AUTH_CONTRACT = bytes32(uint256(uint160(address(0x5678))));
 
     // Events that we expect the contract to emit
-    event MessageReceived(
-        uint32 indexed origin,
-        bytes32 indexed sender,
-        bytes body
-    );
+    event MessageReceived(uint32 indexed origin, bytes32 indexed sender, bytes body);
     event ProcessorPaused();
     event ProcessorResumed();
 
@@ -35,7 +30,7 @@ contract LiteProcessorTest is Test {
     }
 
     /// @notice Test that the constructor properly initializes state variables
-    function test_Constructor() view public {
+    function test_Constructor() public view {
         assertEq(address(processor.mailbox()), MAILBOX);
         assertEq(processor.authorizationContract(), AUTH_CONTRACT);
         assertFalse(processor.paused());
@@ -72,9 +67,9 @@ contract LiteProcessorTest is Test {
         vm.prank(MAILBOX);
         // Check for both ProcessorPaused and MessageReceived events
         vm.expectEmit(true, true, false, true);
-        emit ProcessorPaused();
-        vm.expectEmit(true, true, false, true);
         emit MessageReceived(1, AUTH_CONTRACT, message);
+        vm.expectEmit(true, true, false, true);
+        emit ProcessorPaused();
 
         processor.handle(1, AUTH_CONTRACT, message);
         assertTrue(processor.paused());
@@ -94,9 +89,9 @@ contract LiteProcessorTest is Test {
         vm.prank(MAILBOX);
         // Check for both ProcessorResumed and MessageReceived events
         vm.expectEmit(true, true, false, true);
-        emit ProcessorResumed();
-        vm.expectEmit(true, true, false, true);
         emit MessageReceived(1, AUTH_CONTRACT, resumeMessage);
+        vm.expectEmit(true, true, false, true);
+        emit ProcessorResumed();
 
         processor.handle(1, AUTH_CONTRACT, resumeMessage);
         assertFalse(processor.paused());
@@ -116,49 +111,41 @@ contract LiteProcessorTest is Test {
     /// @notice Creates an encoded pause message
     /// @return bytes The ABI encoded pause message
     function _encodePauseMessage() internal pure returns (bytes memory) {
-        IProcessorMessageTypes.ProcessorMessage
-            memory message = IProcessorMessageTypes.ProcessorMessage({
-                messageType: IProcessorMessageTypes.ProcessorMessageType.Pause,
-                message: bytes("")
-            });
+        IProcessorMessageTypes.ProcessorMessage memory message = IProcessorMessageTypes.ProcessorMessage({
+            messageType: IProcessorMessageTypes.ProcessorMessageType.Pause,
+            message: bytes("")
+        });
         return abi.encode(message);
     }
 
     /// @notice Creates an encoded resume message
     /// @return bytes The ABI encoded resume message
     function _encodeResumeMessage() internal pure returns (bytes memory) {
-        IProcessorMessageTypes.ProcessorMessage
-            memory message = IProcessorMessageTypes.ProcessorMessage({
-                messageType: IProcessorMessageTypes.ProcessorMessageType.Resume,
-                message: bytes("")
-            });
+        IProcessorMessageTypes.ProcessorMessage memory message = IProcessorMessageTypes.ProcessorMessage({
+            messageType: IProcessorMessageTypes.ProcessorMessageType.Resume,
+            message: bytes("")
+        });
         return abi.encode(message);
     }
 
     /// @notice Creates an encoded InsertMsgs message for testing unsupported operations
     /// @return bytes The ABI encoded InsertMsgs message
     function _encodeInsertMsgsMessage() internal pure returns (bytes memory) {
-        IProcessorMessageTypes.InsertMsgs memory insertMsgs = IProcessorMessageTypes
-            .InsertMsgs({
-                executionId: 1,
-                queuePosition: 0,
-                priority: IProcessorMessageTypes.Priority.Medium,
-                subroutine: IProcessorMessageTypes.Subroutine({
-                    subroutineType: IProcessorMessageTypes
-                        .SubroutineType
-                        .Atomic,
-                    subroutine: bytes("")
-                }),
-                messages: new bytes[](0)
-            });
+        IProcessorMessageTypes.InsertMsgs memory insertMsgs = IProcessorMessageTypes.InsertMsgs({
+            executionId: 1,
+            queuePosition: 0,
+            priority: IProcessorMessageTypes.Priority.Medium,
+            subroutine: IProcessorMessageTypes.Subroutine({
+                subroutineType: IProcessorMessageTypes.SubroutineType.Atomic,
+                subroutine: bytes("")
+            }),
+            messages: new bytes[](0)
+        });
 
-        IProcessorMessageTypes.ProcessorMessage
-            memory message = IProcessorMessageTypes.ProcessorMessage({
-                messageType: IProcessorMessageTypes
-                    .ProcessorMessageType
-                    .SendMsgs,
-                message: abi.encode(insertMsgs)
-            });
+        IProcessorMessageTypes.ProcessorMessage memory message = IProcessorMessageTypes.ProcessorMessage({
+            messageType: IProcessorMessageTypes.ProcessorMessageType.InsertMsgs,
+            message: abi.encode(insertMsgs)
+        });
 
         return abi.encode(message);
     }

--- a/solidity/test/LiteProcessor.t.sol
+++ b/solidity/test/LiteProcessor.t.sol
@@ -46,17 +46,25 @@ contract LiteProcessorTest is Test {
         bytes memory message = _encodePauseMessage();
 
         vm.expectRevert(ProcessorErrors.UnauthorizedAccess.selector);
-        processor.handle(1, AUTH_CONTRACT, message);
+        processor.handle(ORIGIN_DOMAIN, AUTH_CONTRACT, message);
+    }
+
+    /// @notice Test that handle() reverts when receiving a message from an invalid origin domain
+    function test_Handle_RevertOnInvalidOriginDomain() public {
+        bytes memory message = _encodePauseMessage();
+
+        vm.expectRevert(ProcessorErrors.UnauthorizedAccess.selector);
+        processor.handle(2, AUTH_CONTRACT, message);
     }
 
     /// @notice Test that handle() reverts when message is from unauthorized sender
     function test_Handle_RevertOnUnauthorizedContract() public {
         bytes memory message = _encodePauseMessage();
-        bytes32 unauthorizedSender = bytes32(uint256(1));
+        bytes32 unauthorizedSender = bytes32(uint256(ORIGIN_DOMAIN));
 
         vm.prank(MAILBOX);
         vm.expectRevert(ProcessorErrors.NotAuthorizationContract.selector);
-        processor.handle(1, unauthorizedSender, message);
+        processor.handle(ORIGIN_DOMAIN, unauthorizedSender, message);
     }
 
     /// @notice Test successful pause message handling and event emission
@@ -66,11 +74,11 @@ contract LiteProcessorTest is Test {
         vm.prank(MAILBOX);
         // Check for both MessageReceived and ProcessorPaused events
         vm.expectEmit(true, true, false, true);
-        emit ProcessorEvents.MessageReceived(1, AUTH_CONTRACT, message);
+        emit ProcessorEvents.MessageReceived(ORIGIN_DOMAIN, AUTH_CONTRACT, message);
         vm.expectEmit(true, true, false, true);
         emit ProcessorEvents.ProcessorPaused();
 
-        processor.handle(1, AUTH_CONTRACT, message);
+        processor.handle(ORIGIN_DOMAIN, AUTH_CONTRACT, message);
         assertTrue(processor.paused());
     }
 
@@ -79,7 +87,7 @@ contract LiteProcessorTest is Test {
         // First pause the processor to test resume functionality
         bytes memory pauseMessage = _encodePauseMessage();
         vm.prank(MAILBOX);
-        processor.handle(1, AUTH_CONTRACT, pauseMessage);
+        processor.handle(ORIGIN_DOMAIN, AUTH_CONTRACT, pauseMessage);
         assertTrue(processor.paused());
 
         // Then test resume message
@@ -88,7 +96,7 @@ contract LiteProcessorTest is Test {
         vm.prank(MAILBOX);
         // Check for both MessageReceived and ProcessorResumed events
         vm.expectEmit(true, true, false, true);
-        emit ProcessorEvents.MessageReceived(1, AUTH_CONTRACT, resumeMessage);
+        emit ProcessorEvents.MessageReceived(ORIGIN_DOMAIN, AUTH_CONTRACT, resumeMessage);
         vm.expectEmit(true, true, false, true);
         emit ProcessorEvents.ProcessorResumed();
 

--- a/solidity/test/Processor.t.sol
+++ b/solidity/test/Processor.t.sol
@@ -21,14 +21,14 @@ contract ProcessorTest is Test {
     }
 
     /// @notice Test that the constructor properly initializes state variables
-    function test_Constructor() public view {
+    function testConstructor() public view {
         assertEq(address(processor.mailbox()), MAILBOX);
         assertEq(processor.authorizationContract(), AUTH_CONTRACT);
         assertFalse(processor.paused());
     }
 
     /// @notice Test that constructor reverts when given zero address for mailbox
-    function test_Constructor_RevertOnZeroMailbox() public {
+    function testConstructorRevertOnZeroMailbox() public {
         vm.expectRevert(ProcessorErrors.InvalidAddress.selector);
         new Processor(AUTH_CONTRACT, address(0), ORIGIN_DOMAIN);
     }

--- a/solidity/test/Processor.t.sol
+++ b/solidity/test/Processor.t.sol
@@ -20,7 +20,7 @@ contract ProcessorTest is Test {
     }
 
     function testConstructorZeroMailbox() public {
-        vm.expectRevert(Processor.InvalidAddress.selector);
+        vm.expectRevert(Processor.InvalidAddressError.selector);
         new Processor(MOCK_AUTH_CONTRACT, address(0));
     }
 }

--- a/solidity/test/Processor.t.sol
+++ b/solidity/test/Processor.t.sol
@@ -14,22 +14,26 @@ contract ProcessorTest is Test {
     bytes32 public constant AUTH_CONTRACT = bytes32(uint256(uint160(address(0x5678))));
     // Domain ID of the origin domain
     uint32 public constant ORIGIN_DOMAIN = 1;
+    // Authorized addresses that can call the processor directly
+    address[] public AUTHORIZED_ADDRESSES = [address(0x1234)];
 
     /// @notice Deploy a fresh instance of the processor before each test
     function setUp() public {
-        processor = new Processor(AUTH_CONTRACT, MAILBOX, ORIGIN_DOMAIN);
+        processor = new Processor(AUTH_CONTRACT, MAILBOX, ORIGIN_DOMAIN, AUTHORIZED_ADDRESSES);
     }
 
     /// @notice Test that the constructor properly initializes state variables
     function testConstructor() public view {
         assertEq(address(processor.mailbox()), MAILBOX);
         assertEq(processor.authorizationContract(), AUTH_CONTRACT);
+        assertEq(processor.originDomain(), ORIGIN_DOMAIN);
+        assertEq(processor.authorizedAddresses(AUTHORIZED_ADDRESSES[0]), true);
         assertFalse(processor.paused());
     }
 
     /// @notice Test that constructor reverts when given zero address for mailbox
     function testConstructorRevertOnZeroMailbox() public {
         vm.expectRevert(ProcessorErrors.InvalidAddress.selector);
-        new Processor(AUTH_CONTRACT, address(0), ORIGIN_DOMAIN);
+        new Processor(AUTH_CONTRACT, address(0), ORIGIN_DOMAIN, AUTHORIZED_ADDRESSES);
     }
 }


### PR DESCRIPTION
Full implementation of EVM LiteProcessor, including atomic/non-atomic execution of batches and callbacks.

This lite version of the processor has no queues nor retries. It receives an encoded message via Hyperlane, decodes it, and executes accordingly depending on the subroutine type.

Since we are going to reuse most of the API for other processor(s) I've separated the code and created multiple libraries/interfaces to make the code more modular/reusable.

NOTE: The subroutine execution/callback will be tested once I have the base account and first service (forwarder) implemented. That is in the next PR. For now I've tested all the functionality that can be tested without these 2.