### PR TITLE
storage account rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7549,6 +7549,7 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "valence-account-utils",
+ "valence-middleware-utils",
 ]
 
 [[package]]

--- a/contracts/accounts/base_account/schema/valence-base-account.json
+++ b/contracts/accounts/base_account/schema/valence-base-account.json
@@ -360,7 +360,7 @@
         ]
       },
       "Empty": {
-        "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object",
         "additionalProperties": false
       },
@@ -675,7 +675,7 @@
             "$ref": "#/definitions/CosmosMsg_for_Empty"
           },
           "payload": {
-            "description": "Some arbirary data that the contract can set in an application specific way. This is just passed into the `reply` entry point and is not stored to state. Any encoding can be used. If `id` is used to identify a particular action, the encoding can also be different for each of those actions since you can match `id` first and then start processing the `payload`.\n\nThe environment restricts the length of this field in order to avoid abuse. The limit is environment specific and can change over time. The initial default is 128 KiB.\n\nUnset/nil/null cannot be differentiated from empty data.\n\nOn chains running CosmWasm 1.x this field will be ignored.",
+            "description": "Some arbitrary data that the contract can set in an application specific way. This is just passed into the `reply` entry point and is not stored to state. Any encoding can be used. If `id` is used to identify a particular action, the encoding can also be different for each of those actions since you can match `id` first and then start processing the `payload`.\n\nThe environment restricts the length of this field in order to avoid abuse. The limit is environment specific and can change over time. The initial default is 128 KiB.\n\nUnset/nil/null cannot be differentiated from empty data.\n\nOn chains running CosmWasm 1.x this field will be ignored.",
             "default": "",
             "allOf": [
               {

--- a/contracts/accounts/storage_account/Cargo.toml
+++ b/contracts/accounts/storage_account/Cargo.toml
@@ -23,6 +23,7 @@ schemars              = { workspace = true }
 serde                 = { workspace = true }
 thiserror             = { workspace = true }
 valence-account-utils = { workspace = true }
+valence-middleware-utils = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test         = { workspace = true }

--- a/contracts/accounts/storage_account/README.md
+++ b/contracts/accounts/storage_account/README.md
@@ -1,4 +1,4 @@
 # Valence Storage Account
 
 The **Valence Storage Account** is a type of Valence account that can store
-data objects of Valence Type(s).
+Valence Type variants.

--- a/contracts/accounts/storage_account/README.md
+++ b/contracts/accounts/storage_account/README.md
@@ -1,4 +1,4 @@
 # Valence Storage Account
 
 The **Valence Storage Account** is a type of Valence account that can store
-arbitrary data blobs.
+data objects of Valence Type(s).

--- a/contracts/accounts/storage_account/schema/valence-storage-account.json
+++ b/contracts/accounts/storage_account/schema/valence-storage-account.json
@@ -72,21 +72,21 @@
       {
         "type": "object",
         "required": [
-          "post_blob"
+          "store_valence_type"
         ],
         "properties": {
-          "post_blob": {
+          "store_valence_type": {
             "type": "object",
             "required": [
               "key",
-              "value"
+              "variant"
             ],
             "properties": {
               "key": {
                 "type": "string"
               },
-              "value": {
-                "$ref": "#/definitions/Binary"
+              "variant": {
+                "$ref": "#/definitions/ValenceType"
               }
             },
             "additionalProperties": false
@@ -164,6 +164,22 @@
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "Expiration": {
         "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
         "oneOf": [
@@ -219,9 +235,84 @@
           }
         ]
       },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
+      },
+      "ValenceBankBalance": {
+        "type": "object",
+        "required": [
+          "assets"
+        ],
+        "properties": {
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coin"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValenceType": {
+        "description": "this is effectively the valence vm types that are enabled on a system level. if a particular type is not defined here, it cannot be used in programs. if a type is here, then developers are free to integrate any remote types that would fall into any of these categories.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "xyk_pool"
+            ],
+            "properties": {
+              "xyk_pool": {
+                "$ref": "#/definitions/ValenceXykPool"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "bank_balance"
+            ],
+            "properties": {
+              "bank_balance": {
+                "$ref": "#/definitions/ValenceBankBalance"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ValenceXykPool": {
+        "type": "object",
+        "required": [
+          "assets",
+          "domain_specific_fields",
+          "total_shares"
+        ],
+        "properties": {
+          "assets": {
+            "description": "assets in the pool",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "domain_specific_fields": {
+            "description": "any other fields that are unique to the external pool type being represented by this struct",
+            "type": "object",
+            "additionalProperties": false
+          },
+          "total_shares": {
+            "description": "total amount of shares issued",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       }
     }
   },
@@ -245,10 +336,10 @@
       {
         "type": "object",
         "required": [
-          "blob"
+          "query_valence_type"
         ],
         "properties": {
-          "blob": {
+          "query_valence_type": {
             "type": "object",
             "required": [
               "key"
@@ -282,12 +373,6 @@
   "migrate": null,
   "sudo": null,
   "responses": {
-    "blob": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Binary",
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-      "type": "string"
-    },
     "list_approved_libraries": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Array_of_String",
@@ -388,6 +473,105 @@
         "Uint64": {
           "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
+        }
+      }
+    },
+    "query_valence_type": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ValenceType",
+      "description": "this is effectively the valence vm types that are enabled on a system level. if a particular type is not defined here, it cannot be used in programs. if a type is here, then developers are free to integrate any remote types that would fall into any of these categories.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "xyk_pool"
+          ],
+          "properties": {
+            "xyk_pool": {
+              "$ref": "#/definitions/ValenceXykPool"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "bank_balance"
+          ],
+          "properties": {
+            "bank_balance": {
+              "$ref": "#/definitions/ValenceBankBalance"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "definitions": {
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "ValenceBankBalance": {
+          "type": "object",
+          "required": [
+            "assets"
+          ],
+          "properties": {
+            "assets": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Coin"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ValenceXykPool": {
+          "type": "object",
+          "required": [
+            "assets",
+            "domain_specific_fields",
+            "total_shares"
+          ],
+          "properties": {
+            "assets": {
+              "description": "assets in the pool",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "domain_specific_fields": {
+              "description": "any other fields that are unique to the external pool type being represented by this struct",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "total_shares": {
+              "description": "total amount of shares issued",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     }

--- a/contracts/accounts/storage_account/src/contract.rs
+++ b/contracts/accounts/storage_account/src/contract.rs
@@ -73,7 +73,7 @@ mod execute {
         );
 
         // store the variant
-        VALENCE_TYPE_STORE.save(deps.storage, key.clone(), &variant)?;
+        VALENCE_TYPE_STORE.save(deps.storage, key.to_string(), &variant)?;
 
         Ok(Response::new()
             .add_attribute("method", "post_valence_type")
@@ -136,11 +136,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_json_binary(&libraries)
         }
         QueryMsg::QueryValenceType { key } => {
-            let obj = VALENCE_TYPE_STORE.may_load(deps.storage, key)?;
-
-            match obj {
+            match VALENCE_TYPE_STORE.may_load(deps.storage, key)? {
                 Some(val) => to_json_binary(&val),
-                None => Err(StdError::generic_err("blob not found")),
+                None => Err(StdError::generic_err(
+                    "no value associated with storage key",
+                )),
             }
         }
     }

--- a/contracts/accounts/storage_account/src/contract.rs
+++ b/contracts/accounts/storage_account/src/contract.rs
@@ -47,7 +47,7 @@ pub fn execute(
         ExecuteMsg::RemoveLibrary { library } => execute::remove_library(deps, info, library),
         ExecuteMsg::UpdateOwnership(action) => execute::update_ownership(deps, env, info, action),
         ExecuteMsg::StoreValenceType { key, variant } => {
-            execute::try_post_valence_type(deps, info, key, variant)
+            execute::try_store_valence_type(deps, info, key, variant)
         }
     }
 }
@@ -59,7 +59,7 @@ mod execute {
 
     use crate::state::{APPROVED_LIBRARIES, VALENCE_TYPE_STORE};
 
-    pub fn try_post_valence_type(
+    pub fn try_store_valence_type(
         deps: DepsMut,
         info: MessageInfo,
         key: String,
@@ -76,7 +76,7 @@ mod execute {
         VALENCE_TYPE_STORE.save(deps.storage, key.to_string(), &variant)?;
 
         Ok(Response::new()
-            .add_attribute("method", "post_valence_type")
+            .add_attribute("method", "store_valence_type")
             .add_attribute("key", key)
             .add_attribute("variant", format!("{:?}", variant)))
     }

--- a/contracts/accounts/storage_account/src/msg.rs
+++ b/contracts/accounts/storage_account/src/msg.rs
@@ -9,7 +9,7 @@ pub enum ExecuteMsg {
     ApproveLibrary { library: String },
     // Remove library from approved list (only admin)
     RemoveLibrary { library: String },
-    // store in storage
+    // stores the given `ValenceType` variant under storage key `key`
     StoreValenceType { key: String, variant: ValenceType },
 }
 
@@ -17,8 +17,10 @@ pub enum ExecuteMsg {
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
+    // Get list of approved libraries
     #[returns(Vec<String>)]
-    ListApprovedLibraries {}, // Get list of approved libraries
+    ListApprovedLibraries {},
+    // Get Valence type variant from storage
     #[returns(ValenceType)]
-    QueryValenceType { key: String }, // Get Valence type object from storage
+    QueryValenceType { key: String },
 }

--- a/contracts/accounts/storage_account/src/msg.rs
+++ b/contracts/accounts/storage_account/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Binary;
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
+use valence_middleware_utils::type_registry::types::ValenceType;
 
 #[cw_ownable_execute]
 #[cw_serde]
@@ -9,8 +9,8 @@ pub enum ExecuteMsg {
     ApproveLibrary { library: String },
     // Remove library from approved list (only admin)
     RemoveLibrary { library: String },
-    // store a payload in storage
-    PostBlob { key: String, value: Binary },
+    // store in storage
+    StoreValenceType { key: String, variant: ValenceType },
 }
 
 #[cw_ownable_query]
@@ -19,6 +19,6 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(Vec<String>)]
     ListApprovedLibraries {}, // Get list of approved libraries
-    #[returns(Binary)]
-    Blob { key: String }, // Get blob from storage
+    #[returns(ValenceType)]
+    QueryValenceType { key: String }, // Get Valence type object from storage
 }

--- a/contracts/accounts/storage_account/src/state.rs
+++ b/contracts/accounts/storage_account/src/state.rs
@@ -1,8 +1,8 @@
-use cosmwasm_std::{Addr, Binary, Empty};
+use cosmwasm_std::{Addr, Empty};
 use cw_storage_plus::Map;
+use valence_middleware_utils::type_registry::types::ValenceType;
 
 /// Approved libraries that can execute actions on behalf of the account
 pub const APPROVED_LIBRARIES: Map<Addr, Empty> = Map::new("libraries");
 
-/// string key indexed blob (`cosmwasm_std::Binary`) storage
-pub const BLOB_STORE: Map<String, Binary> = Map::new("blob_store");
+pub const VALENCE_TYPE_STORE: Map<String, ValenceType> = Map::new("valence_type_store");

--- a/contracts/accounts/storage_account/src/tests.rs
+++ b/contracts/accounts/storage_account/src/tests.rs
@@ -185,7 +185,7 @@ impl StorageAccountTestSuite {
         self.query_wasm(addr, &QueryMsg::Ownership {})
     }
 
-    fn query_blob(&mut self, acc: Addr, key: &str) -> ValenceType {
+    fn query_valence_type(&mut self, acc: Addr, key: &str) -> ValenceType {
         self.query_wasm(
             &acc,
             &QueryMsg::QueryValenceType {
@@ -455,8 +455,8 @@ fn post_data_blob_admin() {
         .post_valence_type(acc.clone(), BLOB_KEY, variant)
         .unwrap();
 
-    // get the posted blob and try to reconstruct it
-    let query_result = suite.query_blob(acc, BLOB_KEY);
+    // get the stored valence type and try to reconstruct it
+    let query_result = suite.query_valence_type(acc, BLOB_KEY);
     let balance_resp: ValenceBankBalance = match query_result {
         ValenceType::BankBalance(blob) => blob,
         _ => panic!("Unexpected variant type"),

--- a/contracts/encoders/evm-encoder/schema/valence-evm-encoder-v1.json
+++ b/contracts/encoders/evm-encoder/schema/valence-evm-encoder-v1.json
@@ -5,14 +5,14 @@
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },
   "execute": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "ExecuteMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },


### PR DESCRIPTION
work towards #153 

# Changes

Reworks the storage account contract to store `ValenceType` variants instead of cosmwasm binaries.

Along with that, the api naming is updated:
- for execution, instead of `PostBlob` the storage variant is now called `StoreValenceType`
- for querying, instead of `Blob` the query is now `QueryValenceType`