### PR TITLE
Add basic vault docs

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,6 +11,7 @@ default-theme         = "light"
 preferred-light-theme = "light"
 preferred-dark-theme  = "ayu"
 additional-js         = ["mermaid.min.js", "mermaid-init.js"]
+mathjax-support = true
 
 [preprocessor.mermaid]
 command = "mdbook-mermaid"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,3 +28,4 @@
   - [Splitter](./libraries/splitter.md)
 - [Examples](./examples/_overview.md)
   - [Token Swap](./examples/token_swap.md)
+  - [Crosschain Vaults](./examples/crosschain_vaults.md)

--- a/docs/src/examples/_overview.md
+++ b/docs/src/examples/_overview.md
@@ -3,3 +3,4 @@
 Here are some examples of Valence Programs that you can use to get started.
 
 - [Token Swap](./token_swap.md)
+- [Crosschain Vaults](./crosschain_vaults.md)

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -9,12 +9,9 @@ You can use Valence Programs to create crosschain vaults. Users interact with a 
 In this example, we have made the following assumptions:
 - Users can deposit tokens into a standard ERC4626 vault on Ethereum
 - ERC20 shares are issued to users on Ethereum
-- A strategist can execute actions to move funds to Neutron where they are held in some position
 - If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed
 - The redemption rate that tells us how many tokens can be redeemed per shares is given by: \\( R = \frac{TotalAssets}{TotalIssuedShares} = \frac{TotalInVault + TotalInTransit + TotalInPostion}{TotalIssuedShares}\\)
-- A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron and vice-versa as well as adjust the redemption rate accordingly
-
-While we have chosen Ethereum and Neutron as examples here, one could similarly construct such vaults between any two chains as long as they are supported by Valence Programs.
+- A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron where they are locked in some DeFi protocol. And vice-versa, the Strategist can withdraw from the position so the funds are redeemable on Ethereum. The redemption rate must be adjusted by the Strategist accordingly
 
 ```mermaid 
 ---
@@ -31,9 +28,11 @@ graph LR
 	NP -- Strategist Transport --> EV
 ```
 
+While we have chosen Ethereum and Neutron as examples here, one could similarly construct such vaults between any two chains as long as they are supported by Valence Programs.
+
 ## Implementing Crosschain Vaults as a Valence Program
 
-Recall that Valence Programs are comprised of Libraries and Accounts. Libraries are a colletion of Functions that perform token oprations on the Accounts. Since there are two chains here, Libraries and Accounts will exist on both chains.
+Recall that Valence Programs are comprised of Libraries and Accounts. Libraries are a collection of Functions that perform token oprations on the Accounts. Since there are two chains here, Libraries and Accounts will exist on both chains.
 
 Since gas is cheaper on Neutron than on Ethereum, computationally expensive operations, such as constraining the Strategist actions will be done on Neutron. Authorized messages will then be executed by each chain's Processor. Hyperlane is used to pass messages from the Authorization contract on Neutron to the Processor on Ethereum.
 

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -1,6 +1,6 @@
 # Crosschain Vaults
 
-**Note:** _This example is still in design and includes new or experimental features of Valence Programs that may not be supported in current production releases._
+**Note:** _This example is still in the design phase and includes new or experimental features of Valence Programs that may not be supported in the current production release._
 
 ## Overview
 

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -6,6 +6,8 @@
 
 You can use Valence Programs to create crosschain vaults. Users interact with a vault on one chain while the tokens are held on another chain where yield is generated.
 
+Note: In our initial implementation we use Neutron for co-processing and Hyperlane for general message passing between the co-processor and the target domain. Deployment of Valence programs as zk RISC-V co-processors with permissionless message passing will be available in the coming months.
+
 In this example, we have made the following assumptions:
 - Users can deposit tokens into a standard ERC-4626 vault on Ethereum.
 - ERC-20 shares are issued to users on Ethereum.

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -7,11 +7,11 @@
 You can use Valence Programs to create crosschain vaults. Users interact with a vault on one chain while the tokens are held on another chain where yield is generated.
 
 In this example, we have made the following assumptions:
-- Users can deposit tokens into a standard ERC4626 vault on Ethereum
-- ERC20 shares are issued to users on Ethereum
-- If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed
+- Users can deposit tokens into a standard ERC4626 vault on Ethereum.
+- ERC20 shares are issued to users on Ethereum.
+- If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed.
 - The redemption rate that tells us how many tokens can be redeemed per shares is given by: \\( R = \frac{TotalAssets}{TotalIssuedShares} = \frac{TotalInVault + TotalInTransit + TotalInPostion}{TotalIssuedShares}\\)
-- A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron where they are locked in some DeFi protocol. And vice-versa, the Strategist can withdraw from the position so the funds are redeemable on Ethereum. The redemption rate must be adjusted by the Strategist accordingly
+- A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron where they are locked in some DeFi protocol. And vice-versa, the Strategist can withdraw from the position so the funds are redeemable on Ethereum. The redemption rate must be adjusted by the Strategist accordingly.
 
 ```mermaid 
 ---
@@ -66,20 +66,20 @@ graph BT
 
 On Ethereum, we'll need Accounts for:
 - **Deposit**: To hold user deposited tokens. Tokens from this pool can be then transported to Neutron.
-- **Withdraw**: Told hold tokens received from Neutron. Tokens from this pool can then be 
+- **Withdraw**: To hold tokens received from Neutron. Tokens from this pool can then be redeemed for shares.
 
 On Neutron, we'll need Accounts for:
 - **Deposit**: To hold tokens bridged from Ethereum. Tokens from this pool can be used to enter into the position on Neutron.
-- **Position**: Will hold the vouchers or shares associated with the position on Neutron
+- **Position**: Will hold the vouchers or shares associated with the position on Neutron.
 - **Withdraw**: To hold the tokens that are withdrawn from the position. Tokens from this pool can be bridged back to Ethereum.
 
 We'll need the following Libraries on Ethereum:
-- **Bridge Transfer**: To transfer funds from the Etherem Deposit Account to the Neutron Deposit Account. 
-- **Forwarder**: To transfer funds between the Deposit and Withdraw accounts on Ethereum. Two instances of the Library will be required.
+- **Bridge Transfer**: To transfer funds from the Ethereum Deposit Account to the Neutron Deposit Account. 
+- **Forwarder**: To transfer funds between the Deposit and Withdraw Accounts on Ethereum. Two instances of the Library will be required.
 
 We'll need the following Libraries on Neutron:
-- **Position Depositor**: To take funds in the Deposit and create a position with them. The position is helf by the Position account.
-- **Position Withdrawer**: To redeem a position for underlying funds that are then transferred to the withdraw account.
+- **Position Depositor**: To take funds in the Deposit and create a position with them. The position is held by the Position account.
+- **Position Withdrawer**: To redeem a position for underlying funds that are then transferred to the Withdraw Account on Neutron.
 - **Bridge Transfer**: To transfer funds from the Neutron Withdraw Account to the Ethereum Withdraw Account.
 
 Note that the Accounts mentioned here the standard [Valence Accounts](../components/accounts.md). Th Bridge Transfer library will depend on the token being transferred, but will offer similar functionality to the [IBC Transfer](../libraries/generic-ibc-transfer.md) library. The Position Depositor and Withdrawer will depend on the type of position, but can be similar to the [Liqudity Provider](../libraries/astroport-lper.md) and [Liquidity Withdrawer](../libraries/astroport-withdrawer.md).
@@ -172,10 +172,9 @@ The vault validates that the Processor is making calls to it. On Neutron, the Au
   ```
 ### Program subroutines
 
-The program authorizes the Strategist to update the redemption rate and transport funds between various accounts.
+The program authorizes the Strategist to update the redemption rate and transport funds between various Accounts.
 
 #### Allowing the Strategist to transport funds
-
 
 ```mermaid
 ---

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -58,7 +58,7 @@ graph BT
 	end
 
 	Strategist --> A
-	A --> NHM --> EE --> Relayer --> EHM --> EP --> EL --> EVA
+	A --> EE --> NHM --> Relayer --> EHM --> EP --> EL --> EVA
 	A --> NP --> NL--> NVA
 ```
 

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-You can use Valence Programs to create crosschain vaults. Users interact with a vault on one chain while the hokens are held on another chain where yield is generated.
+You can use Valence Programs to create crosschain vaults. Users interact with a vault on one chain while the tokens are held on another chain where yield is generated.
 
 In this example, we have made the following assumptions:
 - Users can deposit tokens into a standard ERC4626 vault on Ethereum

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -1,0 +1,172 @@
+# Crosschain Vaults
+
+**Note:** _This example is still in design and includes new or experimental features of Valence Programs that may not be supported in current production releases._
+
+## Overview
+
+You can use Valence Programs to create crosschain vaults. Users interact with a vault on one chain while the hokens are held on another chain where yield is generated.
+
+In this example, we have made the following assumptions:
+- Users can deposit tokens into a standard ERC4626 vault on Ethereum
+- ERC20 shares are issued to users on Ethereum
+- A strategist can execute actions to move funds to Neutron where they are held in some position
+- If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed
+- The redemption rate that tells us how many tokens can be redeemed per shares is given by: \\( R = \frac{TotalAssets}{TotalIssuedShares} = \frac{TotalInVault + TotalInTransit + TotalInPostion}{TotalIssuedShares}\\)
+- A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron and vice-versa as well as adjust the redemption rate accordingly
+
+While we have chosen Ethereum and Neutron as examples here, one could similarly construct such vaults between any two chains as long as they are supported by Valence Programs.
+
+```mermaid 
+---
+title: Crosschain Vaults Overview
+---
+graph LR
+	User
+	EV(Ethereum Vault)
+	NP(Neutron Position)
+
+	User -- Tokens --> EV
+	EV -- Shares --> User
+	EV -- Strategist Transport --> NP
+	NP -- Strategist Transport --> EV
+```
+
+## Implementing Crosschain Vaults as a Valence Program
+
+Recall that Valence Programs are comprised of Libraries and Accounts. Libraries are a colletion of Functions that perform token oprations on the Accounts. Since there are two chains here, Libraries and Accounts will exist on both chains.
+
+Since gas is cheaper on Neutron than on Ethereum, computationally expensive operations, such as constraining the Strategist actions will be done on Neutron. Authorized messages will then be executed by each chain's Processor. Hyperlane is used to pass messages from the Authorization contract on Neutron to the Processor on Ethereum.
+
+```mermaid
+---
+title: Program Control
+---
+graph LR
+	Strategist
+	subgraph Ethereum
+		EP(Processor)
+		EHM(Hyperlane Mailbox)
+		EL(Ethereum Libraries)
+		EVA(Valence Accounts)
+
+	end
+	subgraph Neutron
+		A(Authorizations)
+		NP(Processor)
+		NHM(Hyperlane Mailbox)
+		NL(Neutron Libraries)
+		NVA(Valence Accounts)
+	end
+
+	Strategist --> A
+	A --> NHM -- Relayer --> EHM --> EP --> EL --> EVA
+	A --> NP --> NL--> NVA
+```
+
+### Libraries and Accounts needed
+
+On Ethereum, we'll need Accounts for:
+- **Deposit**: To hold user deposited tokens. Tokens from this pool can be then transported to Neutron.
+- **Withdraw**: Told hold tokens received from Neutron. Tokens from this pool can then be 
+
+On Neutron, we'll need Accounts for:
+- **Deposit**: To hold tokens bridged from Ethereum. Tokens from this pool can be used to enter into the position on Neutron.
+- **Position Holder**: Will hold the vouchers or shares associated with the position on Neutron
+- **Withdraw**: To hold the tokens that are withdrawn from the position. Tokens from this pool can be bridged back to Ethereum.
+
+We'll need the following Libraries on Ethereum:
+
+We'll need the following Libraries on Neutron:
+
+The Vault contract is a special contract on Ethereum that does the following:
+
+
+#### Allowing users to deposit and withdraw tokens
+
+```mermaid 
+---
+title: User Deposit Flow
+---
+graph LR
+	User
+	subgraph Ethereum
+		direction LR
+		EV(Vault)
+		ED((Deposit))
+	end
+	
+	User -- 1/ Deposit Tokens --> EV
+	EV -- 2/ Send Shares --> User
+	EV -- 3/ Send Tokens --> ED
+```
+
+```mermaid 
+---
+title: User Withdraw Flow
+---
+graph RL
+	subgraph Ethereum
+		direction RL
+		EV(Vault)
+		EW((Withdraw))
+	end
+	EW -- 2/ Send Tokens --> EV -- 3/ Send Tokens --> User
+	User -- 1/ Deposit Shares --> EV
+
+
+```
+
+#### Allowing the Strategist to transport funds
+
+
+```mermaid
+---
+title: From Ethereum Deposit Account to Neutron Position Account
+---
+graph LR
+	subgraph Ethereum
+		ED((Deposit))
+		ET(Bridge Transfer)
+	end
+	subgraph Neutron
+		NPH((Position Holder))
+		NPD(Position Depositor)
+		ND((Deposit))
+	end
+
+	ED --> ET --> ND --> NPD --> NPH
+```
+
+```mermaid
+---
+title: From Neutron Position Account to Ethereum Withdraw Account
+---
+graph RL
+	subgraph Ethereum
+		EW((Withdraw))
+	end
+	subgraph Neutron
+		NPH((Position Holder))
+		NW((Widthdraw))
+		NT(Bridge Transfer)
+		NPW(Position Withdrawer)
+	end
+
+	NPH --> NPW --> NW --> NT --> EW
+
+```
+
+```mermaid
+---
+title: Between Ethereum Deposit and Ethereum Withdraw Accounts
+---
+graph
+	subgraph Ethereum
+		ED((Deposit))
+		EW((Withdraw))
+		FDW(Forwarder)
+	end
+	ED --> FDW --> EW
+```
+
+

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -82,6 +82,8 @@ We'll need the following Libraries on Neutron:
 - **Position Withdrawer**: To redeem a position for underlying funds that are then transferred to the withdraw account.
 - **Bridge Transfer**: To transfer funds from the Neutron Withdraw Account to the Ethereum Withdraw Account.
 
+Note that the Accounts mentioned here the standard [Valence Accounts](../components/accounts.md). Th Bridge Transfer library will depend on the token being transferred, but will offer similar functionality to the [IBC Transfer](../libraries/generic-ibc-transfer.md) library. The Position Depositor and Withdrawer will depend on the type of position, but can be similar to the [Liqudity Provider](../libraries/astroport-lper.md) and [Liquidity Withdrawer](../libraries/astroport-withdrawer.md).
+
 ### Vault Contract
 The Vault contract is a special contract on Ethereum that has an ERC4626 interface.
 

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -161,7 +161,7 @@ graph RL
 ```
 
 ### Strategist methods to manage the vault
-The vault validates that the Processor is making calls to it. On Neutron, the Authorization contract limits the calls to be made only by a trusted Strategist. The Authorization contract can further constrain when/how the Strategist actions can be taken.
+The vault validates that the Processor is making calls to it. On Neutron, the Authorization contract limits the calls to be made only by a trusted Strategist. The Authorization contract can further constrain when or how Strategist actions can be taken.
 
 - **Update**: The strategist can update the current redemption rate. 
   ```

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -130,7 +130,7 @@ graph LR
 		max_loss_bps: u64
 	}
 	```
-- **Withdraw**: Withdraw amount of assets. It expects the the user to have sufficient shares. This creates a `WithdrawRecord` in a queue. This record is processed at the next `Epoch`
+- **Withdraw**: Withdraw amount of assets. It expects the user to have sufficient shares. This creates a `WithdrawRecord` in a queue. This record is processed at the next `Epoch`.
 	```
 	Withdraw {
 		amount: Uint256,

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -8,7 +8,7 @@ You can use Valence Programs to create crosschain vaults. Users interact with a 
 
 In this example, we have made the following assumptions:
 - Users can deposit tokens into a standard ERC-4626 vault on Ethereum.
-- ERC20 shares are issued to users on Ethereum.
+- ERC-20 shares are issued to users on Ethereum.
 - If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed.
 - The redemption rate that tells us how many tokens can be redeemed per shares is given by: \\( R = \frac{TotalAssets}{TotalIssuedShares} = \frac{TotalInVault + TotalInTransit + TotalInPostion}{TotalIssuedShares}\\)
 - A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron where they are locked in some DeFi protocol. And vice-versa, the Strategist can withdraw from the position so the funds are redeemable on Ethereum. The redemption rate must be adjusted by the Strategist accordingly.

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -229,6 +229,6 @@ graph
 ```
 
 ## Design notes
-This is a simplified design to demonstrate how a cross-chain vault may be implemented with Valence Programs. Production deployments will need to consider factors not covered here including:
+This is a simplified design to demonstrate how a cross-chain vault can be implemented with Valence Programs. Production deployments will need to consider additional factors not covered here including:
 - Fees for gas, bridging, and for entering/exiting the position on Neutron. It is recommend that the vault impose withdraw fee and platform for users.
 - How to constrain Strategist behavior to ensure they set redemption rates correctly.

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -231,4 +231,4 @@ graph
 ## Design notes
 This is a simplified design to demonstrate how a cross-chain vault may be implemented with Valence Programs. Production deployments will need to consider factors not covered here including:
 - Fees for gas, bridging, and for entering/exiting the position on Neutron. It is recommend that the vault impose withdraw fee and platform for users.
-- How to constrain the strategist behaviour to ensure to ensure that they are setting the redemption rates correctly
+- How to constrain Strategist behavior to ensure they set redemption rates correctly.

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -7,7 +7,7 @@
 You can use Valence Programs to create crosschain vaults. Users interact with a vault on one chain while the tokens are held on another chain where yield is generated.
 
 In this example, we have made the following assumptions:
-- Users can deposit tokens into a standard ERC4626 vault on Ethereum.
+- Users can deposit tokens into a standard ERC-4626 vault on Ethereum.
 - ERC20 shares are issued to users on Ethereum.
 - If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed.
 - The redemption rate that tells us how many tokens can be redeemed per shares is given by: \\( R = \frac{TotalAssets}{TotalIssuedShares} = \frac{TotalInVault + TotalInTransit + TotalInPostion}{TotalIssuedShares}\\)

--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -87,7 +87,7 @@ We'll need the following Libraries on Neutron:
 Note that the Accounts mentioned here the standard [Valence Accounts](../components/accounts.md). Th Bridge Transfer library will depend on the token being transferred, but will offer similar functionality to the [IBC Transfer](../libraries/generic-ibc-transfer.md) library. The Position Depositor and Withdrawer will depend on the type of position, but can be similar to the [Liqudity Provider](../libraries/astroport-lper.md) and [Liquidity Withdrawer](../libraries/astroport-withdrawer.md).
 
 ### Vault Contract
-The Vault contract is a special contract on Ethereum that has an ERC4626 interface.
+The Vault contract is a special contract on Ethereum that has an ERC-4626 interface.
 
 #### User methods to deposit funds
 - **Deposit**: Deposit funds into the registered Deposit Account. Receive shares back based on the redemption rate. 


### PR DESCRIPTION
This PR adds specifications to build crosschain vaults using Valence Programs in the Examples section of the docs.