### PR TITLE
extend `conditional_lp` e2e test description

### DIFF
--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -201,7 +201,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Configuration below sets up the following:
     // 1. Construct a processor message asserting that the amount of Neutron tokens
     // in a given Osmosis pool is less than 150_000_000.
-    // 2. Construct a processor message which will perform an IBC transfer from neutron to osmosis.
+    // 2. Construct a processor message which will perform an IBC transfer from Neutron to Osmosis
     // 3. Send the messages to the processor in order of `[assert, transfer]`.
     //
     // After the configuration is complete, ticking the processor will start by executing

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -204,7 +204,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // 2. Construct a processor message which will perform an IBC transfer from Neutron to Osmosis
     // 3. Send the messages to the processor in order of `[assert, transfer]`.
     //
-    // After the configuration is complete, ticking the processor will start by executing
+    // After configuration is complete, ticking the processor begins with execution of
     // the assertion message:
     // - If the assertion returns `Ok`, the processor will proceed to execute the IBC transfer message
     // - If the assertion returns `Err`, the processor will error out and exit

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     //
     // Configuration below sets up the following:
     // 1. Construct a processor message asserting that the amount of Neutron tokens
-    // in a given osmosis pool is less than 150_000_000.
+    // in a given Osmosis pool is less than 150_000_000.
     // 2. Construct a processor message which will perform an IBC transfer from neutron to osmosis.
     // 3. Send the messages to the processor in order of `[assert, transfer]`.
     //

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -199,7 +199,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // This is the core of the example program where conditional execution is demonstrated.
     //
     // Configuration below sets up the following:
-    // 1. Construct a processor message which will assert that the amount of neutron tokens
+    // 1. Construct a processor message asserting that the amount of Neutron tokens
     // in a given osmosis pool is less than 150_000_000.
     // 2. Construct a processor message which will perform an IBC transfer from neutron to osmosis.
     // 3. Send the messages to the processor in order of `[assert, transfer]`.

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -196,7 +196,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // 2. Conditional IBC forwarding
     //
-    // This is the core of this example program where conditional execution is demonstrated.
+    // This is the core of the example program where conditional execution is demonstrated.
     //
     // Configuration below sets up the following:
     // 1. Construct a processor message which will assert that the amount of neutron tokens

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -195,6 +195,29 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // 2. Conditional IBC forwarding
+    //
+    // This is the core of this example program where conditional execution is demonstrated.
+    //
+    // Configuration below sets up the following:
+    // 1. Construct a processor message which will assert that the amount of neutron tokens
+    // in a given osmosis pool is less than 150_000_000.
+    // 2. Construct a processor message which will perform an IBC transfer.
+    // 3. Send the messages to the processor in order of `[assert, transfer]`.
+    //
+    // After the configuration is complete, ticking the processor will start by executing
+    // the assertion message:
+    // - If the assertion returns `Ok`, the processor will proceed to execute the IBC transfer message
+    // - If the assertion returns `Err`, the processor will error out and exit
+    //
+    // More generally, Valence Programs can use this pattern to achieve logical branching and cross-chain
+    // error handling. For example, consider the condition `if a > b, do x, else do y`.
+    //
+    // This can be configured by defining two sets of messages with complementary (negated) assertions:
+    //   1. `[assert a > b, do x]`
+    //   2. `[assert a <= b, do y]`
+    //
+    // The processor will attempt to execute both sets of messages but because `eval(a > b)` can
+    // never equal `eval(a <= b)`, only `x` or `y` can be executed (but never both).
     {
         // we configure the assertion message which will:
         // - 1. let a = the amount of ntrn tokens in the pool

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -201,7 +201,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Configuration below sets up the following:
     // 1. Construct a processor message which will assert that the amount of neutron tokens
     // in a given osmosis pool is less than 150_000_000.
-    // 2. Construct a processor message which will perform an IBC transfer.
+    // 2. Construct a processor message which will perform an IBC transfer from neutron to osmosis.
     // 3. Send the messages to the processor in order of `[assert, transfer]`.
     //
     // After the configuration is complete, ticking the processor will start by executing


### PR DESCRIPTION
extending the comments of conditional lp test to highlight the cross-chain error handling and conditional execution capabilities