### PR TITLE
add pfm config sections to neutron and generic ibc transfer libraries

### DIFF
--- a/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
@@ -108,7 +108,7 @@ Generic IBC Transfer library can be configured to make use of PFM as follows:
   More information about this can be found in the [official documentation](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware#full-example---chain-forward-a-b-c-d-with-retry-on-timeout
   ).
 
-Consider an example configuration transferring tokens from Neutron to Gaia via Juno.
+Consider an example configuration transferring tokens from Osmosis to Gaia via Juno.
 Library config may look like this:
 
 ```rust
@@ -119,13 +119,13 @@ LibraryConfig {
     amount: IbcTransferAmount::FixedAmount(transfer_amount),
     memo: "".to_string(),
     remote_chain_info: RemoteChainInfo {
-        channel_id: neutron_to_juno_channel_id,
+        channel_id: osmosis_to_juno_channel_id,
         ibc_transfer_timeout: Some(500u64.into()),
     },
     denom_to_pfm_map: BTreeMap::from([(
         denom,
         PacketForwardMiddlewareConfig {
-            local_to_hop_chain_channel_id: neutron_to_juno_channel_id,
+            local_to_hop_chain_channel_id: osmosis_to_juno_channel_id,
             hop_to_destination_chain_channel_id: juno_to_gaia_channel_id,
             hop_chain_receiver_address: "pfm".to_string(),
         },

--- a/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
@@ -83,3 +83,52 @@ struct PacketForwardMiddlewareConfig {
   hop_chain_receiver_address: String,
 }
 ```
+
+### Packet-Forward Middleware
+
+The library supports multi-hop IBC transfers using the Packet Forward Middleware (PFM).
+This allows tokens to be transferred through an intermediate chain to reach their final
+destination. More information about the PFM functionality can be found in the [official
+documentation](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware).
+
+Generic IBC Transfer library can be configured to make use of PFM as follows:
+
+- `output_addr` is set to the final receiver address on the final destination chain
+- `remote_chain_info` is configured between the origin and intermediate chain
+- `denom_to_pfm_map` is configured to map the origin denom to its respective
+`PacketForwardMiddlewareConfig` which should contain:
+
+  - `local_to_hop_chain_channel_id` - origin to intermediate chain channel id
+  - `hop_to_destination_chain_channel_id` - intermediate to destination chain channel id
+  - `hop_chain_receiver_address` - address where funds should settle on the intermediate
+  chain in case of a failure
+
+> Official packet-forward-middleware recommends to configure intermediate chain settlement
+  addresses (`hop_chain_receiver_address`) with an invalid bech32 string such as `"pfm"`.
+  More information about this can be found in the [official documentation](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware#full-example---chain-forward-a-b-c-d-with-retry-on-timeout
+  ).
+
+Consider an example configuration transferring tokens from Neutron to Gaia via Juno.
+Library config may look like this:
+
+```rust
+LibraryConfig {
+    input_addr: input_acc,
+    output_addr: output_acc,
+    denom: UncheckedDenom::Native(target_denom),
+    amount: IbcTransferAmount::FixedAmount(transfer_amount),
+    memo: "".to_string(),
+    remote_chain_info: RemoteChainInfo {
+        channel_id: neutron_to_juno_channel_id,
+        ibc_transfer_timeout: Some(500u64.into()),
+    },
+    denom_to_pfm_map: BTreeMap::from([(
+        denom,
+        PacketForwardMiddlewareConfig {
+            local_to_hop_chain_channel_id: neutron_to_juno_channel_id,
+            hop_to_destination_chain_channel_id: juno_to_gaia_channel_id,
+            hop_chain_receiver_address: "pfm".to_string(),
+        },
+    )]),
+}
+```

--- a/docs/src/libraries/cosmwasm/neutron_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/neutron_ibc_transfer.md
@@ -83,3 +83,53 @@ struct PacketForwardMiddlewareConfig {
   hop_chain_receiver_address: String,
 }
 ```
+
+
+### Packet-Forward Middleware
+
+The library supports multi-hop IBC transfers using the Packet Forward Middleware (PFM).
+This allows tokens to be transferred through an intermediate chain to reach their final
+destination. More information about the PFM functionality can be found in the [official
+documentation](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware).
+
+Neutron IBC Transfer library can be configured to make use of PFM as follows:
+
+- `output_addr` is set to the final receiver address on the final destination chain
+- `remote_chain_info` is configured between the origin and intermediate chain
+- `denom_to_pfm_map` is configured to map the origin denom to its respective
+`PacketForwardMiddlewareConfig` which should contain:
+
+  - `local_to_hop_chain_channel_id` - origin to intermediate chain channel id
+  - `hop_to_destination_chain_channel_id` - intermediate to destination chain channel id
+  - `hop_chain_receiver_address` - address where funds should settle on the intermediate
+  chain in case of a failure
+
+> Official packet-forward-middleware recommends to configure intermediate chain settlement
+  addresses (`hop_chain_receiver_address`) with an invalid bech32 string such as `"pfm"`.
+  More information about this can be found in the [official documentation](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware#full-example---chain-forward-a-b-c-d-with-retry-on-timeout
+  ).
+
+Consider an example configuration transferring tokens from Neutron to Gaia via Juno.
+Library config may look like this:
+
+```rust
+let cfg = LibraryConfig {
+    input_addr: input_acc,
+    output_addr: output_acc,
+    denom: UncheckedDenom::Native(target_denom),
+    amount: IbcTransferAmount::FixedAmount(transfer_amount),
+    memo: "".to_string(),
+    remote_chain_info: RemoteChainInfo {
+        channel_id: neutron_to_juno_channel_id,
+        ibc_transfer_timeout: Some(500u64.into()),
+    },
+    denom_to_pfm_map: BTreeMap::from([(
+        denom,
+        PacketForwardMiddlewareConfig {
+            local_to_hop_chain_channel_id: neutron_to_juno_channel_id,
+            hop_to_destination_chain_channel_id: juno_to_gaia_channel_id,
+            hop_chain_receiver_address: "pfm".to_string(),
+        },
+    )]),
+}
+```


### PR DESCRIPTION
closes #257 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new "Packet-Forward Middleware" section to enhance the guidance on multi-hop IBC transfers in two transfer libraries.
  - Provides detailed configuration instructions and example setups for enabling token transfers through an intermediate chain, including parameter recommendations and mapping strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->