### PR TITLE
refactor: make hop_receiver optional for PFM operations

### DIFF
--- a/contracts/libraries/generic-ibc-transfer/README.md
+++ b/contracts/libraries/generic-ibc-transfer/README.md
@@ -73,7 +73,8 @@ struct PacketForwardMiddlewareConfig {
   local_to_hop_chain_channel_id: String,
   // Channel ID from the intermediate to the destination chain
   hop_to_destination_chain_channel_id: String,
-  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails
-  hop_chain_receiver_address: String,
+  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails. If not 
+  // provided, will be set to "pfm"
+  hop_chain_receiver_address: Option<String>,
 }
 ```

--- a/contracts/libraries/generic-ibc-transfer/schema/valence-generic-ibc-transfer-library.json
+++ b/contracts/libraries/generic-ibc-transfer/schema/valence-generic-ibc-transfer-library.json
@@ -131,13 +131,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"
@@ -538,13 +540,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"
@@ -790,13 +794,15 @@
         "PacketForwardMiddlewareConfig": {
           "type": "object",
           "required": [
-            "hop_chain_receiver_address",
             "hop_to_destination_chain_channel_id",
             "local_to_hop_chain_channel_id"
           ],
           "properties": {
             "hop_chain_receiver_address": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hop_to_destination_chain_channel_id": {
               "type": "string"
@@ -954,13 +960,15 @@
         "PacketForwardMiddlewareConfig": {
           "type": "object",
           "required": [
-            "hop_chain_receiver_address",
             "hop_to_destination_chain_channel_id",
             "local_to_hop_chain_channel_id"
           ],
           "properties": {
             "hop_chain_receiver_address": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hop_to_destination_chain_channel_id": {
               "type": "string"

--- a/contracts/libraries/ica-ibc-transfer/README.md
+++ b/contracts/libraries/ica-ibc-transfer/README.md
@@ -60,7 +60,8 @@ struct PacketForwardMiddlewareConfig {
   local_to_hop_chain_channel_id: String,
   // Channel ID from the intermediate to the destination chain
   hop_to_destination_chain_channel_id: String,
-  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails
-  hop_chain_receiver_address: String,
+  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails. If not 
+  // provided, will be set to "pfm"
+  hop_chain_receiver_address: Option<String>,
 }
 ```

--- a/contracts/libraries/ica-ibc-transfer/schema/valence-ica-ibc-transfer.json
+++ b/contracts/libraries/ica-ibc-transfer/schema/valence-ica-ibc-transfer.json
@@ -109,13 +109,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"
@@ -449,13 +451,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"
@@ -615,13 +619,15 @@
         "PacketForwardMiddlewareConfig": {
           "type": "object",
           "required": [
-            "hop_chain_receiver_address",
             "hop_to_destination_chain_channel_id",
             "local_to_hop_chain_channel_id"
           ],
           "properties": {
             "hop_chain_receiver_address": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hop_to_destination_chain_channel_id": {
               "type": "string"
@@ -751,13 +757,15 @@
         "PacketForwardMiddlewareConfig": {
           "type": "object",
           "required": [
-            "hop_chain_receiver_address",
             "hop_to_destination_chain_channel_id",
             "local_to_hop_chain_channel_id"
           ],
           "properties": {
             "hop_chain_receiver_address": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hop_to_destination_chain_channel_id": {
               "type": "string"

--- a/contracts/libraries/ica-ibc-transfer/src/contract.rs
+++ b/contracts/libraries/ica-ibc-transfer/src/contract.rs
@@ -98,7 +98,10 @@ mod functions {
                             amount: cfg.amount.to_string(),
                         }),
                         sender: remote_address,
-                        receiver: pfm_config.hop_chain_receiver_address.to_string(),
+                        receiver: pfm_config
+                            .hop_chain_receiver_address
+                            .clone()
+                            .unwrap_or("pfm".to_string()),
                         timeout_height: None,
                         timeout_timestamp: env
                             .block

--- a/contracts/libraries/neutron-ibc-transfer/README.md
+++ b/contracts/libraries/neutron-ibc-transfer/README.md
@@ -73,7 +73,8 @@ struct PacketForwardMiddlewareConfig {
   local_to_hop_chain_channel_id: String,
   // Channel ID from the intermediate to the destination chain
   hop_to_destination_chain_channel_id: String,
-  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails
-  hop_chain_receiver_address: String,
+  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails. If not 
+  // provided, will be set to "pfm"
+  hop_chain_receiver_address: Option<String>,
 }
 ```

--- a/contracts/libraries/neutron-ibc-transfer/schema/valence-neutron-ibc-transfer-library.json
+++ b/contracts/libraries/neutron-ibc-transfer/schema/valence-neutron-ibc-transfer-library.json
@@ -131,13 +131,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"
@@ -538,13 +540,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"
@@ -790,13 +794,15 @@
         "PacketForwardMiddlewareConfig": {
           "type": "object",
           "required": [
-            "hop_chain_receiver_address",
             "hop_to_destination_chain_channel_id",
             "local_to_hop_chain_channel_id"
           ],
           "properties": {
             "hop_chain_receiver_address": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hop_to_destination_chain_channel_id": {
               "type": "string"
@@ -954,13 +960,15 @@
         "PacketForwardMiddlewareConfig": {
           "type": "object",
           "required": [
-            "hop_chain_receiver_address",
             "hop_to_destination_chain_channel_id",
             "local_to_hop_chain_channel_id"
           ],
           "properties": {
             "hop_chain_receiver_address": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hop_to_destination_chain_channel_id": {
               "type": "string"

--- a/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/generic_ibc_transfer.md
@@ -79,8 +79,9 @@ struct PacketForwardMiddlewareConfig {
   local_to_hop_chain_channel_id: String,
   // Channel ID from the intermediate to the destination chain
   hop_to_destination_chain_channel_id: String,
-  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails
-  hop_chain_receiver_address: String,
+  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails. If not 
+  // provided, will be set to "pfm"
+  hop_chain_receiver_address: Option<String>,
 }
 ```
 
@@ -127,7 +128,7 @@ LibraryConfig {
         PacketForwardMiddlewareConfig {
             local_to_hop_chain_channel_id: osmosis_to_juno_channel_id,
             hop_to_destination_chain_channel_id: juno_to_gaia_channel_id,
-            hop_chain_receiver_address: "pfm".to_string(),
+            hop_chain_receiver_address: None, // if not passed, "pfm" is used
         },
     )]),
 }

--- a/docs/src/libraries/cosmwasm/ica_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/ica_ibc_transfer.md
@@ -66,8 +66,9 @@ struct PacketForwardMiddlewareConfig {
   local_to_hop_chain_channel_id: String,
   // Channel ID from the intermediate to the destination chain
   hop_to_destination_chain_channel_id: String,
-  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails
-  hop_chain_receiver_address: String,
+  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails. If not 
+  // provided, will be set to "pfm"
+  hop_chain_receiver_address: Option<String>,
 }
 ```
 

--- a/docs/src/libraries/cosmwasm/neutron_ibc_transfer.md
+++ b/docs/src/libraries/cosmwasm/neutron_ibc_transfer.md
@@ -79,8 +79,9 @@ struct PacketForwardMiddlewareConfig {
   local_to_hop_chain_channel_id: String,
   // Channel ID from the intermediate to the destination chain
   hop_to_destination_chain_channel_id: String,
-  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails
-  hop_chain_receiver_address: String,
+  // Temporary receiver address on the intermediate chain. Typically this is set to an invalid address so the entire transaction will revert if the forwarding fails. If not 
+  // provided, will be set to "pfm"
+  hop_chain_receiver_address: Option<String>,
 }
 ```
 
@@ -128,7 +129,7 @@ let cfg = LibraryConfig {
         PacketForwardMiddlewareConfig {
             local_to_hop_chain_channel_id: neutron_to_juno_channel_id,
             hop_to_destination_chain_channel_id: juno_to_gaia_channel_id,
-            hop_chain_receiver_address: "pfm".to_string(),
+            hop_chain_receiver_address: None, // if not passed, "pfm" is used
         },
     )]),
 }

--- a/e2e/examples/ibc_transfer_ntrn_juno_gaia_pfm.rs
+++ b/e2e/examples/ibc_transfer_ntrn_juno_gaia_pfm.rs
@@ -217,7 +217,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .src(JUNO_CHAIN_NAME)
                         .dest(GAIA_CHAIN_NAME)
                         .get(),
-                    hop_chain_receiver_address: JUNO_CHAIN_ADMIN_ADDR.to_string(),
+                    hop_chain_receiver_address: Some(JUNO_CHAIN_ADMIN_ADDR.to_string()),
                 },
             )]),
         ),

--- a/e2e/examples/ibc_transfer_osmo_juno_gaia_pfm.rs
+++ b/e2e/examples/ibc_transfer_osmo_juno_gaia_pfm.rs
@@ -209,7 +209,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .src(JUNO_CHAIN_NAME)
                         .dest(GAIA_CHAIN_NAME)
                         .get(),
-                    hop_chain_receiver_address: JUNO_CHAIN_ADMIN_ADDR.to_string(),
+                    hop_chain_receiver_address: Some(JUNO_CHAIN_ADMIN_ADDR.to_string()),
                 },
             )]),
         ),

--- a/e2e/examples/ica_libraries.rs
+++ b/e2e/examples/ica_libraries.rs
@@ -344,7 +344,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .src(OSMOSIS_CHAIN_NAME)
                         .dest(NEUTRON_CHAIN_NAME)
                         .get(),
-                    hop_chain_receiver_address: "pfm".to_string(),
+                    hop_chain_receiver_address: None,
                 },
             )]),
         },

--- a/packages/ibc-utils/src/generic.rs
+++ b/packages/ibc-utils/src/generic.rs
@@ -32,7 +32,10 @@ pub fn ibc_send_message(
         }),
         Some(pfm_config) => CosmosMsg::Ibc(cosmwasm_std::IbcMsg::Transfer {
             channel_id: pfm_config.local_to_hop_chain_channel_id.to_string(),
-            to_address: pfm_config.hop_chain_receiver_address.to_string(),
+            to_address: pfm_config
+                .hop_chain_receiver_address
+                .clone()
+                .unwrap_or("pfm".to_string()),
             amount: coin(amount, denom),
             timeout: IbcTimeout::with_timestamp(
                 env.block

--- a/packages/ibc-utils/src/neutron.rs
+++ b/packages/ibc-utils/src/neutron.rs
@@ -97,7 +97,10 @@ pub fn ibc_send_message(
                 source_port: "transfer".to_string(),
                 source_channel: pfm_config.local_to_hop_chain_channel_id.to_string(),
                 sender: sender.to_string(),
-                receiver: pfm_config.hop_chain_receiver_address.to_string(),
+                receiver: pfm_config
+                    .hop_chain_receiver_address
+                    .clone()
+                    .unwrap_or("pfm".to_string()),
                 token: Some(coin),
                 timeout_height: None,
                 timeout_timestamp: env

--- a/packages/ibc-utils/src/types.rs
+++ b/packages/ibc-utils/src/types.rs
@@ -4,7 +4,7 @@ use cosmwasm_schema::cw_serde;
 pub struct PacketForwardMiddlewareConfig {
     pub local_to_hop_chain_channel_id: String,
     pub hop_to_destination_chain_channel_id: String,
-    pub hop_chain_receiver_address: String,
+    pub hop_chain_receiver_address: Option<String>,
 }
 
 // https://github.com/strangelove-ventures/packet-forward-middleware/blob/main/router/types/forward.go

--- a/program-manager/schema/valence-program-manager.json
+++ b/program-manager/schema/valence-program-manager.json
@@ -2157,13 +2157,15 @@
       "PacketForwardMiddlewareConfig": {
         "type": "object",
         "required": [
-          "hop_chain_receiver_address",
           "hop_to_destination_chain_channel_id",
           "local_to_hop_chain_channel_id"
         ],
         "properties": {
           "hop_chain_receiver_address": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "hop_to_destination_chain_channel_id": {
             "type": "string"


### PR DESCRIPTION
Closes #301 

We make hop_chain_receiver_address optional in our configs so that if it's not passed "pfm" is used, which is what will be used in most scenarios.