### PR TITLE
Delete docs/src/zk-coprocessor/overview.md

### DIFF
--- a/docs/src/zk-coprocessor/overview.md
+++ b/docs/src/zk-coprocessor/overview.md
@@ -1,1 +1,0 @@
-# Valence zk-Coprocessor


### PR DESCRIPTION
This file was added in a previous docs update unintentionally instead of the typical `_overview.md` expected by mdbooks.