### PR TITLE
fix: remove neutron dependency from ICA libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8384,6 +8384,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "thiserror 1.0.69",
+ "valence-ibc-utils",
  "valence-macros",
 ]
 
@@ -8740,11 +8741,11 @@ dependencies = [
  "cosmwasm-std 2.2.1",
  "cw-ownable",
  "cw-storage-plus 2.0.0",
- "neutron-sdk",
  "prost 0.13.5",
  "schemars",
  "serde",
  "thiserror 1.0.69",
+ "valence-ibc-utils",
  "valence-library-base",
  "valence-library-utils",
  "valence-macros",
@@ -8764,6 +8765,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "valence-account-utils",
  "valence-ibc-utils",
 ]
 
@@ -8797,14 +8799,13 @@ dependencies = [
  "cw-utils 2.0.0",
  "cw20 2.0.0",
  "cw20-base 2.0.0",
- "neutron-sdk",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "valence-account-utils",
  "valence-base-account",
- "valence-interchain-account",
+ "valence-ibc-utils",
  "valence-macros",
 ]
 

--- a/contracts/accounts/interchain_account/Cargo.toml
+++ b/contracts/accounts/interchain_account/Cargo.toml
@@ -14,14 +14,15 @@ crate-type = ["cdylib", "rlib"]
 library = []
 
 [dependencies]
-cosmwasm-schema   = { workspace = true }
-cosmwasm-std      = { workspace = true }
-cw-ownable        = { workspace = true }
-cw-storage-plus   = { workspace = true }
-cw2               = { workspace = true }
-schemars          = { workspace = true }
-serde             = { workspace = true }
-thiserror         = { workspace = true }
-neutron-sdk       = { workspace = true }
-serde_json        = { workspace = true }
-valence-ibc-utils = { workspace = true, features = ["neutron"] }
+cosmwasm-schema       = { workspace = true }
+cosmwasm-std          = { workspace = true }
+cw-ownable            = { workspace = true }
+cw-storage-plus       = { workspace = true }
+cw2                   = { workspace = true }
+schemars              = { workspace = true }
+serde                 = { workspace = true }
+thiserror             = { workspace = true }
+neutron-sdk           = { workspace = true }
+serde_json            = { workspace = true }
+valence-account-utils = { workspace = true }
+valence-ibc-utils     = { workspace = true, features = ["neutron"] }

--- a/contracts/accounts/interchain_account/schema/valence-interchain-account.json
+++ b/contracts/accounts/interchain_account/schema/valence-interchain-account.json
@@ -134,7 +134,7 @@
               "msgs": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/ProtobufAny"
+                  "$ref": "#/definitions/AnyMsg"
                 }
               }
             },
@@ -221,6 +221,23 @@
             ]
           }
         ]
+      },
+      "AnyMsg": {
+        "description": "A message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
+        "type": "object",
+        "required": [
+          "type_url",
+          "value"
+        ],
+        "properties": {
+          "type_url": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/definitions/Binary"
+          }
+        },
+        "additionalProperties": false
       },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
@@ -643,22 +660,6 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
-          }
-        },
-        "additionalProperties": false
-      },
-      "ProtobufAny": {
-        "type": "object",
-        "required": [
-          "type_url",
-          "value"
-        ],
-        "properties": {
-          "type_url": {
-            "type": "string"
-          },
-          "value": {
-            "$ref": "#/definitions/Binary"
           }
         },
         "additionalProperties": false

--- a/contracts/accounts/interchain_account/schema/valence-interchain-account.json
+++ b/contracts/accounts/interchain_account/schema/valence-interchain-account.json
@@ -648,7 +648,6 @@
         "additionalProperties": false
       },
       "ProtobufAny": {
-        "description": "Type for wrapping any protobuf message",
         "type": "object",
         "required": [
           "type_url",
@@ -656,16 +655,10 @@
         ],
         "properties": {
           "type_url": {
-            "description": "*type_url** describes the type of the serialized message",
             "type": "string"
           },
           "value": {
-            "description": "*value** must be a valid serialized protocol buffer of the above specified type",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
+            "$ref": "#/definitions/Binary"
           }
         },
         "additionalProperties": false

--- a/contracts/accounts/interchain_account/src/bin/schema.rs
+++ b/contracts/accounts/interchain_account/src/bin/schema.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::write_api;
 
-use valence_interchain_account::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use valence_account_utils::ica::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
     write_api! {

--- a/contracts/accounts/interchain_account/src/contract.rs
+++ b/contracts/accounts/interchain_account/src/contract.rs
@@ -65,17 +65,16 @@ pub fn execute(
 }
 
 mod execute {
-    use cosmwasm_std::{ensure, CosmosMsg, DepsMut, Empty, Env, MessageInfo, Response, StdError};
+    use cosmwasm_std::{
+        ensure, AnyMsg, CosmosMsg, DepsMut, Empty, Env, MessageInfo, Response, StdError,
+    };
     use neutron_sdk::{
         bindings::{msg::NeutronMsg, query::NeutronQuery},
         query::min_ibc_fee::query_min_ibc_fee,
     };
     use valence_account_utils::ica::IcaState;
-    use valence_ibc_utils::{
-        neutron::{
-            flatten_ntrn_ibc_fee, min_ntrn_ibc_fee, query_ica_registration_fee, register_ica_msg,
-        },
-        types::ProtobufAny,
+    use valence_ibc_utils::neutron::{
+        flatten_ntrn_ibc_fee, min_ntrn_ibc_fee, query_ica_registration_fee, register_ica_msg,
     };
 
     use crate::{
@@ -192,7 +191,7 @@ mod execute {
         deps: DepsMut<NeutronQuery>,
         env: Env,
         info: MessageInfo,
-        msgs: Vec<ProtobufAny>,
+        msgs: Vec<AnyMsg>,
     ) -> Result<Response<NeutronMsg>, ContractError> {
         // If not admin, check if it's an approved library
         ensure!(

--- a/contracts/accounts/interchain_account/src/lib.rs
+++ b/contracts/accounts/interchain_account/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod contract;
 pub mod error;
-pub mod msg;
 pub mod state;

--- a/contracts/accounts/interchain_account/src/state.rs
+++ b/contracts/accounts/interchain_account/src/state.rs
@@ -1,7 +1,6 @@
 use cosmwasm_std::{Addr, Empty};
 use cw_storage_plus::{Item, Map};
-
-use crate::msg::{IcaState, RemoteDomainInfo};
+use valence_account_utils::ica::{IcaState, RemoteDomainInfo};
 
 // Approved libraries that can execute actions on behalf of the account
 pub const APPROVED_LIBRARIES: Map<Addr, Empty> = Map::new("libraries");

--- a/contracts/libraries/ica-cctp-transfer/Cargo.toml
+++ b/contracts/libraries/ica-cctp-transfer/Cargo.toml
@@ -22,7 +22,7 @@ schemars              = { workspace = true }
 serde                 = { workspace = true }
 thiserror             = { workspace = true }
 valence-macros        = { workspace = true }
-valence-library-utils = { workspace = true, features = ["neutron"] }
+valence-library-utils = { workspace = true }
 valence-library-base  = { workspace = true }
+valence-ibc-utils     = { workspace = true }
 prost                 = { workspace = true, features = ["derive"] }
-neutron-sdk           = { workspace = true }

--- a/contracts/libraries/ica-cctp-transfer/src/contract.rs
+++ b/contracts/libraries/ica-cctp-transfer/src/contract.rs
@@ -40,9 +40,8 @@ pub fn execute(
 }
 
 mod functions {
-    use cosmwasm_std::{Binary, DepsMut, Env, MessageInfo, Response};
+    use cosmwasm_std::{AnyMsg, Binary, DepsMut, Env, MessageInfo, Response};
     use prost::{Message, Name};
-    use valence_ibc_utils::types::ProtobufAny;
     use valence_library_utils::{
         error::LibraryError,
         ica::{execute_on_behalf_of, get_remote_ica_address},
@@ -74,7 +73,7 @@ mod functions {
                 };
 
                 // Create the Any
-                let any_msg = ProtobufAny {
+                let any_msg = AnyMsg {
                     type_url: MsgDepositForBurn::type_url(),
                     value: Binary::from(proto_msg.encode_to_vec()),
                 };

--- a/contracts/libraries/ica-cctp-transfer/src/contract.rs
+++ b/contracts/libraries/ica-cctp-transfer/src/contract.rs
@@ -41,8 +41,8 @@ pub fn execute(
 
 mod functions {
     use cosmwasm_std::{Binary, DepsMut, Env, MessageInfo, Response};
-    use neutron_sdk::bindings::types::ProtobufAny;
     use prost::{Message, Name};
+    use valence_ibc_utils::types::ProtobufAny;
     use valence_library_utils::{
         error::LibraryError,
         ica::{execute_on_behalf_of, get_remote_ica_address},
@@ -76,7 +76,7 @@ mod functions {
                 // Create the Any
                 let any_msg = ProtobufAny {
                     type_url: MsgDepositForBurn::type_url(),
-                    value: Binary::new(proto_msg.encode_to_vec()),
+                    value: Binary::from(proto_msg.encode_to_vec()),
                 };
 
                 let input_account_msgs = execute_on_behalf_of(vec![any_msg], &cfg.input_addr)?;

--- a/docs/src/accounts/interchain_accounts.md
+++ b/docs/src/accounts/interchain_accounts.md
@@ -54,8 +54,8 @@ pub enum ExecuteMsg {
     ApproveLibrary { library: String }, // Add library to approved list (only admin)
     RemoveLibrary { library: String },  // Remove library from approved list (only admin)
     ExecuteMsg { msgs: Vec<CosmosMsg> }, // Execute a list of Cosmos messages, useful to retrieve funds that were sent here by the owner for example.
-    ExecuteIcaMsg { msgs: Vec<ProtobufAny> }, // Execute a protobuf message on the ICA
-    RegisterIca {},                     // Register the ICA on the remote chain
+    ExecuteIcaMsg { msgs: Vec<AnyMsg> }, // Execute a protobuf message on the ICA
+    RegisterIca {},                      // Register the ICA on the remote chain
 }
 ```
 

--- a/e2e/examples/ica_libraries.rs
+++ b/e2e/examples/ica_libraries.rs
@@ -8,13 +8,13 @@ use localic_utils::{
     NEUTRON_CHAIN_DENOM, NEUTRON_CHAIN_NAME,
 };
 use log::info;
+use valence_account_utils::ica::{IcaState, RemoteDomainInfo};
 use valence_chain_client_utils::{cosmos::base_client::BaseClient, noble::NobleClient};
 use valence_e2e::utils::{
     parse::get_grpc_address_and_port_from_logs, relayer::restart_relayer, ADMIN_MNEMONIC,
     GAS_FLAGS, LOGS_FILE_PATH, NOBLE_CHAIN_ADMIN_ADDR, NOBLE_CHAIN_DENOM, NOBLE_CHAIN_ID,
     NOBLE_CHAIN_NAME, NOBLE_CHAIN_PREFIX, VALENCE_ARTIFACTS_PATH,
 };
-use valence_interchain_account::msg::{IcaState, RemoteDomainInfo};
 use valence_library_utils::LibraryAccountType;
 
 const UUSDC_DENOM: &str = "uusdc";
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     info!("Instantiating the ICA contract...");
     let timeout_seconds = 90;
-    let ica_instantiate_msg = valence_interchain_account::msg::InstantiateMsg {
+    let ica_instantiate_msg = valence_account_utils::ica::InstantiateMsg {
         admin: NEUTRON_CHAIN_ADMIN_ADDR.to_string(),
         approved_libraries: vec![],
         remote_domain_information: RemoteDomainInfo {
@@ -125,8 +125,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .get_request_builder(NEUTRON_CHAIN_NAME),
         &valence_ica.address,
         DEFAULT_KEY,
-        &serde_json::to_string(&valence_interchain_account::msg::ExecuteMsg::RegisterIca {})
-            .unwrap(),
+        &serde_json::to_string(&valence_account_utils::ica::ExecuteMsg::RegisterIca {}).unwrap(),
         GAS_FLAGS,
     )
     .unwrap_err();
@@ -145,8 +144,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .get_request_builder(NEUTRON_CHAIN_NAME),
         &valence_ica.address,
         DEFAULT_KEY,
-        &serde_json::to_string(&valence_interchain_account::msg::ExecuteMsg::RegisterIca {})
-            .unwrap(),
+        &serde_json::to_string(&valence_account_utils::ica::ExecuteMsg::RegisterIca {}).unwrap(),
         &format!("{} --amount=100000000{}", GAS_FLAGS, NEUTRON_CHAIN_DENOM),
     )
     .unwrap();
@@ -164,8 +162,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .get_request_builder()
                 .get_request_builder(NEUTRON_CHAIN_NAME),
             &valence_ica.address,
-            &serde_json::to_string(&valence_interchain_account::msg::QueryMsg::IcaState {})
-                .unwrap(),
+            &serde_json::to_string(&valence_account_utils::ica::QueryMsg::IcaState {}).unwrap(),
         )["data"]
             .clone(),
     )
@@ -249,11 +246,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             .get_request_builder(NEUTRON_CHAIN_NAME),
         &valence_ica.address,
         DEFAULT_KEY,
-        &serde_json::to_string(
-            &valence_interchain_account::msg::ExecuteMsg::ApproveLibrary {
-                library: ica_cctp_transfer.address.clone(),
-            },
-        )
+        &serde_json::to_string(&valence_account_utils::ica::ExecuteMsg::ApproveLibrary {
+            library: ica_cctp_transfer.address.clone(),
+        })
         .unwrap(),
         GAS_FLAGS,
     )
@@ -322,8 +317,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .get_request_builder(NEUTRON_CHAIN_NAME),
         &valence_ica.address,
         DEFAULT_KEY,
-        &serde_json::to_string(&valence_interchain_account::msg::ExecuteMsg::RegisterIca {})
-            .unwrap(),
+        &serde_json::to_string(&valence_account_utils::ica::ExecuteMsg::RegisterIca {}).unwrap(),
         GAS_FLAGS,
     )
     .unwrap();
@@ -351,8 +345,7 @@ where
                     .get_request_builder()
                     .get_request_builder(NEUTRON_CHAIN_NAME),
                 addr,
-                &serde_json::to_string(&valence_interchain_account::msg::QueryMsg::IcaState {})
-                    .unwrap(),
+                &serde_json::to_string(&valence_account_utils::ica::QueryMsg::IcaState {}).unwrap(),
             )["data"]
                 .clone(),
         )

--- a/packages/account-utils/Cargo.toml
+++ b/packages/account-utils/Cargo.toml
@@ -11,14 +11,15 @@ default = []
 testing = ["dep:cw-multi-test", "dep:cw20", "dep:cw20-base", "dep:sha2"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
-cosmwasm-std    = { workspace = true }
-cw-ownable      = { workspace = true }
-cw-utils        = { workspace = true }
-serde           = { workspace = true }
-serde_json      = { workspace = true }
-thiserror       = { workspace = true }
-valence-macros  = { workspace = true }
+cosmwasm-schema   = { workspace = true }
+cosmwasm-std      = { workspace = true }
+cw-ownable        = { workspace = true }
+cw-utils          = { workspace = true }
+serde             = { workspace = true }
+serde_json        = { workspace = true }
+thiserror         = { workspace = true }
+valence-macros    = { workspace = true }
+valence-ibc-utils = { workspace = true }
 
 # Testing dependencies
 cw-multi-test = { workspace = true, optional = true }

--- a/packages/account-utils/src/ica.rs
+++ b/packages/account-utils/src/ica.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CosmosMsg, StdError, StdResult, Uint64};
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
-use neutron_sdk::bindings::types::ProtobufAny;
+use valence_ibc_utils::types::ProtobufAny;
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/packages/account-utils/src/ica.rs
+++ b/packages/account-utils/src/ica.rs
@@ -1,7 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{CosmosMsg, StdError, StdResult, Uint64};
+use cosmwasm_std::{AnyMsg, CosmosMsg, StdError, StdResult, Uint64};
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
-use valence_ibc_utils::types::ProtobufAny;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -16,7 +15,7 @@ pub enum ExecuteMsg {
     ApproveLibrary { library: String }, // Add library to approved list (only admin)
     RemoveLibrary { library: String },  // Remove library from approved list (only admin)
     ExecuteMsg { msgs: Vec<CosmosMsg> }, // Execute a list of Cosmos messages, useful to retrieve funds that were sent here by the owner for example.
-    ExecuteIcaMsg { msgs: Vec<ProtobufAny> }, // Execute a protobuf message on the ICA
+    ExecuteIcaMsg { msgs: Vec<AnyMsg> }, // Execute a protobuf message on the ICA
     RegisterIca {},                      // Register the ICA on the remote chain
 }
 

--- a/packages/account-utils/src/lib.rs
+++ b/packages/account-utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod ica;
 pub mod msg;
 
 #[cfg(feature = "testing")]

--- a/packages/ibc-utils/src/types.rs
+++ b/packages/ibc-utils/src/types.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Binary;
 
 #[cw_serde]
 pub struct PacketForwardMiddlewareConfig {
@@ -18,4 +19,11 @@ pub struct ForwardMetadata {
     pub receiver: String,
     pub port: String,
     pub channel: String,
+}
+
+// We want a serializable version of Any using the Binary wrapper and not take it from neutron-sdk because it injects neutron feature into the contract
+#[cw_serde]
+pub struct ProtobufAny {
+    pub type_url: String,
+    pub value: Binary,
 }

--- a/packages/ibc-utils/src/types.rs
+++ b/packages/ibc-utils/src/types.rs
@@ -1,5 +1,4 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Binary;
 
 #[cw_serde]
 pub struct PacketForwardMiddlewareConfig {
@@ -19,11 +18,4 @@ pub struct ForwardMetadata {
     pub receiver: String,
     pub port: String,
     pub channel: String,
-}
-
-// We want a serializable version of Any using the Binary wrapper and not take it from neutron-sdk because it injects neutron feature into the contract
-#[cw_serde]
-pub struct ProtobufAny {
-    pub type_url: String,
-    pub value: Binary,
 }

--- a/packages/library-utils/Cargo.toml
+++ b/packages/library-utils/Cargo.toml
@@ -9,22 +9,20 @@ repository = { workspace = true }
 [features]
 default = []
 testing = ["dep:cw-multi-test", "dep:cw20", "dep:cw20-base", "dep:sha2", "dep:valence-base-account"]
-neutron = ["dep:neutron-sdk", "dep:valence-interchain-account"]
 
 [dependencies]
-cosmwasm-schema            = { workspace = true }
-cosmwasm-std               = { workspace = true }
-cw-denom                   = { workspace = true }
-cw-ownable                 = { workspace = true }
-cw-utils                   = { workspace = true }
-serde                      = { workspace = true }
-serde_json                 = { workspace = true }
-thiserror                  = { workspace = true }
-valence-account-utils      = { workspace = true }
-valence-macros             = { workspace = true }
-cw-storage-plus            = { workspace = true }
-valence-interchain-account = { workspace = true, optional = true, features = ["library"] }
-neutron-sdk                = { workspace = true, optional = true }
+cosmwasm-schema       = { workspace = true }
+cosmwasm-std          = { workspace = true }
+cw-denom              = { workspace = true }
+cw-ownable            = { workspace = true }
+cw-utils              = { workspace = true }
+serde                 = { workspace = true }
+serde_json            = { workspace = true }
+thiserror             = { workspace = true }
+valence-account-utils = { workspace = true }
+valence-macros        = { workspace = true }
+cw-storage-plus       = { workspace = true }
+valence-ibc-utils     = { workspace = true }
 
 # Testing dependencies
 cw-multi-test        = { workspace = true, optional = true }

--- a/packages/library-utils/src/ica.rs
+++ b/packages/library-utils/src/ica.rs
@@ -1,9 +1,8 @@
-use cosmwasm_std::{to_json_binary, Addr, CosmosMsg, Deps, StdError, StdResult, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, AnyMsg, CosmosMsg, Deps, StdError, StdResult, WasmMsg};
 use valence_account_utils::ica::{IcaState, QueryMsg};
-use valence_ibc_utils::types::ProtobufAny;
 
 /// Helper function to execute proto messages using the Valence interchain account
-pub fn execute_on_behalf_of(msgs: Vec<ProtobufAny>, account: &Addr) -> StdResult<CosmosMsg> {
+pub fn execute_on_behalf_of(msgs: Vec<AnyMsg>, account: &Addr) -> StdResult<CosmosMsg> {
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: account.to_string(),
         msg: to_json_binary(&valence_account_utils::ica::ExecuteMsg::ExecuteIcaMsg { msgs })?,

--- a/packages/library-utils/src/ica.rs
+++ b/packages/library-utils/src/ica.rs
@@ -1,12 +1,12 @@
 use cosmwasm_std::{to_json_binary, Addr, CosmosMsg, Deps, StdError, StdResult, WasmMsg};
-use neutron_sdk::bindings::types::ProtobufAny;
-use valence_interchain_account::msg::{IcaState, QueryMsg};
+use valence_account_utils::ica::{IcaState, QueryMsg};
+use valence_ibc_utils::types::ProtobufAny;
 
 /// Helper function to execute proto messages using the Valence interchain account
 pub fn execute_on_behalf_of(msgs: Vec<ProtobufAny>, account: &Addr) -> StdResult<CosmosMsg> {
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: account.to_string(),
-        msg: to_json_binary(&valence_interchain_account::msg::ExecuteMsg::ExecuteIcaMsg { msgs })?,
+        msg: to_json_binary(&valence_account_utils::ica::ExecuteMsg::ExecuteIcaMsg { msgs })?,
         funds: vec![],
     }))
 }

--- a/packages/library-utils/src/lib.rs
+++ b/packages/library-utils/src/lib.rs
@@ -8,12 +8,10 @@ pub mod denoms {
 }
 
 pub mod error;
+pub mod ica;
 pub mod liquidity_utils;
 pub mod msg;
 pub mod raw_config;
-
-#[cfg(feature = "neutron")]
-pub mod ica;
 
 #[cfg(feature = "testing")]
 pub mod testing;


### PR DESCRIPTION
Stop using ProtobufAny from neutron-sdk on ICA libraries to not inject the neutron dependency into them and be able to deploy them on other chains if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new public module to enhance message processing.

- **Refactor**
  - Unified message formats and restructured internal interfaces for streamlined execution and querying.

- **Chores**
  - Updated and reorganized dependency configurations across components.

- **Documentation**
  - Revised account documentation to reflect the updated messaging interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->