### PR TITLE
fix ibc transfer

### DIFF
--- a/contracts/libraries/generic-ibc-transfer/README.md
+++ b/contracts/libraries/generic-ibc-transfer/README.md
@@ -37,7 +37,7 @@ struct LibraryConfig {
   // Account from which the funds are pulled (on the source chain)
   input_addr: LibraryAccountType,
   // Account to which the funds are sent (on the destination chain)
-  output_addr: String,
+  output_addr: LibraryAccountType,
   // Denom of the token to transfer
   denom: UncheckedDenom,
   // Amount to be transferred, either a fixed amount or the whole available balance.

--- a/contracts/libraries/generic-ibc-transfer/schema/valence-generic-ibc-transfer-library.json
+++ b/contracts/libraries/generic-ibc-transfer/schema/valence-generic-ibc-transfer-library.json
@@ -120,7 +120,7 @@
             "type": "string"
           },
           "output_addr": {
-            "type": "string"
+            "$ref": "#/definitions/LibraryAccountType"
           },
           "remote_chain_info": {
             "$ref": "#/definitions/RemoteChainInfo"
@@ -513,9 +513,13 @@
             ]
           },
           "output_addr": {
-            "type": [
-              "string",
-              "null"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "remote_chain_info": {
@@ -718,7 +722,7 @@
           "type": "string"
         },
         "output_addr": {
-          "$ref": "#/definitions/Addr"
+          "type": "string"
         },
         "remote_chain_info": {
           "$ref": "#/definitions/RemoteChainInfo"
@@ -872,7 +876,7 @@
           "type": "string"
         },
         "output_addr": {
-          "type": "string"
+          "$ref": "#/definitions/LibraryAccountType"
         },
         "remote_chain_info": {
           "$ref": "#/definitions/RemoteChainInfo"

--- a/contracts/libraries/generic-ibc-transfer/src/msg.rs
+++ b/contracts/libraries/generic-ibc-transfer/src/msg.rs
@@ -29,7 +29,7 @@ pub enum QueryMsg {}
 #[derive(ValenceLibraryInterface)]
 pub struct LibraryConfig {
     pub input_addr: LibraryAccountType,
-    pub output_addr: String,
+    pub output_addr: LibraryAccountType,
     pub denom: UncheckedDenom,
     pub amount: IbcTransferAmount,
     pub memo: String,
@@ -61,7 +61,7 @@ impl RemoteChainInfo {
 impl LibraryConfig {
     pub fn new(
         input_addr: LibraryAccountType,
-        output_addr: String,
+        output_addr: LibraryAccountType,
         denom: UncheckedDenom,
         amount: IbcTransferAmount,
         memo: String,
@@ -80,7 +80,7 @@ impl LibraryConfig {
 
     pub fn with_pfm_map(
         input_addr: LibraryAccountType,
-        output_addr: String,
+        output_addr: LibraryAccountType,
         denom: UncheckedDenom,
         amount: IbcTransferAmount,
         memo: String,
@@ -143,7 +143,7 @@ impl LibraryConfigValidation<Config> for LibraryConfig {
         Ok(Config {
             input_addr,
             // Can't validate output address as it's on another chain
-            output_addr: Addr::unchecked(self.output_addr.clone()),
+            output_addr: self.output_addr.to_string()?,
             denom: self
                 .denom
                 .clone()
@@ -169,7 +169,7 @@ impl LibraryConfigUpdate {
         }
 
         if let Some(output_addr) = self.output_addr {
-            config.output_addr = Addr::unchecked(output_addr);
+            config.output_addr = output_addr.to_string()?;
         }
 
         if let Some(denom) = self.denom {
@@ -224,7 +224,7 @@ pub struct Config {
     #[getset(get = "pub", set)]
     input_addr: Addr,
     #[getset(get = "pub", set)]
-    output_addr: Addr,
+    output_addr: String,
     #[getset(get = "pub", set)]
     denom: CheckedDenom,
     #[getset(get = "pub", set)]
@@ -240,7 +240,7 @@ pub struct Config {
 impl Config {
     pub fn new(
         input_addr: Addr,
-        output_addr: Addr,
+        output_addr: String,
         denom: CheckedDenom,
         amount: IbcTransferAmount,
         memo: String,
@@ -259,7 +259,7 @@ impl Config {
 
     pub fn with_pfm_map(
         input_addr: Addr,
-        output_addr: Addr,
+        output_addr: String,
         denom: CheckedDenom,
         amount: IbcTransferAmount,
         memo: String,

--- a/contracts/libraries/generic-ibc-transfer/src/tests.rs
+++ b/contracts/libraries/generic-ibc-transfer/src/tests.rs
@@ -24,7 +24,7 @@ struct IbcTransferTestSuite {
     #[getset(get)]
     input_addr: Addr,
     #[getset(get)]
-    output_addr: Addr,
+    output_addr: String,
     #[getset(get)]
     input_balance: Option<(u128, String)>,
 }
@@ -41,7 +41,7 @@ impl IbcTransferTestSuite {
         let mut inner = LibraryTestSuiteBase::new();
 
         let input_addr = inner.get_contract_addr(inner.account_code_id(), "input_account");
-        let output_addr = inner.api().addr_make("output_account");
+        let output_addr = inner.api().addr_make("output_account").to_string();
 
         // Template contract
         let ibc_transfer_code = ContractWrapper::new(
@@ -96,7 +96,7 @@ impl IbcTransferTestSuite {
     ) -> LibraryConfig {
         LibraryConfig::new(
             valence_library_utils::LibraryAccountType::Addr(self.input_addr().to_string()),
-            self.output_addr().to_string(),
+            valence_library_utils::LibraryAccountType::Addr(self.output_addr().to_string()),
             valence_library_utils::denoms::UncheckedDenom::Native(denom),
             amount,
             memo,
@@ -343,7 +343,7 @@ fn update_config_with_valid_config() {
 
     // Update config: swap input and output addresses
     cfg.input_addr = LibraryAccountType::Addr(suite.output_addr().to_string());
-    cfg.output_addr = suite.input_addr().to_string();
+    cfg.output_addr = LibraryAccountType::Addr(suite.input_addr().to_string());
     cfg.amount = IbcTransferAmount::FixedAmount(ONE_MILLION.into());
     cfg.memo = "Chancellor on brink of second bailout for banks.".to_string();
 
@@ -355,8 +355,8 @@ fn update_config_with_valid_config() {
     assert_eq!(
         lib_cfg,
         Config::new(
-            suite.output_addr().clone(),
-            suite.input_addr().clone(),
+            Addr::unchecked(suite.output_addr().clone()),
+            suite.input_addr().clone().to_string(),
             CheckedDenom::Native(NTRN.into()),
             IbcTransferAmount::FixedAmount(ONE_MILLION.into()),
             "Chancellor on brink of second bailout for banks.".to_string(),

--- a/contracts/libraries/neutron-ibc-transfer/README.md
+++ b/contracts/libraries/neutron-ibc-transfer/README.md
@@ -37,7 +37,7 @@ struct LibraryConfig {
   // Account from which the funds are pulled (on the source chain)
   input_addr: LibraryAccountType,
   // Account to which the funds are sent (on the destination chain)
-  output_addr: String,
+  output_addr: LibraryAccountType,
   // Denom of the token to transfer
   denom: UncheckedDenom,
   // Amount to be transferred, either a fixed amount or the whole available balance.

--- a/contracts/libraries/neutron-ibc-transfer/schema/valence-neutron-ibc-transfer-library.json
+++ b/contracts/libraries/neutron-ibc-transfer/schema/valence-neutron-ibc-transfer-library.json
@@ -120,7 +120,7 @@
             "type": "string"
           },
           "output_addr": {
-            "type": "string"
+            "$ref": "#/definitions/LibraryAccountType"
           },
           "remote_chain_info": {
             "$ref": "#/definitions/RemoteChainInfo"
@@ -513,9 +513,13 @@
             ]
           },
           "output_addr": {
-            "type": [
-              "string",
-              "null"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "remote_chain_info": {
@@ -718,7 +722,7 @@
           "type": "string"
         },
         "output_addr": {
-          "$ref": "#/definitions/Addr"
+          "type": "string"
         },
         "remote_chain_info": {
           "$ref": "#/definitions/RemoteChainInfo"
@@ -872,7 +876,7 @@
           "type": "string"
         },
         "output_addr": {
-          "type": "string"
+          "$ref": "#/definitions/LibraryAccountType"
         },
         "remote_chain_info": {
           "$ref": "#/definitions/RemoteChainInfo"

--- a/contracts/libraries/neutron-ibc-transfer/src/tests.rs
+++ b/contracts/libraries/neutron-ibc-transfer/src/tests.rs
@@ -36,7 +36,7 @@ struct IbcTransferTestSuite {
     #[getset(get)]
     input_addr: Addr,
     #[getset(get)]
-    output_addr: Addr,
+    output_addr: String,
     #[getset(get)]
     input_balance: Option<(u128, String)>,
 }
@@ -56,7 +56,7 @@ impl IbcTransferTestSuite {
         let mut inner = CustomLibraryTestSuiteBase::new(app);
 
         let input_addr = inner.get_contract_addr(inner.account_code_id(), "input_account");
-        let output_addr = inner.api().addr_make("output_account");
+        let output_addr = inner.api().addr_make("output_account").to_string();
 
         // Template contract
         let ibc_transfer_code = ContractWrapper::new(
@@ -111,7 +111,7 @@ impl IbcTransferTestSuite {
     ) -> LibraryConfig {
         LibraryConfig::new(
             valence_library_utils::LibraryAccountType::Addr(self.input_addr().to_string()),
-            self.output_addr().to_string(),
+            valence_library_utils::LibraryAccountType::Addr(self.output_addr().to_string()),
             valence_library_utils::denoms::UncheckedDenom::Native(denom),
             amount,
             memo,
@@ -388,7 +388,7 @@ fn update_config_with_valid_config() {
 
     // Update config: swap input and output addresses
     cfg.input_addr = LibraryAccountType::Addr(suite.output_addr().to_string());
-    cfg.output_addr = suite.input_addr().to_string();
+    cfg.output_addr = LibraryAccountType::Addr(suite.input_addr().to_string());
     cfg.amount = IbcTransferAmount::FixedAmount(ONE_MILLION.into());
     cfg.memo = "Chancellor on brink of second bailout for banks.".to_string();
 
@@ -400,8 +400,8 @@ fn update_config_with_valid_config() {
     assert_eq!(
         lib_cfg,
         Config::new(
-            suite.output_addr().clone(),
-            suite.input_addr().clone(),
+            Addr::unchecked(suite.output_addr().clone()),
+            suite.input_addr().clone().to_string(),
             CheckedDenom::Native(NTRN.into()),
             IbcTransferAmount::FixedAmount(ONE_MILLION.into()),
             "Chancellor on brink of second bailout for banks.".to_string(),

--- a/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
@@ -43,7 +43,7 @@ struct LibraryConfig {
   // Account from which the funds are pulled (on the source chain)
   input_addr: LibraryAccountType,
   // Account to which the funds are sent (on the destination chain)
-  output_addr: String,
+  output_addr: LibraryAccountType,
   // Denom of the token to transfer
   denom: UncheckedDenom,
   // Amount to be transferred, either a fixed amount or the whole available balance.

--- a/docs/src/libraries/cosmwasm/neutron_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/neutron_ibc_transfer.md
@@ -43,7 +43,7 @@ struct LibraryConfig {
   // Account from which the funds are pulled (on the source chain)
   input_addr: LibraryAccountType,
   // Account to which the funds are sent (on the destination chain)
-  output_addr: String,
+  output_addr: LibraryAccountType,
   // Denom of the token to transfer
   denom: UncheckedDenom,
   // Amount to be transferred, either a fixed amount or the whole available balance.

--- a/e2e/examples/conditional_lp.rs
+++ b/e2e/examples/conditional_lp.rs
@@ -680,7 +680,7 @@ fn neutron_setup(
         processor: neutron_processor_address.to_string(),
         config: valence_neutron_ibc_transfer_library::msg::LibraryConfig::new(
             LibraryAccountType::Addr(neutron_input_acc_addr.clone()),
-            osmo_input_acc.to_string(),
+            LibraryAccountType::Addr(osmo_input_acc.to_string()),
             UncheckedDenom::Native(NEUTRON_CHAIN_DENOM.to_string()),
             IbcTransferAmount::FixedAmount(transfer_amount.into()),
             "".to_owned(),

--- a/e2e/examples/ibc_transfer_juno_ntrn.rs
+++ b/e2e/examples/ibc_transfer_juno_ntrn.rs
@@ -139,7 +139,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         processor: JUNO_CHAIN_ADMIN_ADDR.to_string(),
         config: LibraryConfig::new(
             LibraryAccountType::Addr(input_account.clone()),
-            output_account.clone(),
+            LibraryAccountType::Addr(output_account.clone()),
             UncheckedDenom::Native(neutron_on_juno_denom.to_string()),
             IbcTransferAmount::FixedAmount(transfer_amount.into()),
             "".to_owned(),

--- a/e2e/examples/ibc_transfer_ntrn_juno.rs
+++ b/e2e/examples/ibc_transfer_ntrn_juno.rs
@@ -145,7 +145,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         processor: NEUTRON_CHAIN_ADMIN_ADDR.to_string(),
         config: LibraryConfig::new(
             LibraryAccountType::Addr(input_account.clone()),
-            output_account.clone(),
+            LibraryAccountType::Addr(output_account.clone()),
             UncheckedDenom::Native(NEUTRON_CHAIN_DENOM.to_string()),
             IbcTransferAmount::FixedAmount(transfer_amount.into()),
             "".to_owned(),

--- a/e2e/examples/ibc_transfer_ntrn_juno_gaia_pfm.rs
+++ b/e2e/examples/ibc_transfer_ntrn_juno_gaia_pfm.rs
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         processor: NEUTRON_CHAIN_ADMIN_ADDR.to_string(),
         config: LibraryConfig::with_pfm_map(
             LibraryAccountType::Addr(input_account.clone()),
-            output_account.clone(),
+            LibraryAccountType::Addr(output_account.clone()),
             UncheckedDenom::Native(atom_on_neutron_via_juno.clone()),
             IbcTransferAmount::FixedAmount(transfer_amount.into()),
             "".to_owned(),

--- a/e2e/examples/ibc_transfer_osmo_juno_gaia_pfm.rs
+++ b/e2e/examples/ibc_transfer_osmo_juno_gaia_pfm.rs
@@ -184,7 +184,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         processor: OSMOSIS_CHAIN_ADMIN_ADDR.to_string(),
         config: LibraryConfig::with_pfm_map(
             LibraryAccountType::Addr(input_account.clone()),
-            output_account.clone(),
+            LibraryAccountType::Addr(output_account.clone()),
             UncheckedDenom::Native(atom_on_osmo_via_juno.clone()),
             IbcTransferAmount::FixedAmount(transfer_amount.into()),
             "".to_owned(),

--- a/e2e/examples/ibc_transfer_osmo_ntrn.rs
+++ b/e2e/examples/ibc_transfer_osmo_ntrn.rs
@@ -146,7 +146,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         processor: OSMOSIS_CHAIN_ADMIN_ADDR.to_string(),
         config: LibraryConfig::new(
             LibraryAccountType::Addr(input_account.clone()),
-            output_account.clone(),
+            LibraryAccountType::Addr(output_account.clone()),
             UncheckedDenom::Native(OSMOSIS_CHAIN_DENOM.to_string()),
             IbcTransferAmount::FixedAmount(transfer_amount.into()),
             "".to_owned(),

--- a/program-manager/schema/valence-program-manager.json
+++ b/program-manager/schema/valence-program-manager.json
@@ -1128,7 +1128,7 @@
             "type": "string"
           },
           "output_addr": {
-            "type": "string"
+            "$ref": "#/definitions/LibraryAccountType"
           },
           "remote_chain_info": {
             "$ref": "#/definitions/RemoteChainInfo"
@@ -1708,9 +1708,13 @@
             ]
           },
           "output_addr": {
-            "type": [
-              "string",
-              "null"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "remote_chain_info": {


### PR DESCRIPTION
We had a small issue in the ibc transfer libraries, where the output (the recipient) address was a string and not `LibraryAccountType`.

The reason we need to work with `LibraryAccountType` even for addresses that are on other chains is that this is our helper type to link an account id to its address.
In short, when you build the program config you use account ids to represent an account, when you use the manager, the manager instantiate the account and "inject" the address where this account id was used.

P.s, an id is only used for valence accounts, if a string is needed when using the `LibraryAccountType` type, you can always use `LibraryAccountType::Addr(String)` to put any string there that represents an address, and in contract use `.to_string()` to get that string.
We probably will also add something like `LibraryAccountType::Binary(Binary)` for solidity in the future.