### PR TITLE
add local-ic config to prevent CORs errors on neutron node

### DIFF
--- a/e2e/chains/neutron.json
+++ b/e2e/chains/neutron.json
@@ -88,6 +88,14 @@
       "ics_consumer_link": "localcosmos-1",
       "debugging": true,
       "block_time": "1s",
+      "config_file_overrides": [
+        {
+          "file": "config/config.toml",
+          "paths": {
+            "rpc.cors_allowed_origins": ["*"]
+          }
+        }
+      ],
       "genesis": {
         "modify": [
           {


### PR DESCRIPTION
# Description
The neutron RPC running with local-ic will throw CORs errors if you attempt to sign a transaction in the browser with the RPC endpoint. This config will allow all cross origin requests on the RPC API endpoint