### PR TITLE
[processor] add execution time limit for subroutines

### DIFF
--- a/contracts/authorization/src/tests/processor.rs
+++ b/contracts/authorization/src/tests/processor.rs
@@ -2023,6 +2023,9 @@ fn failed_atomic_batch_after_retries() {
                     }),
                     priority: Priority::Medium,
                     retry: None,
+                    expiration_time: cw_utils::Expiration::AtTime(
+                        setup.app.get_block_timestamp().plus_seconds(100),
+                    ),
                 },
             }),
             &[],


### PR DESCRIPTION
Closes #137 

This is a proposition for adding execution time limit of the subroutines. It adds a const in config for `timeout` but it can be provided another way.
Is there a specific way to test locally ?