### PR TITLE
docs: change deployment folder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,4 +31,4 @@ jobs:
         if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: docs/book
+          folder: docs/book/html


### PR DESCRIPTION
When adding linkcheck we have multiple outputs so they are created in subdirectories.
Therefore we must deploy the one in html