### PR TITLE
bug: Migrate entry point in program registry

### DIFF
--- a/contracts/program-registry/src/contract.rs
+++ b/contracts/program-registry/src/contract.rs
@@ -6,7 +6,9 @@ use cw_storage_plus::Bound;
 
 use crate::state::{PROGRAMS, PROGRAMS_BACKUP};
 use crate::{error::ContractError, state::LAST_ID};
-use valence_program_registry_utils::{ExecuteMsg, InstantiateMsg, ProgramResponse, QueryMsg};
+use valence_program_registry_utils::{
+    ExecuteMsg, InstantiateMsg, MigrateMsg, ProgramResponse, QueryMsg,
+};
 
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -162,6 +164,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::GetLastId {} => to_json_binary(&LAST_ID.load(deps.storage)?),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    Ok(Response::default())
 }
 
 #[cfg(test)]

--- a/packages/program-registry-utils/src/lib.rs
+++ b/packages/program-registry-utils/src/lib.rs
@@ -27,6 +27,9 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
+pub enum MigrateMsg {}
+
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Gets the most up to date program config for the id

--- a/packages/program-registry-utils/src/lib.rs
+++ b/packages/program-registry-utils/src/lib.rs
@@ -27,7 +27,9 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum MigrateMsg {}
+pub enum MigrateMsg {
+    NoStateChange {},
+}
 
 #[cw_serde]
 #[derive(QueryResponses)]


### PR DESCRIPTION
We need the migrate entry point to migrate the registry, no state changes are done, so nothing really is needed, just for the entry point to exists, else migration will fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added migration capability to enable smooth contract upgrades.
	- Introduced a new migration message type to support future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->