### PR TITLE
Add noble local-ic config setup

### DIFF
--- a/e2e/chains/neutron_noble.json
+++ b/e2e/chains/neutron_noble.json
@@ -1,0 +1,277 @@
+{
+  "chains": [
+    {
+      "name": "gaia",
+      "chain_id": "localcosmos-1",
+      "denom": "uatom",
+      "binary": "gaiad",
+      "bech32_prefix": "cosmos",
+      "docker_image": {
+        "version": "v15.0.0-rc2"
+      },
+      "gas_prices": "0%DENOM%",
+      "chain_type": "cosmos",
+      "coin_type": 118,
+      "trusting_period": "336h",
+      "gas_adjustment": 1.3,
+      "number_vals": 1,
+      "number_node": 0,
+      "ibc_paths": ["gaia-noble"],
+      "debugging": true,
+      "block_time": "1s",
+      "genesis": {
+        "modify": [
+          {
+            "key": "app_state.gov.params.voting_period",
+            "value": "3s"
+          },
+          {
+            "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",
+            "value": [
+              "/cosmos.bank.v1beta1.MsgSend",
+              "/cosmos.bank.v1beta1.MsgMultiSend",
+              "/cosmos.staking.v1beta1.MsgDelegate",
+              "/cosmos.staking.v1beta1.MsgUndelegate",
+              "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+              "/cosmos.staking.v1beta1.MsgRedeemTokensforShares",
+              "/cosmos.staking.v1beta1.MsgTokenizeShares",
+              "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+              "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+              "/ibc.applications.transfer.v1.MsgTransfer"
+            ]
+          }
+        ],
+        "accounts": [
+          {
+            "name": "acc0",
+            "address": "cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr",
+            "amount": "20000000000000%DENOM%",
+            "mnemonic": "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
+          },
+          {
+            "name": "acc1",
+            "address": "cosmos1kljf09rj77uxeu5lye7muejx6ajsu55cc3re5h",
+            "amount": "20000000000000%DENOM%",
+            "mnemonic": "across army acoustic hurt help sad turkey switch popular fade purse obvious session tuition file asset cover agree number motor pupil slim hundred busy"
+          },
+          {
+            "name": "acc2",
+            "address": "cosmos17lp3n649rxt2jadn455frcj0q6anjndsw0xwrz",
+            "amount": "20000000000000%DENOM%",
+            "mnemonic": "demise erode feature decade dune uncle limb stock quit nation neck marriage pledge achieve tell cat baby wrist expect scrub welcome hole ribbon mirror"
+          },
+          {
+            "name": "acc3",
+            "address": "cosmos1p0var04vhr03r2j8zwv4jfrz73rxgjt5v29x49",
+            "amount": "20000000000000%DENOM%",
+            "mnemonic": "scheme force walk answer decide submit crowd flush slim raw type tackle lend follow multiply sting rule jealous coyote slight toddler skirt crawl decade"
+          }
+        ]
+      }
+    },
+    {
+      "name": "neutron",
+      "chain_id": "localneutron-1",
+      "denom": "untrn",
+      "binary": "neutrond",
+      "bech32_prefix": "neutron",
+      "docker_image": {
+        "version": "v3.0.4",
+        "repository": "ghcr.io/strangelove-ventures/heighliner/neutron"
+      },
+      "gas_prices": "0.0untrn,0.0uatom",
+      "chain_type": "cosmos",
+      "coin_type": 118,
+      "trusting_period": "336h",
+      "gas_adjustment": 1.3,
+      "number_vals": 1,
+      "number_node": 0,
+      "ics_consumer_link": "localcosmos-1",
+      "ibc_paths": ["neutron-noble"],
+      "debugging": true,
+      "block_time": "1s",
+      "genesis": {
+        "modify": [
+          {
+            "key": "consensus_params.block.max_gas",
+            "value": "100000000"
+          },
+          {
+            "key": "app_state.ccvconsumer.params.soft_opt_out_threshold",
+            "value": "0.05"
+          },
+          {
+            "key": "app_state.ccvconsumer.params.reward_denoms",
+            "value": ["untrn"]
+          },
+          {
+            "key": "app_state.ccvconsumer.params.provider_reward_denoms",
+            "value": ["uatom"]
+          },
+          {
+            "key": "app_state.globalfee.params.minimum_gas_prices",
+            "value": [
+              {
+                "denom": "untrn",
+                "amount": "0"
+              }
+            ]
+          },
+          {
+            "key": "app_state.feeburner.params.treasury_address",
+            "value": "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky"
+          },
+          {
+            "key": "app_state.tokenfactory.params.fee_collector_address",
+            "value": "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky"
+          },
+          {
+            "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",
+            "value": [
+              "/cosmos.bank.v1beta1.MsgSend",
+              "/cosmos.bank.v1beta1.MsgMultiSend",
+              "/cosmos.staking.v1beta1.MsgDelegate",
+              "/cosmos.staking.v1beta1.MsgUndelegate",
+              "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+              "/cosmos.staking.v1beta1.MsgRedeemTokensforShares",
+              "/cosmos.staking.v1beta1.MsgTokenizeShares",
+              "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+              "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+              "/ibc.applications.transfer.v1.MsgTransfer",
+              "/ibc.lightclients.localhost.v2.ClientState",
+              "/ibc.core.client.v1.MsgCreateClient",
+              "/ibc.core.client.v1.Query/ClientState",
+              "/ibc.core.client.v1.Query/ConsensusState",
+              "/ibc.core.connection.v1.Query/Connection"
+            ]
+          }
+        ],
+        "accounts": [
+          {
+            "name": "acc0",
+            "address": "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky",
+            "amount": "10000000000000%DENOM%",
+            "mnemonic": "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
+          },
+          {
+            "name": "acc1",
+            "address": "neutron1kljf09rj77uxeu5lye7muejx6ajsu55cuw2mws",
+            "amount": "10000000000000%DENOM%",
+            "mnemonic": "across army acoustic hurt help sad turkey switch popular fade purse obvious session tuition file asset cover agree number motor pupil slim hundred busy"
+          },
+          {
+            "name": "acc2",
+            "address": "neutron17lp3n649rxt2jadn455frcj0q6anjnds2s0ve9",
+            "amount": "10000000000000%DENOM%",
+            "mnemonic": "demise erode feature decade dune uncle limb stock quit nation neck marriage pledge achieve tell cat baby wrist expect scrub welcome hole ribbon mirror"
+          },
+          {
+            "name": "acc3",
+            "address": "neutron1p0var04vhr03r2j8zwv4jfrz73rxgjt5g4vy0z",
+            "amount": "10000000000000%DENOM%",
+            "mnemonic": "scheme force walk answer decide submit crowd flush slim raw type tackle lend follow multiply sting rule jealous coyote slight toddler skirt crawl decade"
+          }
+        ]
+      }
+    },
+    {
+      "name": "noble",
+      "chain_id": "localnoble-1",
+      "denom": "ustake",
+      "binary": "nobled",
+      "bech32_prefix": "noble",
+      "docker_image": {
+        "version": "v8.0.7",
+        "repository": "ghcr.io/strangelove-ventures/heighliner/noble"
+      },
+      "gas_prices": "0.0025%DENOM%",
+      "chain_type": "cosmos",
+      "coin_type": 118,
+      "trusting_period": "336h",
+      "gas_adjustment": 2,
+      "number_vals": 1,
+      "number_node": 0,
+      "ibc_paths": ["gaia-noble", "neutron-noble"],
+      "debugging": true,
+      "block_time": "1s",
+      "genesis": {
+        "modify": [
+          {
+            "key": "app_state.authority.owner",
+            "value": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d"
+          },
+          {
+            "key": "app_state.bank.denom_metadata",
+            "value": [
+              {
+                "description": "Circle USD Coin",
+                "denom_units": [
+                  { "denom": "uusdc", "exponent": 0, "aliases": ["microusdc"] },
+                  { "denom": "usdc", "exponent": 6 }
+                ],
+                "base": "uusdc",
+                "display": "usdc",
+                "name": "Circle USD Coin",
+                "symbol": "USDC"
+              }
+            ]
+          },
+          {
+            "key": "app_state.fiat-tokenfactory.mintingDenom",
+            "value": { "denom": "uusdc" }
+          },
+          {
+            "key": "app_state.fiat-tokenfactory.owner",
+            "value": { "address": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d" }
+          },
+          {
+            "key": "app_state.fiat-tokenfactory.masterMinter",
+            "value": { "address": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d" }
+          },
+          {
+            "key": "app_state.fiat-tokenfactory.paused",
+            "value": { "paused": false }
+          },
+          {
+            "key": "app_state.fiat-tokenfactory.mintersList",
+            "value": [{"address": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d", "allowance": {"denom": "uusdc", "amount": "1000000000000000"}}]
+          },
+          {
+            "key": "app_state.fiat-tokenfactory.minterControllerList",
+            "value": [{"minter": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d"}]
+          },
+          {
+            "key": "app_state.cctp",
+            "value": {
+              "owner": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d",
+              "attesterManager": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d",
+              "tokenController": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d",
+              "burningAndMintingPaused": { "paused": false },
+              "sendingAndReceivingMessagesPaused": { "paused": false },
+              "nextAvailableNonce": { "nonce": 0 },
+              "signatureThreshold": { "amount": 1 }
+            }
+          },
+          {
+            "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",
+            "value": ["*"]
+          }
+        ],
+        "accounts": [
+          {
+            "name": "acc0",
+            "address": "noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d",
+            "amount": "10000000000000%DENOM%",
+            "mnemonic": "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
+          },
+          {
+            "name": "acc1",
+            "address": "noble1kljf09rj77uxeu5lye7muejx6ajsu55csjk3ve",
+            "amount": "10000000000000%DENOM%",
+            "mnemonic": "across army acoustic hurt help sad turkey switch popular fade purse obvious session tuition file asset cover agree number motor pupil slim hundred busy"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding config here to spin-up noble to set up the chain with all the initial values required to test bridging assets. Doing this PR first in case @bekauz you need to spin up noble for some reason, which I don't think you'll be doing soon but anyways.

Additional things that need to be done to be able to trigger the bridging (reproduced in CLI) and taken from their go integration tests in noble-assets/noble:

```bash
# Get the module account for cctp module which happens to be noble12l2w4ugfz4m6dd73yysz477jszqnfughxvkss5
nobled q auth module-accounts

# Mint some USDC to myself
nobled tx fiat-tokenfactory mint noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d 1000000uusdc --from admin --chain-id localnoble-1 -y

# Configure the cctp module account to allow minting
nobled tx fiat-tokenfactory configure-minter-controller noble1hj5fveer5cjtn4wd6wstzugjfdxzl0xpw0865d noble12l2w4ugfz4m6dd73yysz477jszqnfughxvkss5 --from admin --chain-id localnoble-1 -y

nobled tx fiat-tokenfactory configure-minter noble12l2w4ugfz4m6dd73yysz477jszqnfughxvkss5 10000000000uusdc --from admin --chain-id localnoble-1 -y

# Add a remote token messenger for a destination domain (in this case we are using domain-id 0), my guess is this is the contract address that mints
nobled tx cctp add-remote-token-messenger 0 0xfce4ce85e1f74c01e0ecccd8bbc4606f83d3fc90 --from admin --chain-id localnoble-1 -y

# Link the token, uusdc representation on that domain
nobled tx cctp link-token-pair uusdc 0x07865c6E87B9F70255377e024ace6630C1Eaa37F 0 --from admin --chain-id localnoble-1 -y

# Call the deposit-for burn (bridging). Here im bridging 1000 uusdc to domain 0 and recipient address is 0xfce... (could be any address)
nobled tx cctp deposit-for-burn 1000 0 0xfce4ce85e1f74c01e0ecccd8bbc4606f83d3fc90 uusdc --from admin --chain-id localnoble-1 -y
```

Next steps when I'm writing my tests will be writing a helper that does all this via rust before writing my tests