### PR TITLE
Add informational timestamps of executions

### DIFF
--- a/contracts/authorization/schema/valence-authorization.json
+++ b/contracts/authorization/schema/valence-authorization.json
@@ -3299,11 +3299,13 @@
       "title": "ProcessorCallbackInfo",
       "type": "object",
       "required": [
+        "created_at",
         "domain",
         "execution_id",
         "execution_result",
         "initiator",
         "label",
+        "last_updated_at",
         "messages",
         "processor_callback_address"
       ],
@@ -3317,6 +3319,11 @@
               "type": "null"
             }
           ]
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "domain": {
           "$ref": "#/definitions/Domain"
@@ -3334,6 +3341,11 @@
         },
         "label": {
           "type": "string"
+        },
+        "last_updated_at": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "messages": {
           "type": "array",
@@ -3818,11 +3830,13 @@
         "ProcessorCallbackInfo": {
           "type": "object",
           "required": [
+            "created_at",
             "domain",
             "execution_id",
             "execution_result",
             "initiator",
             "label",
+            "last_updated_at",
             "messages",
             "processor_callback_address"
           ],
@@ -3836,6 +3850,11 @@
                   "type": "null"
                 }
               ]
+            },
+            "created_at": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             },
             "domain": {
               "$ref": "#/definitions/Domain"
@@ -3853,6 +3872,11 @@
             },
             "label": {
               "type": "string"
+            },
+            "last_updated_at": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             },
             "messages": {
               "type": "array",

--- a/contracts/authorization/src/tests/processor.rs
+++ b/contracts/authorization/src/tests/processor.rs
@@ -138,6 +138,22 @@ fn user_enqueing_messages() {
     )
     .unwrap();
 
+    // The created_at and last_updated_at timestamps for this entry should be the same as it was just created
+    let query_callbacks = wasm
+        .query::<QueryMsg, Vec<ProcessorCallbackInfo>>(
+            &authorization_contract,
+            &QueryMsg::ProcessorCallbacks {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(
+        query_callbacks[0].created_at,
+        query_callbacks[0].last_updated_at
+    );
+
     // This should have enqueued one message in the medium priority queue, and none in the high priority queue
     let query_med_prio_queue = wasm
         .query::<ProcessorQueryMsg, Vec<MessageBatch>>(
@@ -2468,6 +2484,7 @@ fn successful_non_atomic_and_atomic_batches_together() {
             confirmed_callback.execution_result,
             ExecutionResult::Success
         );
+        assert!(confirmed_callback.last_updated_at > confirmed_callback.created_at);
     }
 }
 

--- a/docs/src/authorizations_processors/callbacks.md
+++ b/docs/src/authorizations_processors/callbacks.md
@@ -16,6 +16,10 @@ Once a Processor batch is executed or it fails and there are no more retries ava
 pub struct ProcessorCallbackInfo {
     // Execution ID that the callback was for
     pub execution_id: u64,
+    // Timestamp of entry creation
+    pub created_at: u64,
+    // Timestamp of last update of this entry
+    pub last_updated_at: u64,
     // Who started this operation, used for tokenfactory actions
     pub initiator: OperationInitiator,
     // Address that can send a bridge timeout or success for the message (if applied)

--- a/packages/authorization-utils/src/callback.rs
+++ b/packages/authorization-utils/src/callback.rs
@@ -8,6 +8,10 @@ use crate::{domain::Domain, msg::ProcessorMessage};
 pub struct ProcessorCallbackInfo {
     // Execution ID that the callback was for
     pub execution_id: u64,
+    // Timestamp of entry creation
+    pub created_at: u64,
+    // Timestamp of last update of this entry
+    pub last_updated_at: u64,
     // Who started this operation, used for tokenfactory actions
     pub initiator: OperationInitiator,
     // Address that can send a bridge timeout or success for the message (if applied)


### PR DESCRIPTION
Closes #116 

Adds informational timestamps for the historical in the authorization contract. We store when an execution is started on the Authorization contract in `created_at` and we also update the `last_updated_at` value every time the log is updated. This is mainly for the UI as we want to display this information