### PR TITLE
feat: Upgradeable vaults

### DIFF
--- a/e2e/hyperlane/config/config.json
+++ b/e2e/hyperlane/config/config.json
@@ -58,10 +58,10 @@
           "http": "http://localneutron-1-val-0-neutronic:9090"
         }
       ],
-      "interchainGasPaymaster": "0xf04a313a7349b120c55c99788f12f712176bb3e5926d012d0ea72fa2bbb85051",
+      "interchainGasPaymaster": "0x30e2301c8c6f801fc1d4218af4ae03509b745725169f7a379c820c167957e363",
       "isTestnet": false,
       "mailbox": "0x3e202fb37a08b2f316028a813902ac5b6b4366e081da0f61c4392e08d1c99ce2",
-      "merkleTreeHook": "0x2311739b32e51a41bc46fd980796eb65e5253d33c0688a1e61af15441c760a25",
+      "merkleTreeHook": "0x022994774d25ac6c45fe22a81ce39c48e5635ba845ac6bfa7d6bd9725d7cbba3",
       "name": "neutron",
       "nativeToken": {
         "decimals": 6,
@@ -87,7 +87,7 @@
       },
       "slip44": 118,
       "technicalStack": "other",
-      "validatorAnnounce": "0xbf3e6f610c0a70c41e2eb52e5d432d0227e54dead3b53fd7dcbae94a9aec9167"
+      "validatorAnnounce": "0xc4f8e8a5fed390d276f0836cd7a23319758b00f87755bbbd454ce9b42549de37"
     }
   },
   "defaultRpcConsensusType": "fallback"

--- a/e2e/src/utils/solidity_contracts.rs
+++ b/e2e/src/utils/solidity_contracts.rs
@@ -59,6 +59,13 @@ sol!(
     "../solidity/out/ValenceVault.sol/ValenceVault.json",
 );
 
+// Proxy contract
+sol!(
+    #[sol(rpc)]
+    ERC1967Proxy,
+    "../solidity/out/ERC1967Proxy.sol/ERC1967Proxy.json",
+);
+
 // Testing utils
 sol!(
     #[sol(rpc)]

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -8,6 +8,7 @@ optimizer = true
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 [dependencies]
-forge-std                 = "1.9.4"
-hyperlane                 = { version = "5.8.3", git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", directory = "solidity", rev = "5b70527" }
-"@openzeppelin-contracts" = "5.2.0"
+forge-std                             = "1.9.4"
+hyperlane                             = { version = "5.8.3", git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", directory = "solidity", rev = "5b70527" }
+"@openzeppelin-contracts"             = "5.2.0"
+"@openzeppelin-contracts-upgradeable" = "5.2.0"

--- a/solidity/remappings.txt
+++ b/solidity/remappings.txt
@@ -1,3 +1,4 @@
-@openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.2.0/
+@openzeppelin-contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
+@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.2.0/
 forge-std/=dependencies/forge-std-1.9.4/
 hyperlane/=dependencies/hyperlane-5.8.3/solidity/contracts

--- a/solidity/soldeer.lock
+++ b/solidity/soldeer.lock
@@ -6,6 +6,13 @@ checksum = "6dbd0440446b2ed16ca25e9f1af08fc0c5c1e73e71fee86ae8a00daa774e3817"
 integrity = "4cb7f3777f67fdf4b7d0e2f94d2f93f198b2e5dce718b7062ac7c2c83e1183bd"
 
 [[dependencies]]
+name = "@openzeppelin-contracts-upgradeable"
+version = "5.2.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts-upgradeable/5_2_0_11-01-2025_09:30:25_contracts-upgradeable.zip"
+checksum = "25d9cf22b6f4d8da7975f24234eefbf6c71348464ea74c8fdd481be3811767f5"
+integrity = "498747bedc3f757976da0b6125d26a63e79bb2b4dbabd8ecd2547e809a2fa27e"
+
+[[dependencies]]
 name = "forge-std"
 version = "1.9.4"
 url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_4_25-10-2024_14:36:59_forge-std-1.9.zip"

--- a/solidity/src/accounts/Account.sol
+++ b/solidity/src/accounts/Account.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title Account

--- a/solidity/src/libraries/Library.sol
+++ b/solidity/src/libraries/Library.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title Library

--- a/solidity/src/libraries/ValenceVault.sol
+++ b/solidity/src/libraries/ValenceVault.sol
@@ -249,7 +249,7 @@ contract ValenceVault is
      * @param newImplementation address of the new implementation
      */
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
-        // You can add additional validation logic here if needed
+        // Upgrade logic comes here
     }
 
     /**

--- a/solidity/src/libraries/ValenceVault.sol
+++ b/solidity/src/libraries/ValenceVault.sol
@@ -1,14 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {SafeERC20, ERC20, IERC20, ERC4626} from "@openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
-import "@openzeppelin-contracts/utils/ReentrancyGuard.sol";
+import {ERC20Upgradeable} from "@openzeppelin-contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {ERC4626Upgradeable} from "@openzeppelin-contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {BaseAccount} from "../accounts/BaseAccount.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
-// import {console} from "forge-std/src/console.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {OwnableUpgradeable} from "@openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 
-contract ValenceVault is ERC4626, Ownable, ReentrancyGuard {
+contract ValenceVault is
+    Initializable,
+    ERC4626Upgradeable,
+    OwnableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable
+{
     using Math for uint256;
 
     error VaultIsPaused();
@@ -168,7 +178,7 @@ contract ValenceVault is ERC4626, Ownable, ReentrancyGuard {
     // 1 day = 86400 seconds
     uint64 private constant SECONDS_PER_YEAR = 365 days;
     // One share
-    uint256 internal immutable ONE_SHARE;
+    uint256 internal ONE_SHARE;
 
     modifier onlyStrategist() {
         if (msg.sender != config.strategist) {
@@ -191,16 +201,36 @@ contract ValenceVault is ERC4626, Ownable, ReentrancyGuard {
         _;
     }
 
-    constructor(
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev Initializes the contract replacing the constructor
+     * @param _owner Address of the contract owner
+     * @param _config Encoded configuration bytes
+     * @param underlying Address of the underlying token
+     * @param vaultTokenName Name of the vault token
+     * @param vaultTokenSymbol Symbol of the vault token
+     * @param startingRate Initial redemption rate
+     */
+    function initialize(
         address _owner,
         bytes memory _config,
         address underlying,
         string memory vaultTokenName,
         string memory vaultTokenSymbol,
         uint256 startingRate
-    ) ERC20(vaultTokenName, vaultTokenSymbol) ERC4626(IERC20(underlying)) Ownable(_owner) {
+    ) public initializer {
+        __ERC20_init(vaultTokenName, vaultTokenSymbol);
+        __ERC4626_init(IERC20(underlying));
+        __Ownable_init(_owner);
+        __ReentrancyGuard_init();
+
         config = abi.decode(_config, (VaultConfig));
         _validateConfig(config);
+
         unchecked {
             ONE_SHARE = 10 ** decimals();
             redemptionRate = startingRate; // Initialize at 1:1
@@ -208,6 +238,18 @@ contract ValenceVault is ERC4626, Ownable, ReentrancyGuard {
             lastUpdateTimestamp = uint64(block.timestamp);
             lastUpdateTotalShares = 0;
         }
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
+     * {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Normally, this function will use an xref:access.adoc[access control] modifier such as {Ownable-onlyOwner}.
+     *
+     * @param newImplementation address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
+        // You can add additional validation logic here if needed
     }
 
     /**
@@ -920,5 +962,12 @@ contract ValenceVault is ERC4626, Ownable, ReentrancyGuard {
         if (receiver == address(0)) revert InvalidReceiver();
         if (owner == address(0)) revert InvalidOwner();
         if (maxLossBps > BASIS_POINTS) revert InvalidMaxLoss();
+    }
+
+    /// @notice Fallback function that reverts all calls to non-existent functions
+    /// @dev Called when no other function matches the function signature
+    /// @dev Add this to your contract to explicitly fail calls to wrong/non-existent
+    fallback() external {
+        revert("Function not found");
     }
 }

--- a/solidity/test/Vault/VaultBasic.t.sol
+++ b/solidity/test/Vault/VaultBasic.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.28;
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultBasicTest is VaultHelper {
     using Math for uint256;

--- a/solidity/test/Vault/VaultCompleteWithdraw.t.sol
+++ b/solidity/test/Vault/VaultCompleteWithdraw.t.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.28;
 
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {IERC20} from "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {console} from "forge-std/src/console.sol";
 import {VmSafe} from "forge-std/src/Vm.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultCompleteWithdrawTest is VaultHelper {
     using Math for uint256;

--- a/solidity/test/Vault/VaultDeposit.t.sol
+++ b/solidity/test/Vault/VaultDeposit.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.28;
 
 import {VaultHelper} from "./VaultHelper.t.sol";
-import {ERC4626} from "../../src/libraries/ValenceVault.sol";
-import {IERC20Errors} from "@openzeppelin-contracts/interfaces/draft-IERC6093.sol";
+import {ERC4626Upgradeable} from "../../src/libraries/ValenceVault.sol";
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 
 contract ValenceVaultDepositTest is VaultHelper {
     function testBasicDeposit() public {
@@ -49,7 +49,7 @@ contract ValenceVaultDepositTest is VaultHelper {
         assertEq(vault.totalAssets(), cap, "Second deposit failed");
 
         // Test deposit exceeding cap
-        vm.expectRevert(abi.encodeWithSelector(ERC4626.ERC4626ExceededMaxDeposit.selector, user, 1000, 0));
+        vm.expectRevert(abi.encodeWithSelector(ERC4626Upgradeable.ERC4626ExceededMaxDeposit.selector, user, 1000, 0));
         vault.deposit(1000, user);
         vm.stopPrank();
     }
@@ -69,7 +69,7 @@ contract ValenceVaultDepositTest is VaultHelper {
         assertEq(vault.totalSupply(), cap, "Second mint failed");
 
         // Test mint exceeding cap
-        vm.expectRevert(abi.encodeWithSelector(ERC4626.ERC4626ExceededMaxMint.selector, user, 1000, 0));
+        vm.expectRevert(abi.encodeWithSelector(ERC4626Upgradeable.ERC4626ExceededMaxMint.selector, user, 1000, 0));
         vault.mint(1000, user);
         vm.stopPrank();
     }

--- a/solidity/test/Vault/VaultFees.t.sol
+++ b/solidity/test/Vault/VaultFees.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {VaultHelper} from "./VaultHelper.t.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {console} from "forge-std/src/console.sol";
 
 contract ValenceVaultFeeTest is VaultHelper {

--- a/solidity/test/Vault/VaultGasBenchmark.t.sol
+++ b/solidity/test/Vault/VaultGasBenchmark.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {IERC20} from "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {console} from "forge-std/src/console.sol";
 
 contract VaultGasBenchmarkTest is VaultHelper {

--- a/solidity/test/Vault/VaultRedemptionRate.t.sol
+++ b/solidity/test/Vault/VaultRedemptionRate.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {Test} from "forge-std/src/Test.sol";
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/solidity/test/Vault/VaultRedemptionRate.t.sol
+++ b/solidity/test/Vault/VaultRedemptionRate.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/src/Test.sol";
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultRedemptionTest is VaultHelper {
     using Math for uint256;

--- a/solidity/test/Vault/VaultSimulationTest.t.sol
+++ b/solidity/test/Vault/VaultSimulationTest.t.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.28;
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {WithdrawDebugger} from "./WithdrawDebugger.t.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {IERC20} from "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {console} from "forge-std/src/console.sol";
 import {VmSafe} from "forge-std/src/Vm.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultSimulationTest is VaultHelper {
     using Math for uint256;

--- a/solidity/test/Vault/VaultUpdate.t.sol
+++ b/solidity/test/Vault/VaultUpdate.t.sol
@@ -6,7 +6,7 @@ import {VaultHelper} from "./VaultHelper.t.sol";
 import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
 import {console} from "forge-std/src/console.sol";
-import {Math} from "@openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultUpdateTest is VaultHelper {
     using Math for uint256;

--- a/solidity/test/Vault/VaultUpdate.t.sol
+++ b/solidity/test/Vault/VaultUpdate.t.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {Test} from "forge-std/src/Test.sol";
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {console} from "forge-std/src/console.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract VaultUpdateTest is VaultHelper {

--- a/solidity/test/Vault/VaultUpgrade.t.sol
+++ b/solidity/test/Vault/VaultUpgrade.t.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {VaultHelper} from "./VaultHelper.t.sol";
+import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
+
+/**
+ * @title ValenceVaultV2
+ * @dev Upgraded version of ValenceVault with emergency shutdown functionality.
+ */
+contract ValenceVaultV2 is ValenceVault {
+    // New state variable
+    bool public emergencyShutdown;
+
+    // Event for the new feature
+    event EmergencyShutdownSet(bool status);
+    event V2Initialized(bool initialShutdownState);
+
+    /**
+     * @notice Initialize the V2 contract with specific settings
+     * @dev Called via upgradeToAndCall
+     * @param _initialShutdownState The initial emergency shutdown state
+     */
+    function initializeV2(bool _initialShutdownState) external onlyOwner {
+        emergencyShutdown = _initialShutdownState;
+        emit V2Initialized(_initialShutdownState);
+    }
+
+    /**
+     * @notice Set the emergency shutdown status
+     * @dev Only callable by the vault owner
+     * @param _status New emergency shutdown status (true = enabled, false = disabled)
+     */
+    function setEmergencyShutdown(bool _status) external onlyOwner {
+        emergencyShutdown = _status;
+        emit EmergencyShutdownSet(_status);
+    }
+
+    /**
+     * @notice Check if deposits are allowed based on emergency shutdown status
+     * @dev This can be used externally to verify if deposits would succeed
+     * @return bool True if deposits are allowed, false otherwise
+     */
+    function depositsAllowed() public view returns (bool) {
+        return !emergencyShutdown;
+    }
+
+    /**
+     * @notice Verify that the vault is not in emergency shutdown
+     * @dev This function can be called before attempting deposits
+     */
+    function checkEmergencyShutdown() public view {
+        require(!emergencyShutdown, "Vault is in emergency shutdown");
+    }
+}
+
+contract ValenceVaultUpgradeTest is VaultHelper {
+    ValenceVaultV2 internal vaultV2Implementation;
+
+    function test_UpgradeToV2WithInitData() public {
+        // First do a deposit to ensure we have state to preserve
+        vm.startPrank(user);
+        uint256 depositAmount = 1_000_000_000;
+        vault.deposit(depositAmount, user);
+        uint256 userShares = vault.balanceOf(user);
+        assertGt(userShares, 0);
+        vm.stopPrank();
+
+        // Deploy V2 implementation
+        vm.startPrank(owner);
+        vaultV2Implementation = new ValenceVaultV2();
+
+        // Prepare initialization data - start with emergency shutdown enabled
+        bool initialShutdownState = true;
+        bytes memory initData = abi.encodeWithSelector(ValenceVaultV2.initializeV2.selector, initialShutdownState);
+
+        // Upgrade and initialize in one step
+        vault.upgradeToAndCall(address(vaultV2Implementation), initData);
+        vm.stopPrank();
+
+        // Cast to V2 to access new functions
+        ValenceVaultV2 vaultV2 = ValenceVaultV2(address(vault));
+
+        // Verify that initialization worked
+        assertTrue(vaultV2.emergencyShutdown(), "Emergency shutdown should be initialized to true");
+
+        // Verify that state was preserved
+        assertEq(vaultV2.balanceOf(user), userShares, "User shares should be preserved after upgrade");
+
+        // Check helper functions with emergency shutdown active
+        vm.startPrank(user);
+        assertFalse(vaultV2.depositsAllowed(), "depositsAllowed should return false during emergency shutdown");
+        vm.expectRevert("Vault is in emergency shutdown");
+        vaultV2.checkEmergencyShutdown();
+        vm.stopPrank();
+
+        // Disable emergency shutdown
+        vm.prank(owner);
+        vaultV2.setEmergencyShutdown(false);
+
+        // Verify helper functions after disabling emergency shutdown
+        vm.startPrank(user);
+        assertTrue(vaultV2.depositsAllowed(), "depositsAllowed should return true after emergency shutdown is disabled");
+        vaultV2.checkEmergencyShutdown(); // Should not revert
+
+        // Now we can deposit (since actual guards aren't in place, this is just to complete the flow)
+        uint256 sharesBefore = vaultV2.balanceOf(user);
+        vault.deposit(depositAmount, user);
+        assertGt(vaultV2.balanceOf(user), sharesBefore, "User should have more shares after deposit");
+        vm.stopPrank();
+    }
+
+    function test_UpgradeToV2WithoutEmergencyShutdown() public {
+        // Deploy V2 implementation
+        vm.startPrank(owner);
+        vaultV2Implementation = new ValenceVaultV2();
+
+        // Prepare initialization data - start with emergency shutdown disabled
+        bool initialShutdownState = false;
+        bytes memory initData = abi.encodeWithSelector(ValenceVaultV2.initializeV2.selector, initialShutdownState);
+
+        // Upgrade and initialize in one step
+        vault.upgradeToAndCall(address(vaultV2Implementation), initData);
+        vm.stopPrank();
+
+        // Cast to V2 to access new functions
+        ValenceVaultV2 vaultV2 = ValenceVaultV2(address(vault));
+
+        // Verify that initialization worked
+        assertFalse(vaultV2.emergencyShutdown(), "Emergency shutdown should be initialized to false");
+
+        // Verify helper functions with emergency shutdown disabled
+        vm.startPrank(user);
+        assertTrue(vaultV2.depositsAllowed(), "depositsAllowed should return true with emergency shutdown disabled");
+        vaultV2.checkEmergencyShutdown(); // Should not revert
+
+        // Make a deposit (regular deposit works since we don't have guards in the deposit function)
+        uint256 depositAmount = 1_000_000_000;
+        uint256 sharesBefore = vaultV2.balanceOf(user);
+        vault.deposit(depositAmount, user);
+        uint256 sharesAfter = vaultV2.balanceOf(user);
+        assertGt(sharesAfter, sharesBefore, "Deposit should work with emergency shutdown disabled");
+        vm.stopPrank();
+    }
+}

--- a/solidity/test/Vault/VaultWithdraw.t.sol
+++ b/solidity/test/Vault/VaultWithdraw.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {VaultHelper} from "./VaultHelper.t.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {ERC4626} from "@openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 
 abstract contract ValenceVaultWithdrawBaseTest is VaultHelper {
     event WithdrawRequested(

--- a/solidity/test/Vault/WithdrawDebugger.t.sol
+++ b/solidity/test/Vault/WithdrawDebugger.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/src/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
-import {console} from "forge-std/src/console.sol";
 
 contract WithdrawDebugger is Test {
     function debugWithdrawRequest(ValenceVault vault, address owner)

--- a/solidity/test/Vault/WithdrawDebugger.t.sol
+++ b/solidity/test/Vault/WithdrawDebugger.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/src/Test.sol";
-import {IERC20} from "@openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {ValenceVault} from "../../src/libraries/ValenceVault.sol";
 import {console} from "forge-std/src/console.sol";
 

--- a/solidity/test/libraries/Forwarder.t.sol
+++ b/solidity/test/libraries/Forwarder.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/src/Test.sol";
 import {Forwarder} from "../../src/libraries/Forwarder.sol";
 import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title Forwarder Test

--- a/solidity/test/mocks/MockERC20.sol
+++ b/solidity/test/mocks/MockERC20.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {ERC20} from "@openzeppelin-contracts/token/ERC20/ERC20.sol";
-import {ERC20Burnable} from "@openzeppelin-contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 
 contract MockERC20 is ERC20, ERC20Burnable {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}


### PR DESCRIPTION
This PR makes the vault upgradeable by using the UUPS proxy pattern of openzeppelin.
This requires removing the constructor and use initializers instead. For this the upgradeable version of openzeppelin contracts the dependencies are used.

When the Proxy pattern is used, interaction is not done through the Vault contract anymore but instead the Proxy is initialized with the Vault contract implementation and all calls go through it to have the state there.

Added new tests that test that upgrading works as expected.
Note: The openzeppelin-contracts-upgradeable needs to have @openzeppelin/contracts as a dependency so modiied the mapping in remappings.txt to make it all work with this one instead of having a duplicated remapping.

The vault.rs example had to be adjusted to now follow  the proxy pattern instead of using the immutable vault constructor. Order:
1. Deploys vault contract.
2. Deploys proxy pointing at the vault contract implementation.
3. Initializes vault through proxy contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an upgradeable vault deployment process using separate implementation and proxy components for enhanced flexibility.
  - Launched a new vault version that supports an emergency shutdown mechanism, offering improved safety controls.

- **Chores / Refactor**
  - Updated critical configuration parameters to ensure reliable integrations.
  - Standardized dependency references and streamlined module imports for better maintainability and overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->