### PR TITLE
feat: ICA IBC transfer library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8598,6 +8598,7 @@ dependencies = [
  "valence-generic-ibc-transfer-library",
  "valence-ibc-utils",
  "valence-ica-cctp-transfer",
+ "valence-ica-ibc-transfer",
  "valence-interchain-account",
  "valence-library-utils",
  "valence-middleware-asserter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8752,6 +8752,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "valence-ica-ibc-transfer"
+version = "0.2.0"
+dependencies = [
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 2.2.1",
+ "cosmwasm-std 2.2.1",
+ "cw-multi-test",
+ "cw-ownable",
+ "cw-storage-plus 2.0.0",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+ "valence-account-utils",
+ "valence-library-base",
+ "valence-library-utils",
+ "valence-macros",
+]
+
+[[package]]
 name = "valence-interchain-account"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ valence-neutron-ic-querier           = { path = "contracts/libraries/neutron-ic-
 valence-drop-liquid-staker           = { path = "contracts/libraries/drop-liquid-staker", features = ["library"] }
 valence-drop-liquid-unstaker         = { path = "contracts/libraries/drop-liquid-unstaker", features = ["library"] }
 valence-ica-cctp-transfer            = { path = "contracts/libraries/ica-cctp-transfer", features = ["library"] }
+valence-ica-ibc-transfer             = { path = "contracts/libraries/ica-ibc-transfer", features = ["library"] }
 
 # middleware
 valence-middleware-osmosis = { path = "contracts/middleware/type-registries/osmosis/osmo-26-0-0", features = [

--- a/contracts/libraries/ica-ibc-transfer/.cargo/config.toml
+++ b/contracts/libraries/ica-ibc-transfer/.cargo/config.toml
@@ -1,0 +1,3 @@
+[alias]
+wasm   = "build --release --lib --target wasm32-unknown-unknown"
+schema = "run --bin schema"

--- a/contracts/libraries/ica-ibc-transfer/Cargo.toml
+++ b/contracts/libraries/ica-ibc-transfer/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name       = "valence-ica-ibc-transfer"
+authors    = { workspace = true }
+edition    = { workspace = true }
+license    = { workspace = true }
+version    = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-schema       = { workspace = true }
+cosmwasm-std          = { workspace = true }
+cw-ownable            = { workspace = true }
+cw-storage-plus       = { workspace = true }
+schemars              = { workspace = true }
+serde                 = { workspace = true }
+thiserror             = { workspace = true }
+valence-macros        = { workspace = true }
+valence-library-utils = { workspace = true }
+valence-library-base  = { workspace = true }
+cosmos-sdk-proto      = { workspace = true }
+
+[dev-dependencies]
+cw-multi-test         = { workspace = true }
+valence-account-utils = { workspace = true }
+valence-library-utils = { workspace = true, features = ["testing"] }

--- a/contracts/libraries/ica-ibc-transfer/README.md
+++ b/contracts/libraries/ica-ibc-transfer/README.md
@@ -46,7 +46,7 @@ pub struct LibraryConfig {
 pub struct RemoteChainInfo {
     // Channel ID to be used
     pub channel_id: String,
-    // Timeout for the IBC transfer in seconds, if not specified a default 600 seconds will be used will be used
+    // Timeout for the IBC transfer in seconds. If not specified, a default 600 seconds will be used will be used
     pub ibc_transfer_timeout: Option<u64>,
 }
 ```

--- a/contracts/libraries/ica-ibc-transfer/README.md
+++ b/contracts/libraries/ica-ibc-transfer/README.md
@@ -6,22 +6,22 @@ The **Valence ICA IBC Transfer Library** library allows remotely executing an **
 
 ```mermaid
 ---
-title: ICA CCTP Transfer Library
+title: ICA IBC Transfer Library
 ---
 graph LR
     subgraph Neutron
       P[Processor]
-      L[ICA CCTP
+      L[ICA IBC
       Transfer Library]
       I[Input Account]
       P -- 1)Transfer --> L
       L -- 2)Query ICA address --> I
-      L -- 3)Do ICA MsgDepositForBurn --> I
+      L -- 3)Do ICA MsgTransfer --> I
     end
 
-    subgraph Noble
+    subgraph Remote domain
       ICA[Interchain Account]
-      I -- 4)Execute MsgDepositForBurn--> ICA
+      I -- 4)Execute MsgTransfer --> ICA
     end
 ```
 

--- a/contracts/libraries/ica-ibc-transfer/README.md
+++ b/contracts/libraries/ica-ibc-transfer/README.md
@@ -1,0 +1,47 @@
+# Valence ICA CCTP Transfer Library
+
+The **Valence ICA CCTP Transfer Library** library allows remotely executing a **CCTP transfer** using a **Valence interchain account** on [Noble Chain](https://www.noble.xyz/). It does that by remotely sending a **MsgDepositForBurn** to the ICA created by the **Valence interchain account** on Noble. It is typically used as part of a **Valence Program**. In that context, a **Processor** contract will be the main contract interacting with the **Valence ICA CCTP Transfer Library**.
+
+## High-level flow
+
+```mermaid
+---
+title: ICA CCTP Transfer Library
+---
+graph LR
+    subgraph Neutron
+      P[Processor]
+      L[ICA CCTP
+      Transfer Library]
+      I[Input Account]
+      P -- 1)Transfer --> L
+      L -- 2)Query ICA address --> I
+      L -- 3)Do ICA MsgDepositForBurn --> I
+    end
+
+    subgraph Noble
+      ICA[Interchain Account]
+      I -- 4)Execute MsgDepositForBurn--> ICA
+    end
+```
+
+## Configuration
+
+The library is configured on instantiation via the `LibraryConfig` type.
+
+```rust
+pub struct LibraryConfig {
+    // Address of the input account (Valence interchain account)
+    pub input_addr: LibraryAccountType,
+    // Amount that is going to be transferred
+    pub amount: Uint128,
+    // Denom that is going to be transferred
+    pub denom: String,
+    // Destination domain id
+    pub destination_domain_id: u32,
+    // Address of the recipient account on the destination domain
+    // This address is the bytes representation of the address (with 32 length and padded zeroes)
+    // For more information, check https://docs.noble.xyz/cctp/mint#example
+    pub mint_recipient: Binary,
+}
+```

--- a/contracts/libraries/ica-ibc-transfer/schema/valence-ica-ibc-transfer.json
+++ b/contracts/libraries/ica-ibc-transfer/schema/valence-ica-ibc-transfer.json
@@ -1,0 +1,773 @@
+{
+  "contract_name": "valence-ica-ibc-transfer",
+  "contract_version": "0.2.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "config",
+      "owner",
+      "processor"
+    ],
+    "properties": {
+      "config": {
+        "$ref": "#/definitions/LibraryConfig"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "processor": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfig": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom",
+          "input_addr",
+          "receiver",
+          "remote_chain_info"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          },
+          "input_addr": {
+            "$ref": "#/definitions/LibraryAccountType"
+          },
+          "receiver": {
+            "type": "string"
+          },
+          "remote_chain_info": {
+            "$ref": "#/definitions/RemoteChainInfo"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoteChainInfo": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          },
+          "ibc_transfer_timeout": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "process_function"
+        ],
+        "properties": {
+          "process_function": {
+            "$ref": "#/definitions/FunctionMsgs"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "required": [
+              "new_config"
+            ],
+            "properties": {
+              "new_config": {
+                "$ref": "#/definitions/LibraryConfigUpdate"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_processor"
+        ],
+        "properties": {
+          "update_processor": {
+            "type": "object",
+            "required": [
+              "processor"
+            ],
+            "properties": {
+              "processor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "FunctionMsgs": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "transfer"
+            ],
+            "properties": {
+              "transfer": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryAccountType": {
+        "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "|library_account_addr|"
+            ],
+            "properties": {
+              "|library_account_addr|": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|account_id|"
+            ],
+            "properties": {
+              "|account_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "|library_id|"
+            ],
+            "properties": {
+              "|library_id|": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "LibraryConfigUpdate": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "denom": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "input_addr": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "receiver": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "remote_chain_info": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RemoteChainInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoteChainInfo": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          },
+          "ibc_transfer_timeout": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Enum representing the different query messages that can be sent.",
+    "oneOf": [
+      {
+        "description": "Query to get the processor address.",
+        "type": "object",
+        "required": [
+          "get_processor"
+        ],
+        "properties": {
+          "get_processor": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query to get the library configuration.",
+        "type": "object",
+        "required": [
+          "get_library_config"
+        ],
+        "properties": {
+          "get_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_raw_library_config"
+        ],
+        "properties": {
+          "get_raw_library_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Query the contract's ownership information",
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "get_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "amount",
+        "denom",
+        "input_addr",
+        "receiver",
+        "remote_chain_info"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        },
+        "input_addr": {
+          "$ref": "#/definitions/Addr"
+        },
+        "receiver": {
+          "type": "string"
+        },
+        "remote_chain_info": {
+          "$ref": "#/definitions/RemoteChainInfo"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "RemoteChainInfo": {
+          "type": "object",
+          "required": [
+            "channel_id"
+          ],
+          "properties": {
+            "channel_id": {
+              "type": "string"
+            },
+            "ibc_transfer_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "get_processor": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_raw_library_config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LibraryConfig",
+      "type": "object",
+      "required": [
+        "amount",
+        "denom",
+        "input_addr",
+        "receiver",
+        "remote_chain_info"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        },
+        "input_addr": {
+          "$ref": "#/definitions/LibraryAccountType"
+        },
+        "receiver": {
+          "type": "string"
+        },
+        "remote_chain_info": {
+          "$ref": "#/definitions/RemoteChainInfo"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "LibraryAccountType": {
+          "description": "An account type that is used in the library configs It can either be an Id or Addr The config that will be passed to the library must be of Addr veriant",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "|library_account_addr|"
+              ],
+              "properties": {
+                "|library_account_addr|": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|account_id|"
+              ],
+              "properties": {
+                "|account_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "|library_id|"
+              ],
+              "properties": {
+                "|library_id|": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "RemoteChainInfo": {
+          "type": "object",
+          "required": [
+            "channel_id"
+          ],
+          "properties": {
+            "channel_id": {
+              "type": "string"
+            },
+            "ibc_transfer_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_String",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/libraries/ica-ibc-transfer/src/bin/schema.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/bin/schema.rs
@@ -1,0 +1,12 @@
+use cosmwasm_schema::write_api;
+
+use valence_ica_ibc_transfer::msg::{FunctionMsgs, LibraryConfig, LibraryConfigUpdate, QueryMsg};
+use valence_library_utils::msg::{ExecuteMsg, InstantiateMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg<LibraryConfig>,
+        execute: ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>,
+        query: QueryMsg,
+    }
+}

--- a/contracts/libraries/ica-ibc-transfer/src/contract.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/contract.rs
@@ -1,0 +1,144 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use valence_library_utils::{
+    error::LibraryError,
+    msg::{ExecuteMsg, InstantiateMsg},
+};
+
+use crate::msg::{Config, FunctionMsgs, LibraryConfig, LibraryConfigUpdate, QueryMsg};
+
+// version info for migration info
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const DEFAULT_IBC_TIMEOUT: u64 = 600; // 10 minutes
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg<LibraryConfig>,
+) -> Result<Response, LibraryError> {
+    valence_library_base::instantiate(deps, CONTRACT_NAME, CONTRACT_VERSION, msg)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg<FunctionMsgs, LibraryConfigUpdate>,
+) -> Result<Response, LibraryError> {
+    valence_library_base::execute(
+        deps,
+        env,
+        info,
+        msg,
+        functions::process_function,
+        execute::update_config,
+    )
+}
+
+mod functions {
+    use cosmos_sdk_proto::{
+        cosmos::base::v1beta1::Coin, ibc::applications::transfer::v1::MsgTransfer, prost::Name,
+        traits::MessageExt,
+    };
+    use cosmwasm_std::{AnyMsg, Binary, DepsMut, Env, MessageInfo, Response};
+    use valence_library_utils::{
+        error::LibraryError,
+        ica::{execute_on_behalf_of, get_remote_ica_address},
+    };
+
+    use crate::msg::{Config, FunctionMsgs};
+
+    use super::DEFAULT_IBC_TIMEOUT;
+
+    pub fn process_function(
+        deps: DepsMut,
+        env: Env,
+        _info: MessageInfo,
+        msg: FunctionMsgs,
+        cfg: Config,
+    ) -> Result<Response, LibraryError> {
+        let remote_address = get_remote_ica_address(deps.as_ref(), cfg.input_addr.as_str())?;
+
+        match msg {
+            FunctionMsgs::Transfer {} => {
+                // Create the proto message
+                let proto_msg = MsgTransfer {
+                    source_port: "transfer".to_string(),
+                    source_channel: cfg.remote_chain_info.channel_id,
+                    token: Some(Coin {
+                        denom: cfg.denom,
+                        amount: cfg.amount.to_string(),
+                    }),
+                    sender: remote_address,
+                    receiver: cfg.receiver,
+                    timeout_height: None,
+                    timeout_timestamp: env
+                        .block
+                        .time
+                        .plus_seconds(
+                            cfg.remote_chain_info
+                                .ibc_transfer_timeout
+                                .unwrap_or(DEFAULT_IBC_TIMEOUT),
+                        )
+                        .seconds(),
+                };
+
+                // Create the Any
+                let any_msg = AnyMsg {
+                    type_url: MsgTransfer::type_url(),
+                    value: Binary::from(proto_msg.to_bytes().map_err(|e| {
+                        LibraryError::ExecutionError(format!("Failed to encode MsgTransfer: {}", e))
+                    })?),
+                };
+
+                let input_account_msgs = execute_on_behalf_of(vec![any_msg], &cfg.input_addr)?;
+
+                Ok(Response::new()
+                    .add_message(input_account_msgs)
+                    .add_attribute("method", "cctp_transfer"))
+            }
+        }
+    }
+}
+
+mod execute {
+    use cosmwasm_std::{DepsMut, Env, MessageInfo};
+    use valence_library_utils::error::LibraryError;
+
+    use crate::msg::LibraryConfigUpdate;
+
+    pub fn update_config(
+        deps: DepsMut,
+        _env: Env,
+        _info: MessageInfo,
+        new_config: LibraryConfigUpdate,
+    ) -> Result<(), LibraryError> {
+        new_config.update_config(deps)
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Ownership {} => {
+            to_json_binary(&valence_library_base::get_ownership(deps.storage)?)
+        }
+        QueryMsg::GetProcessor {} => {
+            to_json_binary(&valence_library_base::get_processor(deps.storage)?)
+        }
+        QueryMsg::GetLibraryConfig {} => {
+            let config: Config = valence_library_base::load_config(deps.storage)?;
+            to_json_binary(&config)
+        }
+        QueryMsg::GetRawLibraryConfig {} => {
+            let raw_config: LibraryConfig =
+                valence_library_utils::raw_config::query_raw_library_config(deps.storage)?;
+            to_json_binary(&raw_config)
+        }
+    }
+}

--- a/contracts/libraries/ica-ibc-transfer/src/contract.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/contract.rs
@@ -85,7 +85,7 @@ mod functions {
                                 .ibc_transfer_timeout
                                 .unwrap_or(DEFAULT_IBC_TIMEOUT),
                         )
-                        .seconds(),
+                        .nanos(),
                 };
 
                 // Create the Any

--- a/contracts/libraries/ica-ibc-transfer/src/lib.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod contract;
+pub mod msg;
+
+#[cfg(test)]
+mod tests;

--- a/contracts/libraries/ica-ibc-transfer/src/msg.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/msg.rs
@@ -1,0 +1,215 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{Addr, Deps, DepsMut, Uint128};
+use cw_ownable::cw_ownable_query;
+use valence_library_utils::LibraryAccountType;
+use valence_library_utils::{error::LibraryError, msg::LibraryConfigValidation};
+use valence_macros::{valence_library_query, ValenceLibraryInterface};
+
+#[cw_serde]
+pub enum FunctionMsgs {
+    Transfer {},
+}
+
+#[valence_library_query]
+#[cw_ownable_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+/// Enum representing the different query messages that can be sent.
+pub enum QueryMsg {}
+
+#[cw_serde]
+#[derive(ValenceLibraryInterface)]
+pub struct LibraryConfig {
+    // Address of the input account (Valence interchain account)
+    pub input_addr: LibraryAccountType,
+    // Amount that is going to be transferred
+    pub amount: Uint128,
+    // Denom that is going to be transferred
+    pub denom: String,
+    // Receiver on the other chain
+    pub receiver: String,
+    // Remote chain info
+    pub remote_chain_info: RemoteChainInfo,
+}
+
+#[cw_serde]
+pub struct RemoteChainInfo {
+    // Channel ID to be used
+    pub channel_id: String,
+    // Timeout for the IBC transfer in seconds, if not specified a default 600 seconds will be used will be used
+    pub ibc_transfer_timeout: Option<u64>,
+}
+
+impl RemoteChainInfo {
+    pub fn new(channel_id: String, ibc_transfer_timeout: Option<u64>) -> Self {
+        Self {
+            channel_id,
+            ibc_transfer_timeout,
+        }
+    }
+}
+
+impl LibraryConfig {
+    pub fn new(
+        input_addr: impl Into<LibraryAccountType>,
+        amount: Uint128,
+        denom: String,
+        receiver: String,
+        remote_chain_info: RemoteChainInfo,
+    ) -> Self {
+        LibraryConfig {
+            input_addr: input_addr.into(),
+            amount,
+            denom,
+            receiver,
+            remote_chain_info,
+        }
+    }
+
+    fn do_validate(&self, api: &dyn cosmwasm_std::Api) -> Result<Addr, LibraryError> {
+        let input_addr = self.input_addr.to_addr(api)?;
+        if self.amount.is_zero() {
+            return Err(LibraryError::ConfigurationError(
+                "Invalid ICA IBC transfer config: amount cannot be zero.".to_string(),
+            ));
+        }
+
+        if self.denom.is_empty() {
+            return Err(LibraryError::ConfigurationError(
+                "Invalid ICA IBC transfer config: denom cannot be empty.".to_string(),
+            ));
+        }
+
+        if self.remote_chain_info.channel_id.is_empty() {
+            return Err(LibraryError::ConfigurationError(
+                "Invalid ICA IBC transfer config: channel_id cannot be empty.".to_string(),
+            ));
+        }
+
+        if self.receiver.is_empty() {
+            return Err(LibraryError::ConfigurationError(
+                "Invalid ICA IBC transfer config: receiver cannot be empty.".to_string(),
+            ));
+        }
+
+        if let Some(timeout) = self.remote_chain_info.ibc_transfer_timeout {
+            if timeout == 0 {
+                return Err(LibraryError::ConfigurationError(
+                    "Invalid ICA IBC transfer config: timeout cannot be zero.".to_string(),
+                ));
+            }
+        }
+
+        Ok(input_addr)
+    }
+}
+
+impl LibraryConfigValidation<Config> for LibraryConfig {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn pre_validate(&self, api: &dyn cosmwasm_std::Api) -> Result<(), LibraryError> {
+        self.do_validate(api)?;
+        Ok(())
+    }
+
+    fn validate(&self, deps: Deps) -> Result<Config, LibraryError> {
+        let input_addr = self.do_validate(deps.api)?;
+
+        Ok(Config {
+            input_addr,
+            amount: self.amount,
+            denom: self.denom.clone(),
+            receiver: self.receiver.clone(),
+            remote_chain_info: self.remote_chain_info.clone(),
+        })
+    }
+}
+
+impl LibraryConfigUpdate {
+    pub fn update_config(self, deps: DepsMut) -> Result<(), LibraryError> {
+        let mut config: Config = valence_library_base::load_config(deps.storage)?;
+
+        // First update input_addr (if needed)
+        if let Some(input_addr) = self.input_addr {
+            config.input_addr = input_addr.to_addr(deps.api)?;
+        }
+
+        // Next update the amount (if needed)
+        if let Some(amount) = self.amount {
+            if amount.is_zero() {
+                return Err(LibraryError::ConfigurationError(
+                    "Invalid ICA IBC transfer config: amount cannot be zero.".to_string(),
+                ));
+            }
+            config.amount = amount;
+        }
+
+        // Next update the denom (if needed)
+        if let Some(denom) = self.denom {
+            if denom.is_empty() {
+                return Err(LibraryError::ConfigurationError(
+                    "Invalid ICA IBC transfer config: denom cannot be empty.".to_string(),
+                ));
+            }
+            config.denom = denom;
+        }
+
+        // Next update the receiver (if needed)
+        if let Some(receiver) = self.receiver {
+            if receiver.is_empty() {
+                return Err(LibraryError::ConfigurationError(
+                    "Invalid ICA IBC transfer config: receiver cannot be empty.".to_string(),
+                ));
+            }
+            config.receiver = receiver;
+        }
+
+        // Next update the remote_chain_info (if needed)
+        if let Some(remote_chain_info) = self.remote_chain_info {
+            if remote_chain_info.channel_id.is_empty() {
+                return Err(LibraryError::ConfigurationError(
+                    "Invalid ICA IBC transfer config: channel_id cannot be empty.".to_string(),
+                ));
+            }
+
+            if let Some(timeout) = remote_chain_info.ibc_transfer_timeout {
+                if timeout == 0 {
+                    return Err(LibraryError::ConfigurationError(
+                        "Invalid ICA IBC transfer config: timeout cannot be zero.".to_string(),
+                    ));
+                }
+            }
+
+            config.remote_chain_info = remote_chain_info;
+        }
+
+        valence_library_base::save_config(deps.storage, &config)?;
+        Ok(())
+    }
+}
+
+#[cw_serde]
+pub struct Config {
+    pub input_addr: Addr,
+    pub amount: Uint128,
+    pub denom: String,
+    pub receiver: String,
+    pub remote_chain_info: RemoteChainInfo,
+}
+
+impl Config {
+    pub fn new(
+        input_addr: Addr,
+        amount: Uint128,
+        denom: String,
+        receiver: String,
+        remote_chain_info: RemoteChainInfo,
+    ) -> Self {
+        Config {
+            input_addr,
+            amount,
+            denom,
+            receiver,
+            remote_chain_info,
+        }
+    }
+}

--- a/contracts/libraries/ica-ibc-transfer/src/msg.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/msg.rs
@@ -36,7 +36,7 @@ pub struct LibraryConfig {
 pub struct RemoteChainInfo {
     // Channel ID to be used
     pub channel_id: String,
-    // Timeout for the IBC transfer in seconds, if not specified a default 600 seconds will be used will be used
+    // Timeout for the IBC transfer in seconds. If not specified, a default 600 seconds will be used will be used
     pub ibc_transfer_timeout: Option<u64>,
 }
 

--- a/contracts/libraries/ica-ibc-transfer/src/tests.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/tests.rs
@@ -1,0 +1,410 @@
+use cosmwasm_std::{coin, Addr, Empty, Uint128};
+use cw_multi_test::{error::AnyResult, App, AppResponse, ContractWrapper, Executor};
+use cw_ownable::Ownership;
+use valence_library_utils::{
+    msg::{ExecuteMsg, InstantiateMsg, LibraryConfigValidation},
+    testing::{LibraryTestSuite, LibraryTestSuiteBase},
+};
+
+use crate::msg::{Config, FunctionMsgs, LibraryConfig, QueryMsg, RemoteChainInfo};
+
+const UUSDC: &str = "uusdc";
+const ONE_THOUSAND: u128 = 1_000_000_000;
+
+struct IcaIbcTransferTestSuite {
+    inner: LibraryTestSuiteBase,
+    ica_ibc_transfer_code_id: u64,
+    input_addr: Addr,
+    input_balance: Option<(u128, String)>,
+}
+
+impl Default for IcaIbcTransferTestSuite {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+#[allow(dead_code)]
+impl IcaIbcTransferTestSuite {
+    pub fn new(input_balance: Option<(u128, String)>) -> Self {
+        let mut inner = LibraryTestSuiteBase::new();
+
+        let input_addr = inner.get_contract_addr(inner.account_code_id(), "input_account");
+
+        // Template contract
+        let ica_ibc_transfer_code = ContractWrapper::new(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        );
+
+        let ica_ibc_transfer_code_id = inner.app_mut().store_code(Box::new(ica_ibc_transfer_code));
+
+        Self {
+            inner,
+            ica_ibc_transfer_code_id,
+            input_addr,
+            input_balance,
+        }
+    }
+
+    pub fn ica_ibc_transfer_init(&mut self, cfg: &LibraryConfig) -> Addr {
+        let init_msg = InstantiateMsg {
+            owner: self.owner().to_string(),
+            processor: self.processor().to_string(),
+            config: cfg.clone(),
+        };
+        let addr = self.contract_init(
+            self.ica_ibc_transfer_code_id,
+            "ica_ibc_transfer_library",
+            &init_msg,
+            &[],
+        );
+
+        let input_addr = self.input_addr.clone();
+        if self.app_mut().contract_data(&input_addr).is_err() {
+            let account_addr = self.account_init("input_account", vec![addr.to_string()]);
+            assert_eq!(account_addr, input_addr);
+
+            if let Some((amount, denom)) = self.input_balance.as_ref().cloned() {
+                self.init_balance(&input_addr, vec![coin(amount, denom.to_string())]);
+            }
+        }
+
+        addr
+    }
+
+    fn ica_ibc_transfer_config(
+        &self,
+        denom: String,
+        amount: Uint128,
+        receiver: String,
+        remote_chain_info: RemoteChainInfo,
+    ) -> LibraryConfig {
+        LibraryConfig::new(
+            valence_library_utils::LibraryAccountType::Addr(self.input_addr.to_string()),
+            amount,
+            denom,
+            receiver,
+            remote_chain_info,
+        )
+    }
+
+    fn update_config(&mut self, addr: Addr, new_config: LibraryConfig) -> AnyResult<AppResponse> {
+        let owner = self.owner().clone();
+        self.app_mut().execute_contract(
+            owner,
+            addr,
+            &ExecuteMsg::<FunctionMsgs, LibraryConfig>::UpdateConfig { new_config },
+            &[],
+        )
+    }
+}
+
+impl LibraryTestSuite<Empty, Empty> for IcaIbcTransferTestSuite {
+    fn app(&self) -> &App {
+        self.inner.app()
+    }
+
+    fn app_mut(&mut self) -> &mut App {
+        self.inner.app_mut()
+    }
+
+    fn owner(&self) -> &Addr {
+        self.inner.owner()
+    }
+
+    fn processor(&self) -> &Addr {
+        self.inner.processor()
+    }
+
+    fn account_code_id(&self) -> u64 {
+        self.inner.account_code_id()
+    }
+
+    fn cw20_code_id(&self) -> u64 {
+        self.inner.cw20_code_id()
+    }
+}
+
+#[test]
+fn instantiate_with_valid_config() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    // Instantiate IBC transfer contract
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    // Verify owner
+    let owner_res: Ownership<Addr> = suite.query_wasm(&lib, &QueryMsg::Ownership {});
+    assert_eq!(owner_res.owner, Some(suite.owner().clone()));
+
+    // Verify processor
+    let processor_addr: Addr = suite.query_wasm(&lib, &QueryMsg::GetProcessor {});
+    assert_eq!(processor_addr, suite.processor().clone());
+
+    // Verify library config
+    let lib_cfg: Config = suite.query_wasm(&lib, &QueryMsg::GetLibraryConfig {});
+    assert_eq!(
+        lib_cfg,
+        Config::new(
+            suite.input_addr.clone(),
+            Uint128::new(ONE_THOUSAND),
+            UUSDC.to_string(),
+            "receiver".to_string(),
+            RemoteChainInfo::new("channel-1".to_string(), Some(600))
+        )
+    );
+}
+
+#[test]
+fn pre_validate_config_works() {
+    let suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    // Pre-validate config
+    cfg.pre_validate(suite.api()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: amount cannot be zero.")]
+fn instantiate_fails_for_zero_amount() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::zero(),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    suite.ica_ibc_transfer_init(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: denom cannot be empty.")]
+fn instantiate_fails_for_empty_denom() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        "".to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    suite.ica_ibc_transfer_init(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: channel_id cannot be empty.")]
+fn instantiate_fails_for_empty_channel_id() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("".to_string(), Some(600)),
+    );
+
+    suite.ica_ibc_transfer_init(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: receiver cannot be empty.")]
+fn instantiate_fails_for_empty_receiver() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    suite.ica_ibc_transfer_init(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: timeout cannot be zero.")]
+fn instantiate_fails_for_zero_timeout() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(0)),
+    );
+
+    suite.ica_ibc_transfer_init(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: amount cannot be zero.")]
+fn update_config_validates_amount() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    let new_cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::zero(),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    suite.update_config(lib, new_cfg).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: denom cannot be empty.")]
+fn update_config_validates_denom() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    let new_cfg = suite.ica_ibc_transfer_config(
+        "".to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    suite.update_config(lib, new_cfg).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: receiver cannot be empty.")]
+fn update_config_validates_receiver() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    let new_cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    suite.update_config(lib, new_cfg).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: channel_id cannot be empty.")]
+fn update_config_validates_channel_id() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    let new_cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("".to_string(), Some(600)),
+    );
+
+    suite.update_config(lib, new_cfg).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Invalid ICA IBC transfer config: timeout cannot be zero.")]
+fn update_config_validates_timeout() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    let new_cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(0)),
+    );
+
+    suite.update_config(lib, new_cfg).unwrap();
+}
+
+#[test]
+fn update_config_works() {
+    let mut suite = IcaIbcTransferTestSuite::default();
+
+    let cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-1".to_string(), Some(600)),
+    );
+
+    let lib = suite.ica_ibc_transfer_init(&cfg);
+
+    let new_cfg = suite.ica_ibc_transfer_config(
+        UUSDC.to_string(),
+        Uint128::new(ONE_THOUSAND * 2),
+        "receiver".to_string(),
+        RemoteChainInfo::new("channel-2".to_string(), Some(1200)),
+    );
+
+    suite.update_config(lib.clone(), new_cfg.clone()).unwrap();
+
+    // Verify library config
+    let lib_cfg: Config = suite.query_wasm(&lib, &QueryMsg::GetLibraryConfig {});
+    assert_eq!(
+        lib_cfg,
+        Config::new(
+            Addr::unchecked(new_cfg.input_addr.to_string().unwrap()),
+            new_cfg.amount,
+            new_cfg.denom,
+            new_cfg.receiver,
+            new_cfg.remote_chain_info
+        )
+    );
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -42,6 +42,7 @@
     - [Drop Liquid Staker](./libraries/cosmwasm/drop_liquid_staker.md)
     - [Drop Liquid Unstaker](./libraries/cosmwasm/drop_liquid_unstaker.md)
     - [ICA CCTP Transfer](./libraries/cosmwasm/ica_cctp_transfer.md)
+    - [ICA IBC Transfer](./libraries/cosmwasm/ica_ibc_transfer.md)
   - [EVM](./libraries/evm/_overview.md)
     - [Forwarder](./libraries/evm/forwarder.md)
     - [CCTP Transfer](./libraries/evm/cctp_transfer.md)

--- a/docs/src/libraries/cosmwasm/ica_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/ica_ibc_transfer.md
@@ -6,24 +6,30 @@ The **Valence ICA IBC Transfer Library** library allows remotely executing an **
 
 ```mermaid
 ---
-title: ICA CCTP Transfer Library
+title: ICA IBC Transfer Library
 ---
 graph LR
     subgraph Neutron
       P[Processor]
-      L[ICA CCTP
+      L[ICA IBC
       Transfer Library]
       I[Input Account]
       P -- 1)Transfer --> L
       L -- 2)Query ICA address --> I
-      L -- 3)Do ICA MsgDepositForBurn --> I
+      L -- 3)Do ICA MsgTransfer --> I
     end
 
-    subgraph Noble
+    subgraph Remote domain
       ICA[Interchain Account]
-      I -- 4)Execute MsgDepositForBurn--> ICA
+      I -- 4)Execute MsgTransfer --> ICA
     end
 ```
+
+## Functions
+
+| Function     | Parameters | Description                                                                                                                             |
+| ------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Transfer** | -          | Transfer funds using IBC from the ICA created by the **input_acount** to a **receiver** on a remote domain using the IBC **channel_id** |
 
 ## Configuration
 

--- a/docs/src/libraries/cosmwasm/ica_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/ica_ibc_transfer.md
@@ -52,7 +52,7 @@ pub struct LibraryConfig {
 pub struct RemoteChainInfo {
     // Channel ID to be used
     pub channel_id: String,
-    // Timeout for the IBC transfer in seconds, if not specified a default 600 seconds will be used will be used
+    // Timeout for the IBC transfer in seconds. If not specified, a default 600 seconds will be used will be used
     pub ibc_transfer_timeout: Option<u64>,
 }
 ```

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -55,6 +55,7 @@ valence-middleware-asserter          = { workspace = true }
 valence-test-icq-lib                 = { workspace = true }
 valence-chain-client-utils           = { workspace = true }
 valence-ica-cctp-transfer            = { workspace = true }
+valence-ica-ibc-transfer             = { workspace = true }
 tokio                                = { workspace = true }
 osmosis-std                          = { workspace = true }
 neutron-sdk                          = { workspace = true }


### PR DESCRIPTION
Adds the ICA IBC transfer library which is the last library needed for the Vaults flow. The way it works is: the USDC will be sent via CCTP to an account on Noble (the remote account created by the Valence ICA). Then this library will be used to transfer these funds to other IBC connected chains.

Adds the corresponding unit/e2e tests and a doc section for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interchain token transfer capability using the IBC protocol to enable remote transfers via interchain accounts.
- **Documentation**
  - Added comprehensive guides and diagrams detailing configuration and usage of the new transfer functionality.
- **Tests**
  - Implemented extensive testing and an end-to-end example to ensure reliable transfer operations and proper configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->