### PR TITLE
liquidity withdrawer pool ratio checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,6 +5073,7 @@ dependencies = [
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "neutron-test-tube",
+ "valence-library-utils",
 ]
 
 [[package]]

--- a/contracts/libraries/astroport-lper/src/astroport_cw20.rs
+++ b/contracts/libraries/astroport-lper/src/astroport_cw20.rs
@@ -1,18 +1,12 @@
-use crate::msg::{Config, PoolType};
+use crate::msg::Config;
 
 use cosmwasm_std::{coin, CosmosMsg, WasmMsg};
 use cosmwasm_std::{to_json_binary, DepsMut, Uint128};
 use valence_astroport_utils::astroport_cw20_lp_token::{
-    Asset, AssetInfo, ExecuteMsg, PairType, PoolQueryMsg, PoolResponse, SimulationResponse,
+    Asset, AssetInfo, ExecuteMsg, PairType, PoolQueryMsg, SimulationResponse,
 };
+use valence_astroport_utils::PoolType;
 use valence_library_utils::error::LibraryError;
-
-pub fn query_pool(deps: &DepsMut, pool_addr: &str) -> Result<Vec<Asset>, LibraryError> {
-    let response: PoolResponse = deps
-        .querier
-        .query_wasm_smart(pool_addr, &PoolQueryMsg::Pool {})?;
-    Ok(response.assets)
-}
 
 pub fn create_provide_liquidity_msg(
     cfg: &Config,

--- a/contracts/libraries/astroport-lper/src/astroport_native.rs
+++ b/contracts/libraries/astroport-lper/src/astroport_native.rs
@@ -1,17 +1,11 @@
-use crate::msg::{Config, PoolType};
+use crate::msg::Config;
 use cosmwasm_std::{coin, CosmosMsg, WasmMsg};
 use cosmwasm_std::{to_json_binary, DepsMut, Uint128};
 use valence_astroport_utils::astroport_native_lp_token::{
-    Asset, AssetInfo, ExecuteMsg, PairType, PoolQueryMsg, PoolResponse, SimulationResponse,
+    Asset, AssetInfo, ExecuteMsg, PairType, PoolQueryMsg, SimulationResponse,
 };
+use valence_astroport_utils::PoolType;
 use valence_library_utils::error::LibraryError;
-
-pub fn query_pool(deps: &DepsMut, pool_addr: &str) -> Result<Vec<Asset>, LibraryError> {
-    let response: PoolResponse = deps
-        .querier
-        .query_wasm_smart(pool_addr, &PoolQueryMsg::Pool {})?;
-    Ok(response.assets)
-}
 
 /// Creates a provide liquidity message for an astroport pool that will mint LP tokenfactory tokens
 pub fn create_provide_liquidity_msg(

--- a/contracts/libraries/astroport-lper/src/contract.rs
+++ b/contracts/libraries/astroport-lper/src/contract.rs
@@ -59,7 +59,7 @@ mod functions {
     use cosmwasm_std::{Coin, CosmosMsg, DepsMut, Env, MessageInfo, Response, Uint128};
     use valence_astroport_utils::{
         decimal_checked_ops::DecimalCheckedOps, decimal_range::DecimalRange,
-        get_pool_asset_amounts, query_pool, AssetTrait, PoolType,
+        get_pool_asset_amounts, query_pool, PoolType,
     };
     use valence_library_utils::{error::LibraryError, execute_on_behalf_of};
 

--- a/contracts/libraries/astroport-lper/src/msg.rs
+++ b/contracts/libraries/astroport-lper/src/msg.rs
@@ -1,9 +1,13 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
-use valence_astroport_utils::{decimal_range::DecimalRange, AssetData, PoolType};
+use valence_astroport_utils::PoolType;
+
 use valence_library_utils::{
-    error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
+    error::LibraryError,
+    liquidity_utils::{AssetData, DecimalRange},
+    msg::LibraryConfigValidation,
+    LibraryAccountType,
 };
 use valence_macros::{valence_library_query, ValenceLibraryInterface};
 

--- a/contracts/libraries/astroport-lper/src/msg.rs
+++ b/contracts/libraries/astroport-lper/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Addr, Decimal, Deps, DepsMut, Uint128};
+use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Uint128};
 use cw_ownable::cw_ownable_query;
+use valence_astroport_utils::{decimal_range::DecimalRange, AssetData, PoolType};
 use valence_library_utils::{
     error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
 };
@@ -16,22 +17,6 @@ pub enum FunctionMsgs {
         limit: Option<Uint128>,
         expected_pool_ratio_range: Option<DecimalRange>,
     },
-}
-
-#[cw_serde]
-pub struct DecimalRange {
-    min: Decimal,
-    max: Decimal,
-}
-
-impl DecimalRange {
-    pub fn is_within_range(&self, value: Decimal) -> Result<(), LibraryError> {
-        ensure!(
-            value >= self.min && value <= self.max,
-            LibraryError::ExecutionError("Value is not within the expected range".to_string())
-        );
-        Ok(())
-    }
 }
 
 #[valence_library_query]
@@ -82,20 +67,6 @@ pub struct LiquidityProviderConfig {
     pub asset_data: AssetData,
     /// Slippage tolerance when providing liquidity
     pub slippage_tolerance: Option<Decimal>,
-}
-
-#[cw_serde]
-pub enum PoolType {
-    NativeLpToken(valence_astroport_utils::astroport_native_lp_token::PairType),
-    Cw20LpToken(valence_astroport_utils::astroport_cw20_lp_token::PairType),
-}
-
-#[cw_serde]
-pub struct AssetData {
-    /// Denom of the first asset
-    pub asset1: String,
-    /// Denom of the second asset
-    pub asset2: String,
 }
 
 #[cw_serde]

--- a/contracts/libraries/astroport-lper/src/tests.rs
+++ b/contracts/libraries/astroport-lper/src/tests.rs
@@ -7,12 +7,12 @@ use neutron_test_tube::{
     Account, Bank, Module, NeutronTestApp, Wasm,
 };
 use valence_astroport_utils::{
-    decimal_range::DecimalRange,
     suite::{AstroportTestAppBuilder, AstroportTestAppSetup},
-    AssetData, PoolType,
+    PoolType,
 };
 use valence_library_utils::{
     error::{LibraryError, UnauthorizedReason},
+    liquidity_utils::{AssetData, DecimalRange},
     msg::{ExecuteMsg, InstantiateMsg},
 };
 

--- a/contracts/libraries/astroport-lper/src/tests.rs
+++ b/contracts/libraries/astroport-lper/src/tests.rs
@@ -6,15 +6,16 @@ use neutron_test_tube::{
     },
     Account, Bank, Module, NeutronTestApp, Wasm,
 };
-use valence_astroport_utils::suite::{AstroportTestAppBuilder, AstroportTestAppSetup};
+use valence_astroport_utils::{
+    suite::{AstroportTestAppBuilder, AstroportTestAppSetup},
+    AssetData, PoolType,
+};
 use valence_library_utils::{
     error::{LibraryError, UnauthorizedReason},
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
-use crate::msg::{
-    AssetData, FunctionMsgs, LibraryConfig, LibraryConfigUpdate, LiquidityProviderConfig, PoolType,
-};
+use crate::msg::{FunctionMsgs, LibraryConfig, LibraryConfigUpdate, LiquidityProviderConfig};
 
 const CONTRACT_PATH: &str = "../../../artifacts";
 
@@ -500,6 +501,17 @@ fn provide_double_sided_liquidity_native_lp_token() {
         output_acc_balance.balances[0].denom,
         setup.inner.pool_native_liquidity_token
     );
+}
+
+#[test]
+fn provide_double_sided_liquidity_native_lp_token_validates_expected_decimal_range() {
+    unimplemented!("todo")
+}
+
+#[test]
+// #[should_panic]
+fn provide_double_sided_liquidity_native_lp_token_expected_decimal_range_validation_fails() {
+    unimplemented!("todo")
 }
 
 #[test]

--- a/contracts/libraries/astroport-lper/src/tests.rs
+++ b/contracts/libraries/astroport-lper/src/tests.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Decimal, Uint128};
 use neutron_test_tube::{
     neutron_std::types::cosmos::{
         bank::v1beta1::{MsgSend, QueryAllBalancesRequest, QueryBalanceRequest},
@@ -7,6 +7,7 @@ use neutron_test_tube::{
     Account, Bank, Module, NeutronTestApp, Wasm,
 };
 use valence_astroport_utils::{
+    decimal_range::DecimalRange,
     suite::{AstroportTestAppBuilder, AstroportTestAppSetup},
     AssetData, PoolType,
 };
@@ -504,17 +505,6 @@ fn provide_double_sided_liquidity_native_lp_token() {
 }
 
 #[test]
-fn provide_double_sided_liquidity_native_lp_token_validates_expected_decimal_range() {
-    unimplemented!("todo")
-}
-
-#[test]
-// #[should_panic]
-fn provide_double_sided_liquidity_native_lp_token_expected_decimal_range_validation_fails() {
-    unimplemented!("todo")
-}
-
-#[test]
 fn provide_double_sided_liquidity_cw20_lp_token() {
     let setup = LPerTestSuite::new(false, 1_000_000, 2_000_000);
     let wasm = Wasm::new(&setup.inner.app);
@@ -810,4 +800,182 @@ fn test_not_enough_asset2_balance() {
         output_acc_balance.balances[0].denom,
         setup.inner.pool_native_liquidity_token
     );
+}
+
+#[test]
+fn provide_double_sided_liquidity_native_lp_token_validates_expected_decimal_range() {
+    let setup = LPerTestSuite::default();
+    let wasm = Wasm::new(&setup.inner.app);
+    let bank = Bank::new(&setup.inner.app);
+
+    // Get balances before providing liquidity
+    let input_acc_balance_before = bank
+        .query_all_balances(&QueryAllBalancesRequest {
+            address: setup.input_acc.clone(),
+            pagination: None,
+            resolve_denom: false,
+        })
+        .unwrap();
+
+    assert_eq!(input_acc_balance_before.balances.len(), 2);
+    assert!(input_acc_balance_before
+        .balances
+        .iter()
+        .any(|c| c.denom == setup.inner.pool_asset1));
+    assert!(input_acc_balance_before
+        .balances
+        .iter()
+        .any(|c| c.denom == setup.inner.pool_asset2));
+
+    wasm.execute::<ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>>(
+        &setup.lper_addr,
+        &ExecuteMsg::ProcessFunction(FunctionMsgs::ProvideDoubleSidedLiquidity {
+            expected_pool_ratio_range: Some(DecimalRange::new(
+                Decimal::from_ratio(1u128, 10u128),
+                Decimal::from_ratio(11u128, 10u128),
+            )),
+        }),
+        &[],
+        setup.inner.processor_acc(),
+    )
+    .unwrap();
+
+    // No balance should be left in the input account
+    let input_acc_balance_after = bank
+        .query_all_balances(&QueryAllBalancesRequest {
+            address: setup.input_acc.clone(),
+            pagination: None,
+            resolve_denom: false,
+        })
+        .unwrap();
+
+    assert_eq!(input_acc_balance_after.balances.len(), 0);
+
+    // Output account should have the LP tokens
+    let output_acc_balance = bank
+        .query_all_balances(&QueryAllBalancesRequest {
+            address: setup.output_acc.clone(),
+            pagination: None,
+            resolve_denom: false,
+        })
+        .unwrap();
+
+    assert_eq!(output_acc_balance.balances.len(), 1);
+    assert_eq!(
+        output_acc_balance.balances[0].denom,
+        setup.inner.pool_native_liquidity_token
+    );
+}
+
+#[test]
+#[should_panic(expected = "Value is not within the expected range")]
+fn provide_double_sided_liquidity_native_lp_token_expected_decimal_range_validation_fails() {
+    let setup = LPerTestSuite::default();
+    let wasm = Wasm::new(&setup.inner.app);
+
+    wasm.execute::<ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>>(
+        &setup.lper_addr,
+        &ExecuteMsg::ProcessFunction(FunctionMsgs::ProvideDoubleSidedLiquidity {
+            expected_pool_ratio_range: Some(DecimalRange::new(
+                Decimal::from_ratio(1u128, 10u128),
+                Decimal::from_ratio(2u128, 10u128),
+            )),
+        }),
+        &[],
+        setup.inner.processor_acc(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn provide_single_sided_liquidity_native_lp_token_validates_expected_decimal_range() {
+    let setup = LPerTestSuite::default();
+    let wasm = Wasm::new(&setup.inner.app);
+    let bank = Bank::new(&setup.inner.app);
+
+    // Get balances before providing liquidity
+    let input_acc_balance_before = bank
+        .query_all_balances(&QueryAllBalancesRequest {
+            address: setup.input_acc.clone(),
+            pagination: None,
+            resolve_denom: false,
+        })
+        .unwrap();
+
+    assert_eq!(input_acc_balance_before.balances.len(), 2);
+    assert!(input_acc_balance_before
+        .balances
+        .iter()
+        .any(|c| c.denom == setup.inner.pool_asset1));
+    assert!(input_acc_balance_before
+        .balances
+        .iter()
+        .any(|c| c.denom == setup.inner.pool_asset2));
+
+    wasm.execute::<ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>>(
+        &setup.lper_addr,
+        &ExecuteMsg::ProcessFunction(FunctionMsgs::ProvideSingleSidedLiquidity {
+            asset: setup.inner.pool_asset1.clone(),
+            limit: None,
+            expected_pool_ratio_range: Some(DecimalRange::new(
+                Decimal::from_ratio(1u128, 10u128),
+                Decimal::from_ratio(11u128, 10u128),
+            )),
+        }),
+        &[],
+        setup.inner.processor_acc(),
+    )
+    .unwrap();
+
+    // No balance should be left in the input account
+    let input_acc_balance_after = bank
+        .query_all_balances(&QueryAllBalancesRequest {
+            address: setup.input_acc.clone(),
+            pagination: None,
+            resolve_denom: false,
+        })
+        .unwrap();
+
+    assert_eq!(input_acc_balance_after.balances.len(), 1);
+    assert_eq!(
+        input_acc_balance_after.balances[0].denom,
+        setup.inner.pool_asset2
+    );
+
+    // Output account should have the LP tokens
+    let output_acc_balance = bank
+        .query_all_balances(&QueryAllBalancesRequest {
+            address: setup.output_acc.clone(),
+            pagination: None,
+            resolve_denom: false,
+        })
+        .unwrap();
+
+    assert_eq!(output_acc_balance.balances.len(), 1);
+    assert_eq!(
+        output_acc_balance.balances[0].denom,
+        setup.inner.pool_native_liquidity_token
+    );
+}
+
+#[test]
+#[should_panic(expected = "Value is not within the expected range")]
+fn provide_single_sided_liquidity_native_lp_token_expected_decimal_range_validation_fails() {
+    let setup = LPerTestSuite::default();
+    let wasm = Wasm::new(&setup.inner.app);
+
+    wasm.execute::<ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>>(
+        &setup.lper_addr,
+        &ExecuteMsg::ProcessFunction(FunctionMsgs::ProvideSingleSidedLiquidity {
+            asset: setup.inner.pool_asset1.clone(),
+            limit: None,
+            expected_pool_ratio_range: Some(DecimalRange::new(
+                Decimal::from_ratio(1u128, 10u128),
+                Decimal::from_ratio(2u128, 10u128),
+            )),
+        }),
+        &[],
+        setup.inner.processor_acc(),
+    )
+    .unwrap();
 }

--- a/contracts/libraries/astroport-withdrawer/schema/valence-astroport-withdrawer.json
+++ b/contracts/libraries/astroport-withdrawer/schema/valence-astroport-withdrawer.json
@@ -24,6 +24,24 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "LibraryAccountType": {
         "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
         "oneOf": [
@@ -96,9 +114,18 @@
       "LiquidityWithdrawerConfig": {
         "type": "object",
         "required": [
+          "asset_data",
           "pool_type"
         ],
         "properties": {
+          "asset_data": {
+            "description": "Denoms of the underlying assets to be withdrawn",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetData"
+              }
+            ]
+          },
           "pool_type": {
             "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
             "allOf": [
@@ -110,11 +137,122 @@
         },
         "additionalProperties": false
       },
+      "PairType": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PairType2": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "PoolType": {
-        "type": "string",
-        "enum": [
-          "native_lp_token",
-          "cw20_lp_token"
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native_lp_token"
+            ],
+            "properties": {
+              "native_lp_token": {
+                "$ref": "#/definitions/PairType"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20_lp_token"
+            ],
+            "properties": {
+              "cw20_lp_token": {
+                "$ref": "#/definitions/PairType2"
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       }
     }
@@ -243,6 +381,44 @@
           }
         ]
       },
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "DecimalRange": {
+        "type": "object",
+        "required": [
+          "max",
+          "min"
+        ],
+        "properties": {
+          "max": {
+            "$ref": "#/definitions/Decimal"
+          },
+          "min": {
+            "$ref": "#/definitions/Decimal"
+          }
+        },
+        "additionalProperties": false
+      },
       "Expiration": {
         "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
         "oneOf": [
@@ -300,6 +476,18 @@
             "properties": {
               "withdraw_liquidity": {
                 "type": "object",
+                "properties": {
+                  "expected_pool_ratio_range": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DecimalRange"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
                 "additionalProperties": false
               }
             },
@@ -397,9 +585,18 @@
       "LiquidityWithdrawerConfig": {
         "type": "object",
         "required": [
+          "asset_data",
           "pool_type"
         ],
         "properties": {
+          "asset_data": {
+            "description": "Denoms of the underlying assets to be withdrawn",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetData"
+              }
+            ]
+          },
           "pool_type": {
             "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
             "allOf": [
@@ -411,11 +608,122 @@
         },
         "additionalProperties": false
       },
+      "PairType": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PairType2": {
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "PoolType": {
-        "type": "string",
-        "enum": [
-          "native_lp_token",
-          "cw20_lp_token"
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native_lp_token"
+            ],
+            "properties": {
+              "native_lp_token": {
+                "$ref": "#/definitions/PairType"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20_lp_token"
+            ],
+            "properties": {
+              "cw20_lp_token": {
+                "$ref": "#/definitions/PairType2"
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       },
       "Timestamp": {
@@ -527,12 +835,39 @@
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         },
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "LiquidityWithdrawerConfig": {
           "type": "object",
           "required": [
+            "asset_data",
             "pool_type"
           ],
           "properties": {
+            "asset_data": {
+              "description": "Denoms of the underlying assets to be withdrawn",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AssetData"
+                }
+              ]
+            },
             "pool_type": {
               "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
               "allOf": [
@@ -544,11 +879,122 @@
           },
           "additionalProperties": false
         },
+        "PairType": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PairType2": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "PoolType": {
-          "type": "string",
-          "enum": [
-            "native_lp_token",
-            "cw20_lp_token"
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "native_lp_token"
+              ],
+              "properties": {
+                "native_lp_token": {
+                  "$ref": "#/definitions/PairType"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cw20_lp_token"
+              ],
+              "properties": {
+                "cw20_lp_token": {
+                  "$ref": "#/definitions/PairType2"
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         }
       }
@@ -585,6 +1031,24 @@
       },
       "additionalProperties": false,
       "definitions": {
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "LibraryAccountType": {
           "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
           "oneOf": [
@@ -633,9 +1097,18 @@
         "LiquidityWithdrawerConfig": {
           "type": "object",
           "required": [
+            "asset_data",
             "pool_type"
           ],
           "properties": {
+            "asset_data": {
+              "description": "Denoms of the underlying assets to be withdrawn",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AssetData"
+                }
+              ]
+            },
             "pool_type": {
               "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
               "allOf": [
@@ -647,11 +1120,122 @@
           },
           "additionalProperties": false
         },
+        "PairType": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PairType2": {
+          "oneOf": [
+            {
+              "description": "XYK pair type",
+              "type": "object",
+              "required": [
+                "xyk"
+              ],
+              "properties": {
+                "xyk": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Stable pair type",
+              "type": "object",
+              "required": [
+                "stable"
+              ],
+              "properties": {
+                "stable": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Custom pair type",
+              "type": "object",
+              "required": [
+                "custom"
+              ],
+              "properties": {
+                "custom": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "PoolType": {
-          "type": "string",
-          "enum": [
-            "native_lp_token",
-            "cw20_lp_token"
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "native_lp_token"
+              ],
+              "properties": {
+                "native_lp_token": {
+                  "$ref": "#/definitions/PairType"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "cw20_lp_token"
+              ],
+              "properties": {
+                "cw20_lp_token": {
+                  "$ref": "#/definitions/PairType2"
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         }
       }

--- a/contracts/libraries/astroport-withdrawer/src/contract.rs
+++ b/contracts/libraries/astroport-withdrawer/src/contract.rs
@@ -56,11 +56,11 @@ mod execute {
 }
 
 mod functions {
-    use cosmwasm_std::{CosmosMsg, DepsMut, Env, MessageInfo, Response};
-    use valence_astroport_utils::{
-        decimal_range::DecimalRange, get_pool_asset_amounts, query_pool, PoolType,
+    use cosmwasm_std::{CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response};
+    use valence_astroport_utils::{get_pool_asset_amounts, query_pool, PoolType};
+    use valence_library_utils::{
+        error::LibraryError, execute_on_behalf_of, liquidity_utils::DecimalRange,
     };
-    use valence_library_utils::{error::LibraryError, execute_on_behalf_of};
 
     use crate::{
         astroport_cw20, astroport_native,
@@ -104,10 +104,10 @@ mod functions {
 
             // Get the pool asset ratios
             let pool_asset_ratios =
-                cosmwasm_std::Decimal::checked_from_ratio(pool_asset1_balance, pool_asset2_balance)
+                Decimal::checked_from_ratio(pool_asset1_balance, pool_asset2_balance)
                     .map_err(|e| LibraryError::ExecutionError(e.to_string()))?;
 
-            range.is_within_range(pool_asset_ratios)?;
+            range.contains(pool_asset_ratios)?;
         }
 
         let msgs = create_withdraw_liquidity_msgs(&deps, &cfg)?;

--- a/contracts/libraries/astroport-withdrawer/src/msg.rs
+++ b/contracts/libraries/astroport-withdrawer/src/msg.rs
@@ -1,9 +1,12 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
-use valence_astroport_utils::{decimal_range::DecimalRange, AssetData, PoolType};
+use valence_astroport_utils::PoolType;
 use valence_library_utils::{
-    error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
+    error::LibraryError,
+    liquidity_utils::{AssetData, DecimalRange},
+    msg::LibraryConfigValidation,
+    LibraryAccountType,
 };
 use valence_macros::{valence_library_query, ValenceLibraryInterface};
 

--- a/contracts/libraries/astroport-withdrawer/src/msg.rs
+++ b/contracts/libraries/astroport-withdrawer/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Deps, DepsMut};
 use cw_ownable::cw_ownable_query;
+use valence_astroport_utils::{decimal_range::DecimalRange, AssetData, PoolType};
 use valence_library_utils::{
     error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
 };
@@ -8,7 +9,9 @@ use valence_macros::{valence_library_query, ValenceLibraryInterface};
 
 #[cw_serde]
 pub enum FunctionMsgs {
-    WithdrawLiquidity {},
+    WithdrawLiquidity {
+        expected_pool_ratio_range: Option<DecimalRange>,
+    },
 }
 
 #[valence_library_query]
@@ -52,15 +55,13 @@ impl LibraryConfig {
 
 #[cw_serde]
 pub struct LiquidityWithdrawerConfig {
-    /// Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get.
-    /// We also provide the PairType structure of the right Astroport version that we are going to use for each scenario
+    /// Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens,
+    /// so we specify here what kind of token we are going to get.
+    /// We also provide the PairType structure of the right Astroport version that we are
+    /// going to use for each scenario
     pub pool_type: PoolType,
-}
-
-#[cw_serde]
-pub enum PoolType {
-    NativeLpToken,
-    Cw20LpToken,
+    /// Denoms of the underlying assets to be withdrawn
+    pub asset_data: AssetData,
 }
 
 #[cw_serde]

--- a/contracts/libraries/astroport-withdrawer/src/tests.rs
+++ b/contracts/libraries/astroport-withdrawer/src/tests.rs
@@ -8,8 +8,7 @@ use neutron_test_tube::{
     Account, Bank, Module, Wasm,
 };
 use valence_astroport_utils::{
-    decimal_range::DecimalRange,
-    suite::{AstroportTestAppBuilder, AstroportTestAppSetup, FEE_DENOM},
+    suite::{AstroportTestAppBuilder, AstroportTestAppSetup},
     AssetData, PoolType,
 };
 use valence_library_utils::{

--- a/contracts/libraries/astroport-withdrawer/src/tests.rs
+++ b/contracts/libraries/astroport-withdrawer/src/tests.rs
@@ -8,12 +8,12 @@ use neutron_test_tube::{
     Account, Bank, Module, Wasm,
 };
 use valence_astroport_utils::{
-    decimal_range::DecimalRange,
     suite::{AstroportTestAppBuilder, AstroportTestAppSetup},
-    AssetData, PoolType,
+    PoolType,
 };
 use valence_library_utils::{
     error::{LibraryError, UnauthorizedReason},
+    liquidity_utils::{AssetData, DecimalRange},
     msg::{ExecuteMsg, InstantiateMsg},
 };
 

--- a/contracts/libraries/osmosis-gamm-lper/schema/valence-osmosis-gamm-lper.json
+++ b/contracts/libraries/osmosis-gamm-lper/schema/valence-osmosis-gamm-lper.json
@@ -24,6 +24,24 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "LibraryAccountType": {
         "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
         "oneOf": [
@@ -92,16 +110,12 @@
       "LiquidityProviderConfig": {
         "type": "object",
         "required": [
-          "pool_asset_1",
-          "pool_asset_2",
+          "asset_data",
           "pool_id"
         ],
         "properties": {
-          "pool_asset_1": {
-            "type": "string"
-          },
-          "pool_asset_2": {
-            "type": "string"
+          "asset_data": {
+            "$ref": "#/definitions/AssetData"
           },
           "pool_id": {
             "type": "integer",
@@ -236,6 +250,24 @@
             ]
           }
         ]
+      },
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "Decimal": {
         "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
@@ -452,16 +484,12 @@
       "LiquidityProviderConfig": {
         "type": "object",
         "required": [
-          "pool_asset_1",
-          "pool_asset_2",
+          "asset_data",
           "pool_id"
         ],
         "properties": {
-          "pool_asset_1": {
-            "type": "string"
-          },
-          "pool_asset_2": {
-            "type": "string"
+          "asset_data": {
+            "$ref": "#/definitions/AssetData"
           },
           "pool_id": {
             "type": "integer",
@@ -580,19 +608,33 @@
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         },
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "LiquidityProviderConfig": {
           "type": "object",
           "required": [
-            "pool_asset_1",
-            "pool_asset_2",
+            "asset_data",
             "pool_id"
           ],
           "properties": {
-            "pool_asset_1": {
-              "type": "string"
-            },
-            "pool_asset_2": {
-              "type": "string"
+            "asset_data": {
+              "$ref": "#/definitions/AssetData"
             },
             "pool_id": {
               "type": "integer",
@@ -632,6 +674,24 @@
       },
       "additionalProperties": false,
       "definitions": {
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "LibraryAccountType": {
           "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
           "oneOf": [
@@ -680,16 +740,12 @@
         "LiquidityProviderConfig": {
           "type": "object",
           "required": [
-            "pool_asset_1",
-            "pool_asset_2",
+            "asset_data",
             "pool_id"
           ],
           "properties": {
-            "pool_asset_1": {
-              "type": "string"
-            },
-            "pool_asset_2": {
-              "type": "string"
+            "asset_data": {
+              "$ref": "#/definitions/AssetData"
             },
             "pool_id": {
               "type": "integer",

--- a/contracts/libraries/osmosis-gamm-lper/src/contract.rs
+++ b/contracts/libraries/osmosis-gamm-lper/src/contract.rs
@@ -13,11 +13,11 @@ use osmosis_std::{
 use valence_library_utils::{
     error::LibraryError,
     execute_on_behalf_of,
+    liquidity_utils::DecimalRange,
     msg::{ExecuteMsg, InstantiateMsg},
 };
 use valence_osmosis_utils::utils::{
     gamm_utils::ValenceLiquidPooler, get_provide_liquidity_msg, get_provide_ss_liquidity_msg,
-    DecimalRange,
 };
 
 use crate::msg::{Config, FunctionMsgs, LibraryConfig, LibraryConfigUpdate, QueryMsg};
@@ -87,8 +87,8 @@ fn provide_single_sided_liquidity(
     let pool = pm_querier.query_pool_config(cfg.lp_config.pool_id)?;
     let pool_ratio = pm_querier.query_spot_price(
         cfg.lp_config.pool_id,
-        cfg.lp_config.pool_asset_1,
-        cfg.lp_config.pool_asset_2,
+        cfg.lp_config.asset_data.asset1,
+        cfg.lp_config.asset_data.asset2,
     )?;
 
     // assert the spot price to be within our expectations,
@@ -144,17 +144,17 @@ pub fn provide_double_sided_liquidity(
     // first we assert the input account balances
     let bal_asset_1 = deps
         .querier
-        .query_balance(&cfg.input_addr, &cfg.lp_config.pool_asset_1)?;
+        .query_balance(&cfg.input_addr, &cfg.lp_config.asset_data.asset1)?;
     let bal_asset_2 = deps
         .querier
-        .query_balance(&cfg.input_addr, &cfg.lp_config.pool_asset_2)?;
+        .query_balance(&cfg.input_addr, &cfg.lp_config.asset_data.asset2)?;
 
     let pm_querier = PoolmanagerQuerier::new(&deps.querier);
 
     let pool_ratio = pm_querier.query_spot_price(
         cfg.lp_config.pool_id,
-        cfg.lp_config.pool_asset_1,
-        cfg.lp_config.pool_asset_2,
+        cfg.lp_config.asset_data.asset1,
+        cfg.lp_config.asset_data.asset2,
     )?;
     let pool = pm_querier.query_pool_config(cfg.lp_config.pool_id)?;
 

--- a/contracts/libraries/osmosis-gamm-lper/src/msg.rs
+++ b/contracts/libraries/osmosis-gamm-lper/src/msg.rs
@@ -4,10 +4,13 @@ use cosmwasm_std::{ensure, Addr, Deps, DepsMut, Uint128, Uint64};
 use cw_ownable::cw_ownable_query;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::PoolmanagerQuerier;
 use valence_library_utils::{
-    error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
+    error::LibraryError,
+    liquidity_utils::{AssetData, DecimalRange},
+    msg::LibraryConfigValidation,
+    LibraryAccountType,
 };
 use valence_macros::{valence_library_query, ValenceLibraryInterface};
-use valence_osmosis_utils::utils::{gamm_utils::ValenceLiquidPooler, DecimalRange};
+use valence_osmosis_utils::utils::gamm_utils::ValenceLiquidPooler;
 
 #[cw_serde]
 pub enum FunctionMsgs {
@@ -30,8 +33,7 @@ pub enum QueryMsg {}
 #[cw_serde]
 pub struct LiquidityProviderConfig {
     pub pool_id: u64,
-    pub pool_asset_1: String,
-    pub pool_asset_2: String,
+    pub asset_data: AssetData,
 }
 
 #[cw_serde]
@@ -92,10 +94,10 @@ impl LibraryConfigValidation<Config> for LibraryConfig {
         let (mut asset_1_found, mut asset_2_found) = (false, false);
         for pool_asset in pool.pool_assets {
             if let Some(asset) = pool_asset.token {
-                if self.lp_config.pool_asset_1 == asset.denom {
+                if self.lp_config.asset_data.asset1 == asset.denom {
                     asset_1_found = true;
                 }
-                if self.lp_config.pool_asset_2 == asset.denom {
+                if self.lp_config.asset_data.asset2 == asset.denom {
                     asset_2_found = true;
                 }
             }

--- a/contracts/libraries/osmosis-gamm-lper/src/testing/test_suite.rs
+++ b/contracts/libraries/osmosis-gamm-lper/src/testing/test_suite.rs
@@ -10,11 +10,13 @@ use osmosis_test_tube::{
     },
     Account, Bank, ExecuteResponse, Module, Wasm,
 };
-use valence_library_utils::msg::{ExecuteMsg, InstantiateMsg};
+use valence_library_utils::{
+    liquidity_utils::{AssetData, DecimalRange},
+    msg::{ExecuteMsg, InstantiateMsg},
+};
 use valence_osmosis_utils::{
     suite::{OsmosisTestAppBuilder, OsmosisTestAppSetup, OSMO_DENOM, TEST_DENOM},
     testing::balancer::BalancerPool,
-    utils::DecimalRange,
 };
 
 use crate::msg::{FunctionMsgs, LibraryConfig, LibraryConfigUpdate, LiquidityProviderConfig};
@@ -60,8 +62,10 @@ impl LPerTestSuite {
                 output_acc.as_str(),
                 lp_config.unwrap_or(LiquidityProviderConfig {
                     pool_id: inner.pool_cfg.pool_id.u64(),
-                    pool_asset_1: inner.pool_cfg.pool_asset1.to_string(),
-                    pool_asset_2: inner.pool_cfg.pool_asset2.to_string(),
+                    asset_data: AssetData {
+                        asset1: inner.pool_cfg.pool_asset1.to_string(),
+                        asset2: inner.pool_cfg.pool_asset2.to_string(),
+                    },
                 }),
             ),
         };

--- a/contracts/libraries/osmosis-gamm-lper/src/testing/tests.rs
+++ b/contracts/libraries/osmosis-gamm-lper/src/testing/tests.rs
@@ -2,7 +2,8 @@ use std::str::FromStr;
 
 use cosmwasm_std::{coin, Decimal};
 
-use valence_osmosis_utils::{suite::OSMO_DENOM, utils::DecimalRange};
+use valence_library_utils::liquidity_utils::{AssetData, DecimalRange};
+use valence_osmosis_utils::suite::OSMO_DENOM;
 
 use crate::msg::LiquidityProviderConfig;
 
@@ -15,8 +16,10 @@ fn test_provide_liquidity_fails_validation() {
         vec![coin(1_000_000u128, OSMO_DENOM)],
         Some(LiquidityProviderConfig {
             pool_id: 1,
-            pool_asset_1: OSMO_DENOM.to_string(),
-            pool_asset_2: "random_denom".to_string(),
+            asset_data: AssetData {
+                asset1: OSMO_DENOM.to_string(),
+                asset2: "random_denom".to_string(),
+            },
         }),
     );
 }
@@ -26,10 +29,10 @@ fn test_provide_liquidity_fails_validation() {
 fn test_provide_two_sided_liquidity_out_of_range() {
     let setup = LPerTestSuite::default();
 
-    setup.provide_two_sided_liquidity(Some(DecimalRange::from((
+    setup.provide_two_sided_liquidity(Some(DecimalRange::new(
         Decimal::from_str("0.0009").unwrap(),
         Decimal::from_str("0.1111").unwrap(),
-    ))));
+    )));
 }
 
 #[test]
@@ -60,10 +63,10 @@ fn test_provide_two_sided_liquidity_valid_range() {
     assert_eq!(input_bals.len(), 2);
     assert_eq!(output_bals.len(), 0);
 
-    setup.provide_two_sided_liquidity(Some(DecimalRange::from((
+    setup.provide_two_sided_liquidity(Some(DecimalRange::new(
         Decimal::from_str("0.9").unwrap(),
         Decimal::from_str("1.1").unwrap(),
-    ))));
+    )));
 
     let input_bals = setup.query_all_balances(&setup.input_acc).unwrap();
     let output_bals = setup.query_all_balances(&setup.output_acc).unwrap();
@@ -79,10 +82,10 @@ fn test_provide_single_sided_liquidity_out_of_range() {
     setup.provide_single_sided_liquidity(
         OSMO_DENOM,
         10_000u128.into(),
-        Some(DecimalRange::from((
+        Some(DecimalRange::new(
             Decimal::from_str("0.00001").unwrap(),
             Decimal::from_str("0.11111").unwrap(),
-        ))),
+        )),
     );
 }
 
@@ -117,10 +120,10 @@ fn test_provide_single_sided_liquidity_valid_range() {
     setup.provide_single_sided_liquidity(
         OSMO_DENOM,
         10_000u128.into(),
-        Some(DecimalRange::from((
+        Some(DecimalRange::new(
             Decimal::from_str("0.9").unwrap(),
             Decimal::from_str("1.1").unwrap(),
-        ))),
+        )),
     );
 
     let input_bals = setup.query_all_balances(&setup.input_acc).unwrap();

--- a/contracts/libraries/osmosis-gamm-withdrawer/schema/valence-osmosis-gamm-withdrawer.json
+++ b/contracts/libraries/osmosis-gamm-withdrawer/schema/valence-osmosis-gamm-withdrawer.json
@@ -24,6 +24,24 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "LibraryAccountType": {
         "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
         "oneOf": [
@@ -92,9 +110,13 @@
       "LiquidityWithdrawerConfig": {
         "type": "object",
         "required": [
+          "asset_data",
           "pool_id"
         ],
         "properties": {
+          "asset_data": {
+            "$ref": "#/definitions/AssetData"
+          },
           "pool_id": {
             "type": "integer",
             "format": "uint64",
@@ -229,6 +251,44 @@
           }
         ]
       },
+      "AssetData": {
+        "type": "object",
+        "required": [
+          "asset1",
+          "asset2"
+        ],
+        "properties": {
+          "asset1": {
+            "description": "Denom of the first asset",
+            "type": "string"
+          },
+          "asset2": {
+            "description": "Denom of the second asset",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "DecimalRange": {
+        "type": "object",
+        "required": [
+          "max",
+          "min"
+        ],
+        "properties": {
+          "max": {
+            "$ref": "#/definitions/Decimal"
+          },
+          "min": {
+            "$ref": "#/definitions/Decimal"
+          }
+        },
+        "additionalProperties": false
+      },
       "Expiration": {
         "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
         "oneOf": [
@@ -286,6 +346,18 @@
             "properties": {
               "withdraw_liquidity": {
                 "type": "object",
+                "properties": {
+                  "expected_spot_price": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DecimalRange"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
                 "additionalProperties": false
               }
             },
@@ -377,9 +449,13 @@
       "LiquidityWithdrawerConfig": {
         "type": "object",
         "required": [
+          "asset_data",
           "pool_id"
         ],
         "properties": {
+          "asset_data": {
+            "$ref": "#/definitions/AssetData"
+          },
           "pool_id": {
             "type": "integer",
             "format": "uint64",
@@ -493,12 +569,34 @@
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         },
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "LiquidityWithdrawerConfig": {
           "type": "object",
           "required": [
+            "asset_data",
             "pool_id"
           ],
           "properties": {
+            "asset_data": {
+              "$ref": "#/definitions/AssetData"
+            },
             "pool_id": {
               "type": "integer",
               "format": "uint64",
@@ -537,6 +635,24 @@
       },
       "additionalProperties": false,
       "definitions": {
+        "AssetData": {
+          "type": "object",
+          "required": [
+            "asset1",
+            "asset2"
+          ],
+          "properties": {
+            "asset1": {
+              "description": "Denom of the first asset",
+              "type": "string"
+            },
+            "asset2": {
+              "description": "Denom of the second asset",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "LibraryAccountType": {
           "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
           "oneOf": [
@@ -585,9 +701,13 @@
         "LiquidityWithdrawerConfig": {
           "type": "object",
           "required": [
+            "asset_data",
             "pool_id"
           ],
           "properties": {
+            "asset_data": {
+              "$ref": "#/definitions/AssetData"
+            },
             "pool_id": {
               "type": "integer",
               "format": "uint64",

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/contract.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/contract.rs
@@ -78,15 +78,16 @@ fn try_withdraw_liquidity(
 ) -> Result<Response, LibraryError> {
     let pm_querier = PoolmanagerQuerier::new(&deps.querier);
 
-    let pool_ratio = pm_querier.query_spot_price(
-        cfg.lw_config.pool_id,
-        cfg.lw_config.pool_asset_1,
-        cfg.lw_config.pool_asset_2,
-    )?;
-
     // assert the spot price to be within our expectations,
     // if expectations are set.
     if let Some(acceptable_spot_price_range) = expected_spot_price {
+        let pool_ratio = pm_querier.query_spot_price(
+            cfg.lw_config.pool_id,
+            cfg.lw_config.pool_asset_1,
+            cfg.lw_config.pool_asset_2,
+        )?;
+
+        // perform the spot price validation
         acceptable_spot_price_range.contains(pool_ratio)?;
     }
 

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/contract.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/contract.rs
@@ -16,11 +16,10 @@ use osmosis_std::{
 use valence_library_utils::{
     error::LibraryError,
     execute_on_behalf_of,
+    liquidity_utils::DecimalRange,
     msg::{ExecuteMsg, InstantiateMsg},
 };
-use valence_osmosis_utils::utils::{
-    gamm_utils::ValenceLiquidPooler, get_withdraw_liquidity_msg, DecimalRange,
-};
+use valence_osmosis_utils::utils::{gamm_utils::ValenceLiquidPooler, get_withdraw_liquidity_msg};
 
 use crate::msg::{Config, FunctionMsgs, LibraryConfig, LibraryConfigUpdate, QueryMsg};
 
@@ -83,8 +82,8 @@ fn try_withdraw_liquidity(
     if let Some(acceptable_spot_price_range) = expected_spot_price {
         let pool_ratio = pm_querier.query_spot_price(
             cfg.lw_config.pool_id,
-            cfg.lw_config.pool_asset_1,
-            cfg.lw_config.pool_asset_2,
+            cfg.lw_config.asset_data.asset1,
+            cfg.lw_config.asset_data.asset2,
         )?;
 
         // perform the spot price validation

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/contract.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/contract.rs
@@ -18,7 +18,9 @@ use valence_library_utils::{
     execute_on_behalf_of,
     msg::{ExecuteMsg, InstantiateMsg},
 };
-use valence_osmosis_utils::utils::{gamm_utils::ValenceLiquidPooler, get_withdraw_liquidity_msg};
+use valence_osmosis_utils::utils::{
+    gamm_utils::ValenceLiquidPooler, get_withdraw_liquidity_msg, DecimalRange,
+};
 
 use crate::msg::{Config, FunctionMsgs, LibraryConfig, LibraryConfigUpdate, QueryMsg};
 
@@ -63,12 +65,30 @@ pub fn process_function(
     cfg: Config,
 ) -> Result<Response, LibraryError> {
     match msg {
-        FunctionMsgs::WithdrawLiquidity {} => try_withdraw_liquidity(deps, cfg),
+        FunctionMsgs::WithdrawLiquidity {
+            expected_spot_price,
+        } => try_withdraw_liquidity(deps, cfg, expected_spot_price),
     }
 }
 
-fn try_withdraw_liquidity(deps: DepsMut, cfg: Config) -> Result<Response, LibraryError> {
+fn try_withdraw_liquidity(
+    deps: DepsMut,
+    cfg: Config,
+    expected_spot_price: Option<DecimalRange>,
+) -> Result<Response, LibraryError> {
     let pm_querier = PoolmanagerQuerier::new(&deps.querier);
+
+    let pool_ratio = pm_querier.query_spot_price(
+        cfg.lw_config.pool_id,
+        cfg.lw_config.pool_asset_1,
+        cfg.lw_config.pool_asset_2,
+    )?;
+
+    // assert the spot price to be within our expectations,
+    // if expectations are set.
+    if let Some(acceptable_spot_price_range) = expected_spot_price {
+        acceptable_spot_price_range.contains(pool_ratio)?;
+    }
 
     // get the LP token balance of configured input account
     let lp_token = pm_querier.query_pool_liquidity_token(cfg.lw_config.pool_id)?;

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/msg.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/msg.rs
@@ -5,10 +5,12 @@ use cw_ownable::cw_ownable_query;
 
 use osmosis_std::types::osmosis::poolmanager::v1beta1::PoolmanagerQuerier;
 use valence_library_utils::{
-    error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
+    error::LibraryError,
+    liquidity_utils::{AssetData, DecimalRange},
+    msg::LibraryConfigValidation,
+    LibraryAccountType,
 };
 use valence_macros::{valence_library_query, ValenceLibraryInterface};
-use valence_osmosis_utils::utils::DecimalRange;
 
 #[cw_serde]
 pub enum FunctionMsgs {
@@ -26,8 +28,7 @@ pub enum QueryMsg {}
 #[cw_serde]
 pub struct LiquidityWithdrawerConfig {
     pub pool_id: u64,
-    pub pool_asset_1: String,
-    pub pool_asset_2: String,
+    pub asset_data: AssetData,
 }
 
 #[cw_serde]

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/msg.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/msg.rs
@@ -8,10 +8,13 @@ use valence_library_utils::{
     error::LibraryError, msg::LibraryConfigValidation, LibraryAccountType,
 };
 use valence_macros::{valence_library_query, ValenceLibraryInterface};
+use valence_osmosis_utils::utils::DecimalRange;
 
 #[cw_serde]
 pub enum FunctionMsgs {
-    WithdrawLiquidity {},
+    WithdrawLiquidity {
+        expected_spot_price: Option<DecimalRange>,
+    },
 }
 
 #[valence_library_query]
@@ -23,6 +26,8 @@ pub enum QueryMsg {}
 #[cw_serde]
 pub struct LiquidityWithdrawerConfig {
     pub pool_id: u64,
+    pub pool_asset_1: String,
+    pub pool_asset_2: String,
 }
 
 #[cw_serde]

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/testing/test_suite.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/testing/test_suite.rs
@@ -15,6 +15,7 @@ use valence_library_utils::msg::{ExecuteMsg, InstantiateMsg};
 use valence_osmosis_utils::{
     suite::{OsmosisTestAppBuilder, OsmosisTestAppSetup},
     testing::balancer::BalancerPool,
+    utils::DecimalRange,
 };
 
 use crate::msg::{FunctionMsgs, LibraryConfig, LibraryConfigUpdate, LiquidityWithdrawerConfig};
@@ -114,13 +115,16 @@ impl LPerTestSuite {
         try_proto_to_cosmwasm_coins(resp.balances)
     }
 
-    pub fn withdraw_liquidity(&self) -> ExecuteResponse<MsgExecuteContractResponse> {
+    pub fn withdraw_liquidity(
+        &self,
+        expected_spot_price: Option<DecimalRange>,
+    ) -> ExecuteResponse<MsgExecuteContractResponse> {
         let wasm = Wasm::new(&self.inner.app);
 
         wasm.execute::<ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>>(
             &self.lp_withdrawer_addr,
             &ExecuteMsg::ProcessFunction(FunctionMsgs::WithdrawLiquidity {
-                expected_spot_price: None,
+                expected_spot_price,
             }),
             &[],
             self.inner.processor_acc(),

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/testing/test_suite.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/testing/test_suite.rs
@@ -53,6 +53,8 @@ impl LPerTestSuite {
                 output_acc.as_str(),
                 lw_config.unwrap_or(LiquidityWithdrawerConfig {
                     pool_id: inner.pool_cfg.pool_id.u64(),
+                    pool_asset_1: inner.pool_cfg.pool_asset1.to_string(),
+                    pool_asset_2: inner.pool_cfg.pool_asset2.to_string(),
                 }),
             ),
         };
@@ -117,7 +119,9 @@ impl LPerTestSuite {
 
         wasm.execute::<ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>>(
             &self.lp_withdrawer_addr,
-            &ExecuteMsg::ProcessFunction(FunctionMsgs::WithdrawLiquidity {}),
+            &ExecuteMsg::ProcessFunction(FunctionMsgs::WithdrawLiquidity {
+                expected_spot_price: None,
+            }),
             &[],
             self.inner.processor_acc(),
         )

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/testing/test_suite.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/testing/test_suite.rs
@@ -11,11 +11,13 @@ use osmosis_test_tube::{
     },
     Account, Bank, ExecuteResponse, Module, Wasm,
 };
-use valence_library_utils::msg::{ExecuteMsg, InstantiateMsg};
+use valence_library_utils::{
+    liquidity_utils::{AssetData, DecimalRange},
+    msg::{ExecuteMsg, InstantiateMsg},
+};
 use valence_osmosis_utils::{
     suite::{OsmosisTestAppBuilder, OsmosisTestAppSetup},
     testing::balancer::BalancerPool,
-    utils::DecimalRange,
 };
 
 use crate::msg::{FunctionMsgs, LibraryConfig, LibraryConfigUpdate, LiquidityWithdrawerConfig};
@@ -54,8 +56,10 @@ impl LPerTestSuite {
                 output_acc.as_str(),
                 lw_config.unwrap_or(LiquidityWithdrawerConfig {
                     pool_id: inner.pool_cfg.pool_id.u64(),
-                    pool_asset_1: inner.pool_cfg.pool_asset1.to_string(),
-                    pool_asset_2: inner.pool_cfg.pool_asset2.to_string(),
+                    asset_data: AssetData {
+                        asset1: inner.pool_cfg.pool_asset1.to_string(),
+                        asset2: inner.pool_cfg.pool_asset2.to_string(),
+                    },
                 }),
             ),
         };

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/testing/tests.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/testing/tests.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{coin, Decimal};
-use valence_osmosis_utils::utils::DecimalRange;
+use valence_library_utils::liquidity_utils::DecimalRange;
 
 use super::test_suite::LPerTestSuite;
 
@@ -63,10 +63,10 @@ fn test_withdraw_liquidity_pool_ratio_validation_fails() {
     assert_eq!(pre_lp_output_bals.len(), 0);
 
     // set the expected spot price to one that does not contain the pool ratio (1.0)
-    let expected_spot_price = DecimalRange::from((
+    let expected_spot_price = DecimalRange::new(
         Decimal::from_ratio(15u128, 1u128),
         Decimal::from_ratio(20u128, 1u128),
-    ));
+    );
 
     suite.withdraw_liquidity(Some(expected_spot_price));
 }
@@ -77,10 +77,10 @@ fn test_withdraw_liquidity_pool_ratio_validation_succeeds() {
     let suite = LPerTestSuite::new(lp_token_amt, None);
 
     // set the expected spot price to (0.1, 2.0)
-    let expected_spot_price = DecimalRange::from((
+    let expected_spot_price = DecimalRange::new(
         Decimal::from_ratio(1u128, 10u128),
         Decimal::from_ratio(2u128, 1u128),
-    ));
+    );
 
     // withdraw the liquidity with price range expectations that should pass
     suite.withdraw_liquidity(Some(expected_spot_price));

--- a/contracts/libraries/osmosis-gamm-withdrawer/src/testing/tests.rs
+++ b/contracts/libraries/osmosis-gamm-withdrawer/src/testing/tests.rs
@@ -1,9 +1,10 @@
-use cosmwasm_std::coin;
+use cosmwasm_std::{coin, Decimal};
+use valence_osmosis_utils::utils::DecimalRange;
 
 use super::test_suite::LPerTestSuite;
 
 #[test]
-fn test_withdraw_liquidity_happy() {
+fn test_withdraw_liquidity_no_range_happy() {
     let lp_token_amt = 50000000000000000000;
     let suite = LPerTestSuite::new(lp_token_amt, None);
 
@@ -20,7 +21,7 @@ fn test_withdraw_liquidity_happy() {
     assert_eq!(pre_lp_output_bals.len(), 0);
 
     // withdraw the liquidity
-    suite.withdraw_liquidity();
+    suite.withdraw_liquidity(None);
 
     let post_lp_input_bals = suite.query_all_balances(&suite.input_acc).unwrap();
     let post_lp_output_bals = suite.query_all_balances(&suite.output_acc).unwrap();
@@ -33,12 +34,62 @@ fn test_withdraw_liquidity_happy() {
 
 #[test]
 #[should_panic(expected = "input account must have LP tokens to withdraw")]
-fn test_withdraw_liquidity_without_lp_tokens() {
+fn test_withdraw_liquidity_no_range_without_lp_tokens() {
     let suite = LPerTestSuite::new(0, None);
 
     let pre_lp_input_bals = suite.query_all_balances(&suite.input_acc).unwrap();
     assert_eq!(pre_lp_input_bals, vec![]);
 
     // trying to withdraw liquidity without lp tokens should panic
-    suite.withdraw_liquidity();
+    suite.withdraw_liquidity(None);
+}
+
+#[test]
+#[should_panic(expected = "Value is not within the expected range")]
+fn test_withdraw_liquidity_pool_ratio_validation_fails() {
+    let lp_token_amt = 50000000000000000000;
+    let suite = LPerTestSuite::new(lp_token_amt, None);
+
+    let pre_lp_input_bals = suite.query_all_balances(&suite.input_acc).unwrap();
+    let pre_lp_output_bals = suite.query_all_balances(&suite.output_acc).unwrap();
+
+    assert_eq!(
+        pre_lp_input_bals,
+        vec![coin(
+            lp_token_amt,
+            suite.inner.pool_cfg.pool_liquidity_token.to_string()
+        )]
+    );
+    assert_eq!(pre_lp_output_bals.len(), 0);
+
+    // set the expected spot price to one that does not contain the pool ratio (1.0)
+    let expected_spot_price = DecimalRange::from((
+        Decimal::from_ratio(15u128, 1u128),
+        Decimal::from_ratio(20u128, 1u128),
+    ));
+
+    suite.withdraw_liquidity(Some(expected_spot_price));
+}
+
+#[test]
+fn test_withdraw_liquidity_pool_ratio_validation_succeeds() {
+    let lp_token_amt = 50000000000000000000;
+    let suite = LPerTestSuite::new(lp_token_amt, None);
+
+    // set the expected spot price to (0.1, 2.0)
+    let expected_spot_price = DecimalRange::from((
+        Decimal::from_ratio(1u128, 10u128),
+        Decimal::from_ratio(2u128, 1u128),
+    ));
+
+    // withdraw the liquidity with price range expectations that should pass
+    suite.withdraw_liquidity(Some(expected_spot_price));
+
+    let post_lp_input_bals = suite.query_all_balances(&suite.input_acc).unwrap();
+    let post_lp_output_bals = suite.query_all_balances(&suite.output_acc).unwrap();
+
+    // assert that input account no longer has any tokens,
+    // and that the output account now has two tokens
+    assert_eq!(post_lp_input_bals.len(), 0);
+    assert_eq!(post_lp_output_bals.len(), 2);
 }

--- a/local-interchaintest/examples/osmo_gamm.rs
+++ b/local-interchaintest/examples/osmo_gamm.rs
@@ -110,7 +110,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let gamm_lwer_config = valence_osmosis_gamm_withdrawer::msg::LibraryConfig {
         input_addr: gamm_output_acc.clone(),
         output_addr: final_output_acc.clone(),
-        lw_config: valence_osmosis_gamm_withdrawer::msg::LiquidityWithdrawerConfig { pool_id },
+        lw_config: valence_osmosis_gamm_withdrawer::msg::LiquidityWithdrawerConfig {
+            pool_id,
+            pool_asset_2: OSMOSIS_CHAIN_DENOM.to_string(),
+            pool_asset_1: ntrn_on_osmo_denom.to_string(),
+        },
     };
 
     let gamm_lper_library = builder.add_library(LibraryInfo::new(
@@ -374,7 +378,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let lw_message = ProcessorMessage::CosmwasmExecuteMsg {
         msg: Binary::from(serde_json::to_vec(
             &valence_library_utils::msg::ExecuteMsg::<_, ()>::ProcessFunction(
-                valence_osmosis_gamm_withdrawer::msg::FunctionMsgs::WithdrawLiquidity {},
+                valence_osmosis_gamm_withdrawer::msg::FunctionMsgs::WithdrawLiquidity {
+                    expected_spot_price: None,
+                },
             ),
         )?),
     };

--- a/local-interchaintest/examples/osmo_gamm.rs
+++ b/local-interchaintest/examples/osmo_gamm.rs
@@ -26,6 +26,7 @@ use valence_authorization_utils::{
     domain::Domain,
     msg::ProcessorMessage,
 };
+use valence_library_utils::liquidity_utils::AssetData;
 use valence_program_manager::{
     account::{AccountInfo, AccountType},
     library::{LibraryConfig, LibraryInfo},
@@ -102,8 +103,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         output_addr: gamm_output_acc.clone(),
         lp_config: valence_osmosis_gamm_lper::msg::LiquidityProviderConfig {
             pool_id,
-            pool_asset_2: OSMOSIS_CHAIN_DENOM.to_string(),
-            pool_asset_1: ntrn_on_osmo_denom.to_string(),
+            asset_data: AssetData {
+                asset1: ntrn_on_osmo_denom.to_string(),
+                asset2: OSMOSIS_CHAIN_DENOM.to_string(),
+            },
         },
     };
 
@@ -112,8 +115,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         output_addr: final_output_acc.clone(),
         lw_config: valence_osmosis_gamm_withdrawer::msg::LiquidityWithdrawerConfig {
             pool_id,
-            pool_asset_2: OSMOSIS_CHAIN_DENOM.to_string(),
-            pool_asset_1: ntrn_on_osmo_denom.to_string(),
+            asset_data: AssetData {
+                asset1: ntrn_on_osmo_denom.to_string(),
+                asset2: OSMOSIS_CHAIN_DENOM.to_string(),
+            },
         },
     };
 

--- a/local-interchaintest/examples/two_party_pol_astroport_neutron.rs
+++ b/local-interchaintest/examples/two_party_pol_astroport_neutron.rs
@@ -24,11 +24,8 @@ use log::info;
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::Value;
 use valence_astroport_lper::msg::LiquidityProviderConfig;
-use valence_astroport_utils::{
-    astroport_native_lp_token::{
-        Asset, AssetInfo, FactoryInstantiateMsg, FactoryQueryMsg, PairConfig, PairType,
-    },
-    AssetData,
+use valence_astroport_utils::astroport_native_lp_token::{
+    Asset, AssetInfo, FactoryInstantiateMsg, FactoryQueryMsg, PairConfig, PairType,
 };
 use valence_authorization_utils::{
     authorization::{AuthorizationModeInfo, PermissionTypeInfo},
@@ -37,7 +34,9 @@ use valence_authorization_utils::{
     msg::ProcessorMessage,
 };
 use valence_forwarder_library::msg::{ForwardingConstraints, UncheckedForwardingConfig};
-use valence_library_utils::{denoms::UncheckedDenom, LibraryAccountType};
+use valence_library_utils::{
+    denoms::UncheckedDenom, liquidity_utils::AssetData, LibraryAccountType,
+};
 use valence_program_manager::{
     account::{AccountInfo, AccountType},
     library::{LibraryConfig, LibraryInfo},

--- a/local-interchaintest/examples/two_party_pol_astroport_neutron.rs
+++ b/local-interchaintest/examples/two_party_pol_astroport_neutron.rs
@@ -28,7 +28,7 @@ use valence_astroport_utils::{
     astroport_native_lp_token::{
         Asset, AssetInfo, FactoryInstantiateMsg, FactoryQueryMsg, PairConfig, PairType,
     },
-    AssetData, PoolType,
+    AssetData,
 };
 use valence_authorization_utils::{
     authorization::{AuthorizationModeInfo, PermissionTypeInfo},

--- a/local-interchaintest/examples/two_party_pol_astroport_neutron.rs
+++ b/local-interchaintest/examples/two_party_pol_astroport_neutron.rs
@@ -23,9 +23,12 @@ use localic_utils::{
 use log::info;
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::Value;
-use valence_astroport_lper::msg::{AssetData, LiquidityProviderConfig};
-use valence_astroport_utils::astroport_native_lp_token::{
-    Asset, AssetInfo, FactoryInstantiateMsg, FactoryQueryMsg, PairConfig, PairType,
+use valence_astroport_lper::msg::LiquidityProviderConfig;
+use valence_astroport_utils::{
+    astroport_native_lp_token::{
+        Asset, AssetInfo, FactoryInstantiateMsg, FactoryQueryMsg, PairConfig, PairType,
+    },
+    AssetData, PoolType,
 };
 use valence_authorization_utils::{
     authorization::{AuthorizationModeInfo, PermissionTypeInfo},
@@ -341,8 +344,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     output_addr: LibraryAccountType::AccountId(5),
                     pool_addr: pool_addr.to_string(),
                     lp_config: LiquidityProviderConfig {
-                        pool_type: valence_astroport_lper::msg::PoolType::NativeLpToken(
-                            PairType::Xyk {},
+                        pool_type: valence_astroport_utils::PoolType::NativeLpToken(
+                            valence_astroport_utils::astroport_native_lp_token::PairType::Xyk {},
                         ),
                         asset_data: AssetData {
                             asset1: NTRN_DENOM.to_string(),
@@ -408,7 +411,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                     pool_addr: pool_addr.to_string(),
                     withdrawer_config:
                         valence_astroport_withdrawer::msg::LiquidityWithdrawerConfig {
-                            pool_type: valence_astroport_withdrawer::msg::PoolType::NativeLpToken,
+                            pool_type: valence_astroport_utils::PoolType::NativeLpToken(
+                                valence_astroport_utils::astroport_native_lp_token::PairType::Xyk {  },
+                            ),
+                            asset_data: AssetData {
+                                asset1: NTRN_DENOM.to_string(),
+                                asset2: token.clone(),
+                            },
                         },
                 },
             ),
@@ -981,7 +990,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let binary2 = Binary::from(
         serde_json::to_vec(
             &valence_library_utils::msg::ExecuteMsg::<_, ()>::ProcessFunction(
-                valence_astroport_withdrawer::msg::FunctionMsgs::WithdrawLiquidity {},
+                valence_astroport_withdrawer::msg::FunctionMsgs::WithdrawLiquidity {
+                    expected_pool_ratio_range: None,
+                },
             ),
         )
         .unwrap(),

--- a/packages/astroport-utils/Cargo.toml
+++ b/packages/astroport-utils/Cargo.toml
@@ -12,6 +12,7 @@ testing = [
 ]
 
 [dependencies]
-cosmwasm-std      = { workspace = true }
-cosmwasm-schema   = { workspace = true }
-neutron-test-tube = { workspace = true, optional = true }
+cosmwasm-std            = { workspace = true }
+cosmwasm-schema         = { workspace = true }
+neutron-test-tube       = { workspace = true, optional = true }
+valence-library-utils   = { workspace = true }

--- a/packages/astroport-utils/src/astroport_cw20_lp_token.rs
+++ b/packages/astroport-utils/src/astroport_cw20_lp_token.rs
@@ -3,7 +3,15 @@
 // The content of this file is taken from the 'astroport' crate, specifically version 2.9.5
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Coin, Decimal, StdError, StdResult, Uint128};
+use cosmwasm_std::{Addr, Binary, Coin, Decimal, DepsMut, StdError, StdResult, Uint128};
+use valence_library_utils::error::LibraryError;
+
+pub fn query_pool(deps: &DepsMut, pool_addr: &str) -> Result<Vec<Asset>, LibraryError> {
+    let response: PoolResponse = deps
+        .querier
+        .query_wasm_smart(pool_addr, &PoolQueryMsg::Pool {})?;
+    Ok(response.assets)
+}
 
 /// This struct is used to return a query result with the total amount of LP tokens and assets in a specific pool.
 #[cw_serde]

--- a/packages/astroport-utils/src/astroport_native_lp_token.rs
+++ b/packages/astroport-utils/src/astroport_native_lp_token.rs
@@ -3,7 +3,15 @@
 // The content of this file is taken from the 'astroport' crate, specifically version 5.0.0
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{coin, Addr, Binary, Coin, Decimal, StdError, StdResult, Uint128};
+use cosmwasm_std::{coin, Addr, Binary, Coin, Decimal, DepsMut, StdError, StdResult, Uint128};
+use valence_library_utils::error::LibraryError;
+
+pub fn query_pool(deps: &DepsMut, pool_addr: &str) -> Result<Vec<Asset>, LibraryError> {
+    let response: PoolResponse = deps
+        .querier
+        .query_wasm_smart(pool_addr, &PoolQueryMsg::Pool {})?;
+    Ok(response.assets)
+}
 
 /// This structure holds the parameters that are returned from a swap simulation response
 #[cw_serde]

--- a/packages/astroport-utils/src/decimal_range.rs
+++ b/packages/astroport-utils/src/decimal_range.rs
@@ -1,0 +1,25 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{ensure, Decimal};
+use valence_library_utils::error::LibraryError;
+
+#[cw_serde]
+pub struct DecimalRange {
+    min: Decimal,
+    max: Decimal,
+}
+
+impl DecimalRange {
+    pub fn new(min: Decimal, max: Decimal) -> Self {
+        DecimalRange { min, max }
+    }
+}
+
+impl DecimalRange {
+    pub fn is_within_range(&self, value: Decimal) -> Result<(), LibraryError> {
+        ensure!(
+            value >= self.min && value <= self.max,
+            LibraryError::ExecutionError("Value is not within the expected range".to_string())
+        );
+        Ok(())
+    }
+}

--- a/packages/astroport-utils/src/lib.rs
+++ b/packages/astroport-utils/src/lib.rs
@@ -4,7 +4,6 @@ use valence_library_utils::error::LibraryError;
 
 pub mod astroport_cw20_lp_token;
 pub mod astroport_native_lp_token;
-pub mod decimal_range;
 
 #[cfg(feature = "testing")]
 pub mod suite;
@@ -33,14 +32,6 @@ impl AssetTrait for astroport_cw20_lp_token::Asset {
 pub enum PoolType {
     NativeLpToken(astroport_native_lp_token::PairType),
     Cw20LpToken(astroport_cw20_lp_token::PairType),
-}
-
-#[cw_serde]
-pub struct AssetData {
-    /// Denom of the first asset
-    pub asset1: String,
-    /// Denom of the second asset
-    pub asset2: String,
 }
 
 pub fn query_pool(

--- a/packages/astroport-utils/src/lib.rs
+++ b/packages/astroport-utils/src/lib.rs
@@ -1,7 +1,98 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::DepsMut;
+use valence_library_utils::error::LibraryError;
+
 pub mod astroport_cw20_lp_token;
 pub mod astroport_native_lp_token;
+pub mod decimal_range;
+
 #[cfg(feature = "testing")]
 pub mod suite;
+
+// Define a trait that both Asset types can implement
+pub trait AssetTrait {
+    fn as_coin(&self) -> Result<cosmwasm_std::Coin, LibraryError>;
+}
+
+// Implement the trait for both Asset types
+impl AssetTrait for astroport_native_lp_token::Asset {
+    fn as_coin(&self) -> Result<cosmwasm_std::Coin, LibraryError> {
+        self.as_coin()
+            .map_err(|error| LibraryError::ExecutionError(error.to_string()))
+    }
+}
+
+impl AssetTrait for astroport_cw20_lp_token::Asset {
+    fn as_coin(&self) -> Result<cosmwasm_std::Coin, LibraryError> {
+        self.to_coin()
+            .map_err(|error| LibraryError::ExecutionError(error.to_string()))
+    }
+}
+
+#[cw_serde]
+pub enum PoolType {
+    NativeLpToken(astroport_native_lp_token::PairType),
+    Cw20LpToken(astroport_cw20_lp_token::PairType),
+}
+
+#[cw_serde]
+pub struct AssetData {
+    /// Denom of the first asset
+    pub asset1: String,
+    /// Denom of the second asset
+    pub asset2: String,
+}
+
+pub fn query_pool(
+    deps: &DepsMut,
+    pool_addr: &str,
+    pool_type: &PoolType,
+) -> Result<Vec<Box<dyn AssetTrait>>, LibraryError> {
+    match pool_type {
+        PoolType::NativeLpToken(_) => {
+            let assets = astroport_native_lp_token::query_pool(deps, pool_addr)?;
+            Ok(assets
+                .into_iter()
+                .map(|asset| Box::new(asset) as Box<dyn AssetTrait>)
+                .collect())
+        }
+        PoolType::Cw20LpToken(_) => {
+            let assets = astroport_cw20_lp_token::query_pool(deps, pool_addr)?;
+            Ok(assets
+                .into_iter()
+                .map(|asset| Box::new(asset) as Box<dyn AssetTrait>)
+                .collect())
+        }
+    }
+}
+
+pub fn get_pool_asset_amounts(
+    assets: Vec<Box<dyn AssetTrait>>,
+    asset1_denom: &str,
+    asset2_denom: &str,
+) -> Result<(u128, u128), LibraryError> {
+    let (mut asset1_balance, mut asset2_balance) = (0, 0);
+
+    for asset in assets {
+        let coin = asset
+            .as_coin()
+            .map_err(|error| LibraryError::ExecutionError(error.to_string()))?;
+
+        if coin.denom == asset1_denom {
+            asset1_balance = coin.amount.u128();
+        } else if coin.denom == asset2_denom {
+            asset2_balance = coin.amount.u128();
+        }
+    }
+
+    if asset1_balance == 0 || asset2_balance == 0 {
+        return Err(LibraryError::ExecutionError(
+            "All pool assets must be non-zero".to_string(),
+        ));
+    }
+
+    Ok((asset1_balance, asset2_balance))
+}
 
 // Implemented in the astroport crate for Decimal
 pub mod decimal_checked_ops {

--- a/packages/library-utils/src/lib.rs
+++ b/packages/library-utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod denoms {
 }
 
 pub mod error;
+pub mod liquidity_utils;
 pub mod msg;
 pub mod raw_config;
 

--- a/packages/library-utils/src/liquidity_utils.rs
+++ b/packages/library-utils/src/liquidity_utils.rs
@@ -1,6 +1,15 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{ensure, Decimal};
-use valence_library_utils::error::LibraryError;
+
+use crate::error::LibraryError;
+
+#[cw_serde]
+pub struct AssetData {
+    /// Denom of the first asset
+    pub asset1: String,
+    /// Denom of the second asset
+    pub asset2: String,
+}
 
 #[cw_serde]
 pub struct DecimalRange {
@@ -15,7 +24,7 @@ impl DecimalRange {
 }
 
 impl DecimalRange {
-    pub fn is_within_range(&self, value: Decimal) -> Result<(), LibraryError> {
+    pub fn contains(&self, value: Decimal) -> Result<(), LibraryError> {
         ensure!(
             value >= self.min && value <= self.max,
             LibraryError::ExecutionError("Value is not within the expected range".to_string())

--- a/packages/osmosis-utils/src/utils.rs
+++ b/packages/osmosis-utils/src/utils.rs
@@ -13,27 +13,27 @@ pub struct LiquidityProviderConfig {
     pub pool_asset_2: String,
 }
 
-#[cw_serde]
-pub struct DecimalRange {
-    min: Decimal,
-    max: Decimal,
-}
+// #[cw_serde]
+// pub struct DecimalRange {
+//     min: Decimal,
+//     max: Decimal,
+// }
 
-impl From<(Decimal, Decimal)> for DecimalRange {
-    fn from((min, max): (Decimal, Decimal)) -> Self {
-        DecimalRange { min, max }
-    }
-}
+// impl From<(Decimal, Decimal)> for DecimalRange {
+//     fn from((min, max): (Decimal, Decimal)) -> Self {
+//         DecimalRange { min, max }
+//     }
+// }
 
-impl DecimalRange {
-    pub fn contains(&self, value: Decimal) -> Result<(), LibraryError> {
-        ensure!(
-            value >= self.min && value <= self.max,
-            LibraryError::ExecutionError("Value is not within the expected range".to_string())
-        );
-        Ok(())
-    }
-}
+// impl DecimalRange {
+//     pub fn contains(&self, value: Decimal) -> Result<(), LibraryError> {
+//         ensure!(
+//             value >= self.min && value <= self.max,
+//             LibraryError::ExecutionError("Value is not within the expected range".to_string())
+//         );
+//         Ok(())
+//     }
+// }
 
 pub fn get_provide_liquidity_msg(
     input_addr: &str,

--- a/packages/osmosis-utils/src/utils.rs
+++ b/packages/osmosis-utils/src/utils.rs
@@ -1,10 +1,9 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{ensure, Coin, CosmosMsg, Decimal, StdResult, Uint128};
+use cosmwasm_std::{Coin, CosmosMsg, StdResult, Uint128};
 use osmosis_std::{
     cosmwasm_to_proto_coins,
     types::osmosis::gamm::v1beta1::{MsgExitPool, MsgJoinPool, MsgJoinSwapExternAmountIn},
 };
-use valence_library_utils::error::LibraryError;
 
 #[cw_serde]
 pub struct LiquidityProviderConfig {
@@ -12,28 +11,6 @@ pub struct LiquidityProviderConfig {
     pub pool_asset_1: String,
     pub pool_asset_2: String,
 }
-
-// #[cw_serde]
-// pub struct DecimalRange {
-//     min: Decimal,
-//     max: Decimal,
-// }
-
-// impl From<(Decimal, Decimal)> for DecimalRange {
-//     fn from((min, max): (Decimal, Decimal)) -> Self {
-//         DecimalRange { min, max }
-//     }
-// }
-
-// impl DecimalRange {
-//     pub fn contains(&self, value: Decimal) -> Result<(), LibraryError> {
-//         ensure!(
-//             value >= self.min && value <= self.max,
-//             LibraryError::ExecutionError("Value is not within the expected range".to_string())
-//         );
-//         Ok(())
-//     }
-// }
 
 pub fn get_provide_liquidity_msg(
     input_addr: &str,

--- a/program-manager/schema/valence-program-manager.json
+++ b/program-manager/schema/valence-program-manager.json
@@ -1208,16 +1208,12 @@
       "LiquidityProviderConfig2": {
         "type": "object",
         "required": [
-          "pool_asset_1",
-          "pool_asset_2",
+          "asset_data",
           "pool_id"
         ],
         "properties": {
-          "pool_asset_1": {
-            "type": "string"
-          },
-          "pool_asset_2": {
-            "type": "string"
+          "asset_data": {
+            "$ref": "#/definitions/AssetData"
           },
           "pool_id": {
             "type": "integer",
@@ -1254,14 +1250,23 @@
       "LiquidityWithdrawerConfig": {
         "type": "object",
         "required": [
+          "asset_data",
           "pool_type"
         ],
         "properties": {
+          "asset_data": {
+            "description": "Denoms of the underlying assets to be withdrawn",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetData"
+              }
+            ]
+          },
           "pool_type": {
             "description": "Pool type, old Astroport pools use Cw20 lp tokens and new pools use native tokens, so we specify here what kind of token we are going to get. We also provide the PairType structure of the right Astroport version that we are going to use for each scenario",
             "allOf": [
               {
-                "$ref": "#/definitions/PoolType2"
+                "$ref": "#/definitions/PoolType"
               }
             ]
           }
@@ -1271,9 +1276,13 @@
       "LiquidityWithdrawerConfig2": {
         "type": "object",
         "required": [
+          "asset_data",
           "pool_id"
         ],
         "properties": {
+          "asset_data": {
+            "$ref": "#/definitions/AssetData"
+          },
           "pool_id": {
             "type": "integer",
             "format": "uint64",
@@ -1600,13 +1609,6 @@
             },
             "additionalProperties": false
           }
-        ]
-      },
-      "PoolType2": {
-        "type": "string",
-        "enum": [
-          "native_lp_token",
-          "cw20_lp_token"
         ]
       },
       "Priority": {


### PR DESCRIPTION
closes #145 

both `valence-osmosis-gamm-withdrawer` and `valence-astroport-withdrawer` now take in `expected_pool_ratio_range: Option<DecimalRange>` as an argument for liquidity withdrawal. this range gets validated against the current pool ratio: if the current pool ratio is not contained in the specified `DecimalRange` (if any), function returns an error. if `DecimalRange` is not specified, pool ratio validation is skipped.

in order to enable that price validation, both astroport & osmosis withdrawer `LiquidityWithdrawerConfig`s now take in an additional parameter - `AssetData`, specifying the denoms in the pool. this pattern follows the same logic as liquidity providers.

because of how much more similar liquidity providers and withdrawers are now looking, a bunch of stuff was moved into utils and normalized across osmosis and astroport counterparts:
- `AssetData`
- `DecimalRange`

### summary

- same `DecimalRange` and `AssetData` structs are now used by `valence-osmosis-gamm-withdrawer`, `valence-osmosis-gamm-lper`, `valence-astroport-withdrawer`, and `valence-astroport-lper`
- `valence-astroport-withdrawer` and `valence-osmosis-gamm-withdrawer` perform decimal range validation on withdrawal
- for astroport components, the following have been moved to utils for reuse: `AssetTrait`, `PoolType`, fns for query helpers, `get_pool_asset_amounts` 

#### out of scope changes

I noticed that astroport lper had not unit tested the decimal range validation on execution, so some unit tests were added on that end.

