### PR TITLE
fix: dont complete withdraws when there was no update performed

### DIFF
--- a/solidity/src/libraries/ValenceVault.sol
+++ b/solidity/src/libraries/ValenceVault.sol
@@ -40,6 +40,7 @@ contract ValenceVault is
     error WithdrawRequestNotFound();
     error SolverNotAllowed();
     error WithdrawNotClaimable();
+    error NoUpdateForRequest();
     error SolverFeeTransferFailed();
     error FeeExceedsUint128();
     error OnlyOwnerCanUnpause();
@@ -738,6 +739,12 @@ contract ValenceVault is
         uint256 _redemptionRate = redemptionRate;
         UpdateInfo memory updateInfo = updateInfos[request.updateId];
         uint256 assetsToWithdraw;
+
+        // Check if there was an update for this request
+        if (updateInfo.timestamp == 0) {
+            if (revertOnFailure) revert NoUpdateForRequest();
+            return WithdrawResult(false, 0, 0, "Update not found");
+        }
 
         // The current withdrawRate is the redemption rate minus the update withdraw fee
         uint256 currentWithdrawRate = _redemptionRate.mulDiv(BASIS_POINTS - updateInfo.withdrawFee, BASIS_POINTS);


### PR DESCRIPTION
closes #265 

When a user was trying to complete a withdraw request and there was no update performed before that, when fetching from the updateInfos array it was using default values (0) because the update didn't exist.

This caused all the calculations to be 0 and the withdraw to succeed sending 0 tokens to the user and his withdraw request removed.

This PR doesn't allow this from happening. If there's no update, the withdraw cannot be completed and reverts/continues to the next one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the withdrawal process to clearly indicate when an update is missing, ensuring users get appropriate feedback.
- **Tests**
  - Added tests to confirm that withdrawal attempts without the necessary updates are correctly blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->