### PR TITLE
Change polytone e2e tests to use osmosis instead of juno

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Run polytone example
         uses: "./.github/actions/run-local-ic-test"
         with:
-          chain-config: "neutron_juno"
+          chain-config: "neutron_osmosis"
           test-name: "polytone"
 
   local-ic-token-swap:

--- a/e2e/examples/persistence_ls.rs
+++ b/e2e/examples/persistence_ls.rs
@@ -266,6 +266,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         PERSISTENCE_CHAIN_NAME,
         DEFAULT_KEY,
         &processor_on_persistence,
+        GAS_FLAGS,
     );
     std::thread::sleep(std::time::Duration::from_secs(3));
 

--- a/e2e/examples/polytone.rs
+++ b/e2e/examples/polytone.rs
@@ -968,6 +968,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         OSMOSIS_CHAIN_NAME,
         DEFAULT_KEY,
         &predicted_processor_on_osmosis_address,
+        osmosis_gas_flags,
     );
 
     // Wait enough time to force the time out

--- a/e2e/examples/two_party_pol_astroport_neutron.rs
+++ b/e2e/examples/two_party_pol_astroport_neutron.rs
@@ -804,6 +804,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         NEUTRON_CHAIN_NAME,
         DEFAULT_KEY,
         &processor_contract_address,
+        GAS_FLAGS,
     );
     std::thread::sleep(std::time::Duration::from_secs(2));
 
@@ -893,6 +894,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         NEUTRON_CHAIN_NAME,
         DEFAULT_KEY,
         &processor_contract_address,
+        GAS_FLAGS,
     );
     std::thread::sleep(std::time::Duration::from_secs(2));
 
@@ -953,6 +955,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         NEUTRON_CHAIN_NAME,
         DEFAULT_KEY,
         &processor_contract_address,
+        GAS_FLAGS,
     );
 
     info!("Verifying available LP tokens account...");
@@ -1034,6 +1037,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         NEUTRON_CHAIN_NAME,
         DEFAULT_KEY,
         &processor_contract_address,
+        GAS_FLAGS,
     );
 
     info!("Verifying final balances...");

--- a/e2e/src/utils/authorization.rs
+++ b/e2e/src/utils/authorization.rs
@@ -469,7 +469,7 @@ pub fn set_up_external_domain_with_polytone(
     Ok(predicted_processor_on_external_domain_address)
 }
 
-fn predict_remote_contract_address(
+pub fn predict_remote_contract_address(
     test_ctx: &TestContext,
     code_id: u64,
     chain_name: &str,

--- a/e2e/src/utils/processor.rs
+++ b/e2e/src/utils/processor.rs
@@ -4,8 +4,6 @@ use log::info;
 use valence_authorization_utils::authorization::Priority;
 use valence_processor_utils::processor::MessageBatch;
 
-use super::GAS_FLAGS;
-
 /// queries the remote domain processor queue and tries to confirm that the queue length
 /// matches `len`.
 /// retries for 10 times with a 5 second sleep in between. fails after 10 retries.
@@ -41,6 +39,7 @@ pub fn tick_processor(
     chain_name: &str,
     key: &str,
     processor_address: &str,
+    flags: &str,
 ) {
     info!("Ticking processor on {}...", chain_name);
     contract_execute(
@@ -55,7 +54,7 @@ pub fn tick_processor(
             ),
         )
         .unwrap(),
-        GAS_FLAGS,
+        flags,
     )
     .unwrap();
 

--- a/examples/src/token_swap.rs
+++ b/examples/src/token_swap.rs
@@ -298,6 +298,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         NEUTRON_CHAIN_NAME,
         DEFAULT_KEY,
         &processor_contract_address,
+        GAS_FLAGS,
     );
 
     info!("Verifying balances...");

--- a/justfile
+++ b/justfile
@@ -13,6 +13,9 @@ disconnect-hyperlane-network:
 run-example program:
     RUST_LOG=debug cargo run --package valence-program-examples --bin {{program}}
 
+run-e2e test:
+    RUST_LOG=debug cargo run --package valence-e2e --example {{test}}
+
 precommit:
     cargo fmt --all -- --check
     cargo clippy --all-targets --verbose -- -D warnings


### PR DESCRIPTION
Use osmosis instead of juno for the polytone tests to avoid random panics due to https://github.com/CosmWasm/wasmvm/issues/523 and https://github.com/CosmosContracts/juno/issues/1074 that is making our CI to fail sometimes, more often during rate limiting