### PR TITLE
fix: increase time between local-ic query and logs check

### DIFF
--- a/scripts/start-local-ic.sh
+++ b/scripts/start-local-ic.sh
@@ -10,7 +10,7 @@ while [[ "$SUCCESS" = false && "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]]; do
   /tmp/local-ic start $CHAIN_CONFIG --api-port 42069 &
   curl --head -X GET --retry 200 --retry-connrefused --retry-delay 5 http://localhost:42069
   echo "$(date): Successfully queried Local-IC"
-  sleep 10
+  sleep 20
   # Check to see if chain config has been created which is the last step of local-ic startup
   CHAIN_INFO=$(<configs/logs.json)
   if [[ "$CHAIN_INFO" != "{}" ]]; then


### PR DESCRIPTION
Sometimes it takes longer for logs to get created once we query local-ic, specially when we have 3+ chains. To avoid killing it even though it was successfully started, increase the time before we check that logs are there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the local service startup routine by extending the wait period between retry attempts, enhancing stability during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->