### PR TITLE
fix: Vault completing withdraw requests when no balance on withdraw account

### DIFF
--- a/solidity/src/libraries/ValenceVault.sol
+++ b/solidity/src/libraries/ValenceVault.sol
@@ -775,20 +775,17 @@ contract ValenceVault is
             assetsToWithdraw = shares.mulDiv(updateInfo.withdrawRate, ONE_SHARE, Math.Rounding.Floor);
         }
 
-        // Delete request before transfer to prevent reentrancy
-        delete userWithdrawRequest[owner];
-
         // Prepare the transfer
         bytes memory transferCalldata = abi.encodeCall(IERC20.transfer, (request.receiver, assetsToWithdraw));
 
         // Execute transfer
         try withdrawAccount.execute(asset(), 0, transferCalldata) {
+            // Only delete the entry if the transfer succeeded
+            delete userWithdrawRequest[owner];
             emit WithdrawCompleted(owner, request.receiver, assetsToWithdraw, request.sharesAmount, msg.sender);
             return WithdrawResult(true, assetsToWithdraw, request.solverFee, "");
         } catch {
             if (revertOnFailure) revert("Asset transfer failed");
-            // Restore request if transfer fails
-            userWithdrawRequest[owner] = request;
             return WithdrawResult(false, 0, 0, "Asset transfer failed");
         }
     }

--- a/solidity/src/libraries/ValenceVault.sol
+++ b/solidity/src/libraries/ValenceVault.sol
@@ -787,6 +787,8 @@ contract ValenceVault is
             return WithdrawResult(true, assetsToWithdraw, request.solverFee, "");
         } catch {
             if (revertOnFailure) revert("Asset transfer failed");
+            // Restore request if transfer fails
+            userWithdrawRequest[owner] = request;
             return WithdrawResult(false, 0, 0, "Asset transfer failed");
         }
     }

--- a/solidity/test/mocks/MockERC20.sol
+++ b/solidity/test/mocks/MockERC20.sol
@@ -10,4 +10,8 @@ contract MockERC20 is ERC20, ERC20Burnable {
     function mint(address to, uint256 amount) public {
         _mint(to, amount);
     }
+
+    function burn(address from, uint256 amount) public {
+        _burn(from, amount);
+    }
 }


### PR DESCRIPTION
When there's no balance in the withdraw account and the withdraw request is completed by a solver using the batch completion, if there's no balance in the withdraw account the withdraw request is still being removed from the array.

Fixed that so that this cannot happen, by restoring the request if the transfer failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved withdrawal error handling so that if an asset transfer fails, your withdrawal request is preserved for retry.

- **Tests**
  - Added a new test scenario to verify batch withdrawal behavior when available funds are depleted.

- **New Features**
  - Introduced a token burning capability in the `MockERC20` contract to allow token holders to reduce their total supply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->