### PR TITLE
remove admin check from registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9122,7 +9122,6 @@ version = "0.2.0"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
- "cw-ownable",
  "serde",
  "serde_json",
 ]

--- a/contracts/program-registry/schema/valence-program-registry.json
+++ b/contracts/program-registry/schema/valence-program-registry.json
@@ -29,6 +29,15 @@
         "properties": {
           "reserve_id": {
             "type": "object",
+            "required": [
+              "addr"
+            ],
+            "properties": {
+              "addr": {
+                "description": "Temp address that can save a program to the reserved id (manager)",
+                "type": "string"
+              }
+            },
             "additionalProperties": false
           }
         },
@@ -45,16 +54,27 @@
             "type": "object",
             "required": [
               "id",
+              "owner",
               "program_config"
             ],
             "properties": {
               "id": {
+                "description": "The reserved id",
                 "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
+              "owner": {
+                "description": "The owner of the program that can update it later",
+                "type": "string"
+              },
               "program_config": {
-                "$ref": "#/definitions/Binary"
+                "description": "The program config to save",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -89,134 +109,11 @@
           }
         },
         "additionalProperties": false
-      },
-      {
-        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
-        "type": "object",
-        "required": [
-          "update_ownership"
-        ],
-        "properties": {
-          "update_ownership": {
-            "$ref": "#/definitions/Action"
-          }
-        },
-        "additionalProperties": false
       }
     ],
     "definitions": {
-      "Action": {
-        "description": "Actions that can be taken to alter the contract's ownership",
-        "oneOf": [
-          {
-            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
-            "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
-            "properties": {
-              "transfer_ownership": {
-                "type": "object",
-                "required": [
-                  "new_owner"
-                ],
-                "properties": {
-                  "expiry": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/Expiration"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "new_owner": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
-            "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
-          },
-          {
-            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
-            "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
-          }
-        ]
-      },
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-        "type": "string"
-      },
-      "Expiration": {
-        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-        "oneOf": [
-          {
-            "description": "AtHeight will expire when `env.block.height` >= height",
-            "type": "object",
-            "required": [
-              "at_height"
-            ],
-            "properties": {
-              "at_height": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "AtTime will expire when `env.block.time` >= time",
-            "type": "object",
-            "required": [
-              "at_time"
-            ],
-            "properties": {
-              "at_time": {
-                "$ref": "#/definitions/Timestamp"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Never will never expire. Used to express the empty variant",
-            "type": "object",
-            "required": [
-              "never"
-            ],
-            "properties": {
-              "never": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "Timestamp": {
-        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-        "allOf": [
-          {
-            "$ref": "#/definitions/Uint64"
-          }
-        ]
-      },
-      "Uint64": {
-        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
       }
     }

--- a/contracts/program-registry/src/contract.rs
+++ b/contracts/program-registry/src/contract.rs
@@ -33,40 +33,35 @@ pub fn instantiate(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::ReserveId {} => execute::reserve_id(deps, &info),
-        ExecuteMsg::SaveProgram { id, program_config } => {
-            execute::save_program(deps, &info, id, program_config)
-        }
+        ExecuteMsg::ReserveId { addr } => execute::reserve_id(deps, addr),
+        ExecuteMsg::SaveProgram {
+            id,
+            owner,
+            program_config,
+        } => execute::save_program(deps, &info, id, owner, program_config),
         ExecuteMsg::UpdateProgram { id, program_config } => {
             execute::update_program(deps, &info, id, program_config)
-        }
-        ExecuteMsg::UpdateOwnership(ownership_action) => {
-            cw_ownable::update_ownership(deps, &env.block, &info.sender, ownership_action)?;
-
-            Ok(Response::new().add_attribute("method", "update_ownership"))
         }
     }
 }
 
 mod execute {
     use cosmwasm_std::{Binary, DepsMut, MessageInfo, Response};
-    use cw_ownable::assert_owner;
 
     use crate::{
-        state::{LAST_ID, PROGRAMS, PROGRAMS_BACKUP},
+        state::{LAST_ID, PROGRAMS, PROGRAMS_BACKUP, PROGRAMS_OWNERS},
         ContractError,
     };
 
-    pub fn reserve_id(deps: DepsMut, info: &MessageInfo) -> Result<Response, ContractError> {
-        assert_owner(deps.storage, &info.sender)?;
-
+    pub fn reserve_id(deps: DepsMut, addr: String) -> Result<Response, ContractError> {
         let id = LAST_ID.load(deps.storage)? + 1;
         LAST_ID.save(deps.storage, &id)?;
+        PROGRAMS_OWNERS.save(deps.storage, id, &deps.api.addr_validate(&addr)?)?;
 
         Ok(Response::new()
             .add_attribute("method", "reserve_id")
@@ -77,15 +72,23 @@ mod execute {
         deps: DepsMut,
         info: &MessageInfo,
         id: u64,
+        owner: String,
         program_config: Binary,
     ) -> Result<Response, ContractError> {
-        assert_owner(deps.storage, &info.sender)?;
+        // When id reserved, only that reserver can save program to this id
+        let id_temp_owner = PROGRAMS_OWNERS.load(deps.storage, id)?;
+        if id_temp_owner != info.sender {
+            return Err(ContractError::UnauthorizedToSave(id_temp_owner.to_string()));
+        }
 
         if PROGRAMS.has(deps.storage, id) {
             return Err(ContractError::ProgramAlreadyExists(id));
         } else {
             PROGRAMS.save(deps.storage, id, &program_config)?;
         }
+
+        // After saving program, update owner so only the owner will be able to update this program
+        PROGRAMS_OWNERS.save(deps.storage, id, &deps.api.addr_validate(&owner)?)?;
 
         Ok(Response::new()
             .add_attribute("method", "get_id")
@@ -98,7 +101,12 @@ mod execute {
         id: u64,
         program_config: Binary,
     ) -> Result<Response, ContractError> {
-        assert_owner(deps.storage, &info.sender)?;
+        let program_owner = PROGRAMS_OWNERS.load(deps.storage, id)?;
+        if program_owner != info.sender {
+            return Err(ContractError::UnauthorizedToUpdate(
+                program_owner.to_string(),
+            ));
+        }
 
         match PROGRAMS.may_load(deps.storage, id)? {
             Some(previous_program) => {

--- a/contracts/program-registry/src/error.rs
+++ b/contracts/program-registry/src/error.rs
@@ -14,4 +14,9 @@ pub enum ContractError {
     ProgramAlreadyExists(u64),
     #[error("Program doesn't exists with id {0}")]
     ProgramDoesntExists(u64),
+
+    #[error("Unauthorized: This id is reserved to {0}")]
+    UnauthorizedToSave(String),
+    #[error("Unauthorized: This id can be only updated by {0}")]
+    UnauthorizedToUpdate(String),
 }

--- a/contracts/program-registry/src/state.rs
+++ b/contracts/program-registry/src/state.rs
@@ -1,6 +1,7 @@
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Addr, Binary};
 use cw_storage_plus::{Item, Map};
 
 pub const LAST_ID: Item<u64> = Item::new("id");
+pub const PROGRAMS_OWNERS: Map<u64, Addr> = Map::new("programs_owners");
 pub const PROGRAMS: Map<u64, Binary> = Map::new("programs");
 pub const PROGRAMS_BACKUP: Map<u64, Binary> = Map::new("programs_backups");

--- a/packages/program-registry-utils/Cargo.toml
+++ b/packages/program-registry-utils/Cargo.toml
@@ -12,4 +12,3 @@ cosmwasm-schema = { workspace = true }
 cosmwasm-std    = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
-cw-ownable      = { workspace = true }

--- a/packages/program-registry-utils/src/lib.rs
+++ b/packages/program-registry-utils/src/lib.rs
@@ -1,19 +1,27 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Binary;
-use cw_ownable::cw_ownable_execute;
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub admin: String, // Only admin can operate on the registry (for now)
 }
 
-#[cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
     /// "Lock" an id for a program to avoid race conditions
-    ReserveId {},
+    ReserveId {
+        /// Temp address that can save a program to the reserved id (manager)
+        addr: String,
+    },
     /// Save a new program config for the id
-    SaveProgram { id: u64, program_config: Binary },
+    SaveProgram {
+        /// The reserved id
+        id: u64,
+        /// The owner of the program that can update it later
+        owner: String,
+        /// The program config to save
+        program_config: Binary,
+    },
     /// Update a program config for the id
     UpdateProgram { id: u64, program_config: Binary },
 }

--- a/program-manager/src/domain/cosmos_cw.rs
+++ b/program-manager/src/domain/cosmos_cw.rs
@@ -152,8 +152,10 @@ impl Connector for CosmosCosmwasmConnector {
         let registry_addr = GLOBAL_CONFIG.lock().await.get_registry_addr();
 
         // Execute a message to reserve the program id
-        let msg = to_vec(&valence_program_registry_utils::ExecuteMsg::ReserveId {})
-            .map_err(CosmosCosmwasmError::SerdeJsonError)?;
+        let msg = to_vec(&valence_program_registry_utils::ExecuteMsg::ReserveId {
+            addr: self.wallet.account_address.clone(),
+        })
+        .map_err(CosmosCosmwasmError::SerdeJsonError)?;
 
         let m = MsgExecuteContract {
             sender: self.wallet.account_address.clone(),
@@ -798,6 +800,7 @@ impl Connector for CosmosCosmwasmConnector {
 
         let msg = to_vec(&valence_program_registry_utils::ExecuteMsg::SaveProgram {
             id: config.id,
+            owner: config.owner.clone(),
             program_config: program_binary,
         })
         .map_err(CosmosCosmwasmError::SerdeJsonError)?;


### PR DESCRIPTION
Tested, so it works.

Up until now only the owner of the registry could save programs. 
But this was limiting because it would mean only a single wallet could run the manager (or share access to this wallet to run programs).
Not something we want to do, so we change it to allow anyone use the manager (and save his program to the registry).

Important security here is that we still have program ownership concept here but we have 2 address, the idea is that:
1. The manager reserves and id, so in the meanwhile he is the "temp_owner" of this program id.
2. When the manager saves the program, he also specify which address is the owner, so ownership is transferred to the new owner
3. Only the owner can update that program.

This is done so there won't be any cases where reserved id is saved by someone else, or anyone could update a program in the registry.