### PR TITLE
feat: StandardBridgeTransfer library

### DIFF
--- a/contracts/encoders/evm-encoder/src/lib.rs
+++ b/contracts/encoders/evm-encoder/src/lib.rs
@@ -4,7 +4,8 @@ use alloy_primitives::{address, Address, Bytes};
 use alloy_sol_types::SolValue;
 use cosmwasm_std::{Binary, StdError, StdResult};
 use libraries::{
-    aave_position_manager, balancer_v2_swap, cctp_transfer, forwarder, stargate_transfer,
+    aave_position_manager, balancer_v2_swap, cctp_transfer, forwarder, standard_bridge_transfer,
+    stargate_transfer,
 };
 use strum::EnumString;
 use valence_authorization_utils::authorization::Subroutine;
@@ -28,6 +29,7 @@ pub enum EVMLibrary {
     StargateTransfer,
     AavePositionManager,
     BalancerV2Swap,
+    StandardBridgeTransfer,
 }
 
 impl EVMLibrary {
@@ -59,6 +61,7 @@ impl EVMLibrary {
             EVMLibrary::StargateTransfer => stargate_transfer::encode(msg),
             EVMLibrary::AavePositionManager => aave_position_manager::encode(msg),
             EVMLibrary::BalancerV2Swap => balancer_v2_swap::encode(msg),
+            EVMLibrary::StandardBridgeTransfer => standard_bridge_transfer::encode(msg),
         }
     }
 }

--- a/contracts/encoders/evm-encoder/src/libraries/mod.rs
+++ b/contracts/encoders/evm-encoder/src/libraries/mod.rs
@@ -8,6 +8,7 @@ use valence_encoder_utils::libraries::{
 pub mod aave_position_manager;
 pub mod cctp_transfer;
 pub mod forwarder;
+pub mod standard_bridge_transfer;
 pub mod stargate_transfer;
 
 // Function calls that are common to all libraries

--- a/contracts/encoders/evm-encoder/src/libraries/standard_bridge_transfer.rs
+++ b/contracts/encoders/evm-encoder/src/libraries/standard_bridge_transfer.rs
@@ -1,0 +1,87 @@
+use alloy_sol_types::{SolCall, SolValue};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Binary, StdError, StdResult, Uint256};
+use valence_encoder_utils::libraries::{
+    standard_bridge_transfer::solidity_types::transferCall, updateConfigCall,
+};
+use valence_library_utils::{msg::ExecuteMsg, LibraryAccountType};
+
+use crate::parse_address;
+
+use super::{get_update_ownership_call, get_update_processor_call};
+
+// We need to define a config and functions for this library as we don't have a CosmWasm equivalent
+#[cw_serde]
+/// Struct representing the library configuration.
+pub struct LibraryConfig {
+    /// The input address for the library.
+    pub input_addr: LibraryAccountType,
+    /// The recipient of the transfer.
+    pub recipient: String,
+    /// Amount to transfer. Setting this to 0 will transfer the entire balance.
+    pub amount: Uint256,
+    /// Address of the L1 or L2 Standard Bridge.
+    pub standard_bridge_address: String,
+    /// The address of the ERC20 token to transfer. For ETH, use the zero address.
+    pub transfer_token: String,
+    /// The address of the remote token. ERC20 representation of the token on the other chain. For ETH, use the zero address.
+    pub remote_token: String,
+    /// Gas to use to complete the transfer on the receiving side. Used for sequencers/relayers.
+    pub gas_limit: u32,
+    /// Extra data to sent with the transaction. Will be emitted to identify the transaction.
+    pub extra_data: Option<Binary>,
+}
+
+#[cw_serde]
+/// Enum representing the different function messages that can be sent.
+pub enum FunctionMsgs {
+    /// Message to transfer tokens.
+    Transfer {},
+}
+
+type StandardBridgeTransferMsg = ExecuteMsg<FunctionMsgs, LibraryConfig>;
+
+pub fn encode(msg: &Binary) -> StdResult<Vec<u8>> {
+    // Extract the message from the binary and verify that it parses into a valid json for the library
+    let msg: StandardBridgeTransferMsg = serde_json::from_slice(msg.as_slice()).map_err(|_| {
+        StdError::generic_err("Message sent is not a valid message for this library!".to_string())
+    })?;
+
+    match msg {
+        ExecuteMsg::ProcessFunction(function) => match function {
+            FunctionMsgs::Transfer {} => Ok(transferCall::SELECTOR.to_vec()),
+        },
+        ExecuteMsg::UpdateConfig { new_config } => {
+            // Parse addresses
+            let input_account = parse_address(&new_config.input_addr.to_string()?)?;
+            let recipient = parse_address(&new_config.recipient)?;
+            let standard_bridge = parse_address(&new_config.standard_bridge_address)?;
+            let transfer_token = parse_address(&new_config.transfer_token)?;
+            let remote_token = parse_address(&new_config.remote_token)?;
+
+            // Build config struct
+            let config =
+                valence_encoder_utils::libraries::standard_bridge_transfer::solidity_types::StandardBridgeTransferConfig {
+                    amount: alloy_primitives::U256::from_be_bytes(new_config.amount.to_be_bytes()),
+                    inputAccount: input_account,
+                    recipient,
+                    standardBridge: standard_bridge,
+                    token: transfer_token,
+                    remoteToken: remote_token,
+                    minGasLimit: new_config.gas_limit,
+                    extraData: new_config
+                        .extra_data
+                        .map(|data| data.to_vec().into())
+                        .unwrap_or_default(),
+                };
+
+            // Create the encoded call with the encoded config
+            let call = updateConfigCall {
+                _config: config.abi_encode().into(),
+            };
+            Ok(call.abi_encode())
+        }
+        ExecuteMsg::UpdateProcessor { processor } => get_update_processor_call(&processor),
+        ExecuteMsg::UpdateOwnership(action) => get_update_ownership_call(action),
+    }
+}

--- a/contracts/encoders/evm-encoder/src/tests.rs
+++ b/contracts/encoders/evm-encoder/src/tests.rs
@@ -22,9 +22,50 @@ use valence_encoder_utils::{
 
 use crate::{
     contract::{instantiate, query},
+    parse_address,
     solidity_types::{EvictMsgs, InsertMsgs, ProcessorMessage, ProcessorMessageType, SendMsgs},
     EVMLibrary,
 };
+
+#[test]
+fn test_parse_zero_address() {
+    // Test with full zero address
+    let result = parse_address("0x0000000000000000000000000000000000000000");
+    assert!(result.is_ok());
+    let zero_addr = result.unwrap();
+    assert_eq!(zero_addr, Address::ZERO);
+}
+
+#[test]
+fn test_parse_real_address() {
+    // A real Ethereum address
+    let address_str = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+    // Parse the address
+    let result = parse_address(address_str);
+    assert!(result.is_ok());
+
+    let parsed_address = result.unwrap();
+
+    // Confirm it's not the zero address
+    assert_ne!(parsed_address, Address::ZERO);
+
+    // Convert back to string and compare (case insensitive)
+    let address_back_to_string = format!("{:?}", parsed_address).to_lowercase();
+
+    assert_eq!(address_back_to_string, address_str.to_lowercase());
+}
+
+#[test]
+fn test_parse_invalid_address() {
+    // Test with invalid address
+    let result = parse_address("not_an_address");
+    assert!(result.is_err());
+
+    // Test with invalid hex but correct prefix
+    let result = parse_address("0xZZZZ");
+    assert!(result.is_err());
+}
 
 #[test]
 fn test_valid_combinations() {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -47,6 +47,7 @@
     - [Forwarder](./libraries/evm/forwarder.md)
     - [CCTP Transfer](./libraries/evm/cctp_transfer.md)
     - [Stargate Transfer](./libraries/evm/stargate_transfer.md)
+    - [Standard Bridge Transfer](./libraries/evm/standard_bridge_transfer.md)
     - [AAVE Position Manager](./libraries/evm/aave_position_manager.md)
 - [Middleware](./middleware/_overview.md)
   - [Broker](./middleware/broker.md)

--- a/docs/src/libraries/evm/standard_bridge_transfer.md
+++ b/docs/src/libraries/evm/standard_bridge_transfer.md
@@ -1,6 +1,6 @@
 # Standard Bridge Transfer library
 
-The **Standard Bridge Transfer** library allows to **transfer funds** from an **input account** to a **recipient** using a [Standard Bridge contract (both L1 and L2 variants)](https://docs.optimism.io/app-developers/bridging/standard-bridge). This bridge is used to transfer tokens between L1 and L2 EVM chains (e.g. Base to Ethereum and viceversa).It is typically used as part of a **Valence Program**. In that context, a **Processor** contract will be the main contract interacting with the Standard Bridge Transfer library.
+The Standard Bridge Transfer library enables transferring funds from an **input account** to a **recipient** using a [StandardBridge contract](https://docs.optimism.io/app-developers/bridging/standard-bridge). This library works with both the L1StandardBridge and L2StandardBridge implementations, allowing token transfers between Ethereum (Layer 1) and its scaling solutions like Optimism or Base (Layer 2). The library facilitates seamless bridging of assets in both directions - from L1 to L2 and from L2 to L1. It is typically used as part of a **Valence Program**. In that context, a **Processor** contract will be the main contract interacting with the Stargate Transfer library.
 
 ## High-level flow
 

--- a/docs/src/libraries/evm/standard_bridge_transfer.md
+++ b/docs/src/libraries/evm/standard_bridge_transfer.md
@@ -49,7 +49,7 @@ The library is configured on deployment using the `StandardBridgeTransferConfig`
      * @param recipient The recipient address on the destination chain.
      * @param standardBridge The StandardBridge contract address (L1 or L2 version).
      * @param token The ERC20 token address to transfer (or address(0) for ETH).
-     * @param remoteToken Address of the corresponding token on the destination chain (for ERC20).
+     * @param remoteToken Address of the corresponding token on the destination chain (only used for ERC20 transfers). Must be zero address for ETH transfers.
      * @param minGasLimit Gas to use to complete the transfer on the receiving side. Used for sequencers/relayers.
      * @param extraData Additional data to be forwarded with the transaction.
      */

--- a/docs/src/libraries/evm/standard_bridge_transfer.md
+++ b/docs/src/libraries/evm/standard_bridge_transfer.md
@@ -1,0 +1,66 @@
+# Standard Bridge Transfer library
+
+The **Standard Bridge Transfer** library allows to **transfer funds** from an **input account** to a **recipient** using a [Standard Bridge contract (both L1 and L2 variants)](https://docs.optimism.io/app-developers/bridging/standard-bridge). This bridge is used to transfer tokens between L1 and L2 EVM chains (e.g. Base to Ethereum and viceversa).It is typically used as part of a **Valence Program**. In that context, a **Processor** contract will be the main contract interacting with the Standard Bridge Transfer library.
+
+## High-level flow
+
+```mermaid
+---
+title: Standard Bridge Transfer Library
+---
+graph LR
+  IA((Input Account))
+  R((Recipient))
+  SBO((Standard Bridge))
+  SBD((Standard Bridge))
+  P[Processor]
+  S[StandardBridgeTransfer
+   Library]
+
+  subgraph DEST[ Destination Chain ]
+    SBD -- 5/WithdrawTo --> R
+  end
+
+  subgraph SRC[ Source Chain ]
+    P -- 1/Transfer --> S
+    S -- 2/Query native or ERC20 balance --> IA
+    IA -- 3/Approve ERC20 (if applies) --> SBO
+    IA -- 4/Call bridgeETHTo or bridgeERC20To --> SBO
+  end
+
+  SRC --- DEST
+```
+
+## Functions
+
+| Function     | Parameters | Description                                                                                         |
+| ------------ | ---------- | --------------------------------------------------------------------------------------------------- |
+| **Transfer** | -          | Transfer funds from the configured **input account** to the **recipient** on the destination chain. |
+
+## Configuration
+
+The library is configured on deployment using the `StandardBridgeTransferConfig` type. More information on the config parameters can be found [here](https://docs.optimism.io/app-developers/bridging/standard-bridge).
+
+```solidity
+    /**
+     * @dev Configuration struct for StandardBridge transfer parameters.
+     * @param amount The number of tokens to transfer. If set to 0, the entire balance is transferred.
+     * @param inputAccount The account from which tokens will be transferred from.
+     * @param recipient The recipient address on the destination chain.
+     * @param standardBridge The StandardBridge contract address (L1 or L2 version).
+     * @param token The ERC20 token address to transfer (or address(0) for ETH).
+     * @param remoteToken Address of the corresponding token on the destination chain (for ERC20).
+     * @param minGasLimit Gas to use to complete the transfer on the receiving side. Used for sequencers/relayers.
+     * @param extraData Additional data to be forwarded with the transaction.
+     */
+    struct StandardBridgeTransferConfig {
+        uint256 amount;
+        BaseAccount inputAccount;
+        address recipient;
+        IStandardBridge standardBridge;
+        address token;
+        address remoteToken;
+        uint32 minGasLimit;
+        bytes extraData;
+    }
+```

--- a/packages/encoder-utils/src/libraries/mod.rs
+++ b/packages/encoder-utils/src/libraries/mod.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::{Binary, StdError, StdResult};
 pub mod aave_position_manager;
 pub mod cctp_transfer;
 pub mod forwarder;
+pub mod standard_bridge_transfer;
 pub mod stargate_transfer;
 
 #[cw_serde]

--- a/packages/encoder-utils/src/libraries/standard_bridge_transfer/mod.rs
+++ b/packages/encoder-utils/src/libraries/standard_bridge_transfer/mod.rs
@@ -1,0 +1,1 @@
+pub mod solidity_types;

--- a/packages/encoder-utils/src/libraries/standard_bridge_transfer/solidity_types.rs
+++ b/packages/encoder-utils/src/libraries/standard_bridge_transfer/solidity_types.rs
@@ -1,0 +1,16 @@
+use alloy_sol_types::sol;
+
+sol! {
+    struct StandardBridgeTransferConfig {
+        uint256 amount;
+        address inputAccount;
+        address recipient;
+        address standardBridge;
+        address token;
+        address remoteToken;
+        uint32 minGasLimit;
+        bytes extraData;
+    }
+
+    function transfer() external view;
+}

--- a/solidity/script/L1StandardBridgeTransfer.script.sol
+++ b/solidity/script/L1StandardBridgeTransfer.script.sol
@@ -57,7 +57,8 @@ contract L1BaseBridgeTransferScript is Script {
         vm.deal(address(inputAccount), ethAmount * 3);
 
         // Deploy a new StandardBridgeTransfer contract for native ETH with fixed amount
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: ethAmount,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -71,7 +72,8 @@ contract L1BaseBridgeTransferScript is Script {
         standardBridgeTransferNative = new StandardBridgeTransfer(owner, processor, ethConfigBytes);
 
         // Deploy a new StandardBridgeTransfer contract for USDC
-        StandardBridgeTransfer.StandardBridgeConfig memory usdcConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory usdcConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: tokenAmount,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -122,7 +124,8 @@ contract L1BaseBridgeTransferScript is Script {
 
         // Deploy a new StandardBridgeTransfer contract for native ETH with full balance transfer
         vm.startPrank(owner);
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfigFull = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfigFull = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 0, // 0 means transfer full balance
             inputAccount: inputAccount,
             recipient: recipient,

--- a/solidity/script/L1StandardBridgeTransfer.script.sol
+++ b/solidity/script/L1StandardBridgeTransfer.script.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {Script} from "forge-std/src/Script.sol";
+import {MockERC20} from "../test/mocks/MockERC20.sol";
+import {StandardBridgeTransfer} from "../src/libraries/StandardBridgeTransfer.sol";
+import {IStandardBridge} from "../src/libraries/interfaces/standard-bridge/IStandardBridge.sol";
+import {BaseAccount} from "../src/accounts/BaseAccount.sol";
+import {console} from "forge-std/src/console.sol";
+
+contract L1BaseBridgeTransferScript is Script {
+    // Address of the USDC ERC-20 token on Ethereum
+    address constant USDC_L1_ADDR = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    // Address of the corresponding USDC on Base
+    address constant USDC_L2_ADDR = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913; // USDC on Base
+
+    // Address of the L1StandardBridge for Base
+    address constant L1_BASE_BRIDGE = 0x3154Cf16ccdb4C6d922629664174b904d80F2C35;
+
+    // Example addresses for owner, processor, and recipient
+    address owner = address(1);
+    address processor = address(2);
+    address recipient = address(3); // Base recipient address
+
+    // Contracts
+    StandardBridgeTransfer public standardBridgeTransferNative;
+    StandardBridgeTransfer public standardBridgeTransferERC20;
+    StandardBridgeTransfer public standardBridgeTransferNativeFull;
+    BaseAccount inputAccount;
+
+    // Amounts to transfer
+    uint256 ethAmount = 0.1 ether; // For native ETH
+    uint256 tokenAmount = 100000; // For USDC
+    uint32 minGasLimit = 200000; // Standard gas limit for L1->L2 messages
+
+    function run() external {
+        // Create a fork of Ethereum mainnet and switch to it
+        uint256 forkId = vm.createFork("https://eth-mainnet.public.blastapi.io");
+        vm.selectFork(forkId);
+
+        // Replace the runtime code at USDC_L1_ADDR with our MockERC20 code so we can mint some USDC
+        bytes memory mockCode = type(MockERC20).runtimeCode;
+        vm.etch(USDC_L1_ADDR, mockCode);
+
+        // Start broadcasting transactions
+        vm.startPrank(owner);
+
+        // Deploy a new BaseAccount contract
+        inputAccount = new BaseAccount(owner, new address[](0));
+
+        // Mint some USDC tokens to the BaseAccount
+        MockERC20 usdc = MockERC20(USDC_L1_ADDR);
+        usdc.mint(address(inputAccount), tokenAmount);
+
+        // Send some ETH to the BaseAccount
+        vm.deal(address(inputAccount), ethAmount * 3);
+
+        // Deploy a new StandardBridgeTransfer contract for native ETH with fixed amount
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: ethAmount,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(L1_BASE_BRIDGE)),
+            token: address(0), // Native ETH
+            remoteToken: address(0), // Not needed for ETH
+            minGasLimit: minGasLimit,
+            extraData: ""
+        });
+        bytes memory ethConfigBytes = abi.encode(ethConfig);
+        standardBridgeTransferNative = new StandardBridgeTransfer(owner, processor, ethConfigBytes);
+
+        // Deploy a new StandardBridgeTransfer contract for USDC
+        StandardBridgeTransfer.StandardBridgeConfig memory usdcConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: tokenAmount,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(L1_BASE_BRIDGE)),
+            token: USDC_L1_ADDR,
+            remoteToken: USDC_L2_ADDR, // Base USDC address
+            minGasLimit: minGasLimit,
+            extraData: ""
+        });
+        bytes memory usdcConfigBytes = abi.encode(usdcConfig);
+        standardBridgeTransferERC20 = new StandardBridgeTransfer(owner, processor, usdcConfigBytes);
+
+        // Approve the libraries from the input account
+        inputAccount.approveLibrary(address(standardBridgeTransferNative));
+        inputAccount.approveLibrary(address(standardBridgeTransferERC20));
+
+        vm.stopPrank();
+
+        // Get the balance before the transfer of the inputAccount
+        uint256 ethBalanceBefore = address(inputAccount).balance;
+        uint256 usdcBalanceBefore = usdc.balanceOf(address(inputAccount));
+
+        console.log("ETH balance before transfer: ", ethBalanceBefore);
+        console.log("USDC balance before transfer: ", usdcBalanceBefore);
+
+        // Execute the native ETH transfer
+        vm.prank(processor);
+        standardBridgeTransferNative.transfer();
+
+        // Execute the USDC transfer
+        vm.prank(processor);
+        standardBridgeTransferERC20.transfer();
+
+        // Get the balance after the transfers
+        uint256 ethBalanceAfter = address(inputAccount).balance;
+        uint256 usdcBalanceAfter = usdc.balanceOf(address(inputAccount));
+
+        console.log("ETH balance after transfer: ", ethBalanceAfter);
+        console.log("USDC balance after transfer: ", usdcBalanceAfter);
+
+        // Check balance changes
+        console.log("ETH used: ", ethBalanceBefore - ethBalanceAfter);
+        console.log("USDC sent: ", usdcBalanceBefore - usdcBalanceAfter);
+
+        // Verify that the balances have been correctly deducted
+        assert(ethBalanceBefore - ethBalanceAfter == ethAmount);
+        assert(usdcBalanceBefore - usdcBalanceAfter == tokenAmount);
+
+        // Deploy a new StandardBridgeTransfer contract for native ETH with full balance transfer
+        vm.startPrank(owner);
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfigFull = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 0, // 0 means transfer full balance
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(L1_BASE_BRIDGE)),
+            token: address(0), // Native ETH
+            remoteToken: address(0), // Not needed for ETH
+            minGasLimit: minGasLimit,
+            extraData: ""
+        });
+        bytes memory ethConfigFullBytes = abi.encode(ethConfigFull);
+        standardBridgeTransferNativeFull = new StandardBridgeTransfer(owner, processor, ethConfigFullBytes);
+
+        // Approve the library from the input account
+        inputAccount.approveLibrary(address(standardBridgeTransferNativeFull));
+        vm.stopPrank();
+
+        uint256 ethBalanceBeforeFullTransfer = address(inputAccount).balance;
+        console.log("ETH balance before full transfer: ", ethBalanceBeforeFullTransfer);
+
+        // Execute the native ETH transfer for full amount
+        vm.prank(processor);
+        standardBridgeTransferNativeFull.transfer();
+
+        uint256 ethBalanceAfterFullTransfer = address(inputAccount).balance;
+        console.log("ETH balance after full transfer: ", ethBalanceAfterFullTransfer);
+
+        assert(ethBalanceAfterFullTransfer == 0); // All ETH should be transferred
+    }
+}

--- a/solidity/script/L2StandardBridgeTransfer.script.sol
+++ b/solidity/script/L2StandardBridgeTransfer.script.sol
@@ -57,7 +57,8 @@ contract L2StandardBridgeTransferScript is Script {
         vm.deal(address(inputAccount), ethAmount * 3);
 
         // Deploy a new StandardBridgeTransfer contract for native ETH with fixed amount
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: ethAmount,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -71,7 +72,8 @@ contract L2StandardBridgeTransferScript is Script {
         standardBridgeTransferNative = new StandardBridgeTransfer(owner, processor, ethConfigBytes);
 
         // Deploy a new StandardBridgeTransfer contract for USDC
-        StandardBridgeTransfer.StandardBridgeConfig memory usdcConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory usdcConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: tokenAmount,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -122,7 +124,8 @@ contract L2StandardBridgeTransferScript is Script {
 
         // Deploy a new StandardBridgeTransfer contract for native ETH with full balance transfer
         vm.startPrank(owner);
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfigFull = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfigFull = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 0, // 0 means transfer full balance
             inputAccount: inputAccount,
             recipient: recipient,

--- a/solidity/script/L2StandardBridgeTransfer.script.sol
+++ b/solidity/script/L2StandardBridgeTransfer.script.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {Script} from "forge-std/src/Script.sol";
+import {MockERC20} from "../test/mocks/MockERC20.sol";
+import {StandardBridgeTransfer} from "../src/libraries/StandardBridgeTransfer.sol";
+import {IStandardBridge} from "../src/libraries/interfaces/standard-bridge/IStandardBridge.sol";
+import {BaseAccount} from "../src/accounts/BaseAccount.sol";
+import {console} from "forge-std/src/console.sol";
+
+contract L2StandardBridgeTransferScript is Script {
+    // Address of the test USDC ERC-20 token
+    address constant USDC_L2_ADDR = 0x7F5c764cBc14f9669B88837ca1490cCa17c31607; // USDC on Optimism
+
+    // Address of the corresponding L1 USDC (for remoteToken parameter)
+    address constant USDC_L1_ADDR = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // USDC on Ethereum
+
+    // Address of the L2StandardBridge on Optimism
+    address constant L2_STANDARD_BRIDGE = 0x4200000000000000000000000000000000000010;
+
+    // Example addresses for owner, processor, and recipient
+    address owner = address(1);
+    address processor = address(2);
+    address recipient = address(3); // L1 recipient address
+
+    // Contracts
+    StandardBridgeTransfer public standardBridgeTransferNative;
+    StandardBridgeTransfer public standardBridgeTransferERC20;
+    StandardBridgeTransfer public standardBridgeTransferNativeFull;
+    BaseAccount inputAccount;
+
+    // Amounts to transfer
+    uint256 ethAmount = 0.1 ether; // For native ETH
+    uint256 tokenAmount = 100000; // For USDC
+    uint32 minGasLimit = 200000; // Standard gas limit for L2->L1 messages
+
+    function run() external {
+        // Create a fork of Optimism and switch to it
+        uint256 forkId = vm.createFork("https://mainnet.optimism.io");
+        vm.selectFork(forkId);
+
+        // Replace the runtime code at USDC_L2_ADDR with our MockERC20 code so we can mint some USDC
+        bytes memory mockCode = type(MockERC20).runtimeCode;
+        vm.etch(USDC_L2_ADDR, mockCode);
+
+        // Start broadcasting transactions
+        vm.startPrank(owner);
+
+        // Deploy a new BaseAccount contract
+        inputAccount = new BaseAccount(owner, new address[](0));
+
+        // Mint some USDC tokens to the BaseAccount
+        MockERC20 usdc = MockERC20(USDC_L2_ADDR);
+        usdc.mint(address(inputAccount), tokenAmount);
+
+        // Send some ETH to the BaseAccount
+        vm.deal(address(inputAccount), ethAmount * 3);
+
+        // Deploy a new StandardBridgeTransfer contract for native ETH with fixed amount
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: ethAmount,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(L2_STANDARD_BRIDGE)),
+            token: address(0), // Native ETH
+            remoteToken: address(0), // Not needed for ETH
+            minGasLimit: minGasLimit,
+            extraData: ""
+        });
+        bytes memory ethConfigBytes = abi.encode(ethConfig);
+        standardBridgeTransferNative = new StandardBridgeTransfer(owner, processor, ethConfigBytes);
+
+        // Deploy a new StandardBridgeTransfer contract for USDC
+        StandardBridgeTransfer.StandardBridgeConfig memory usdcConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: tokenAmount,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(L2_STANDARD_BRIDGE)),
+            token: USDC_L2_ADDR,
+            remoteToken: USDC_L1_ADDR, // L1 USDC address
+            minGasLimit: minGasLimit,
+            extraData: ""
+        });
+        bytes memory usdcConfigBytes = abi.encode(usdcConfig);
+        standardBridgeTransferERC20 = new StandardBridgeTransfer(owner, processor, usdcConfigBytes);
+
+        // Approve the libraries from the input account
+        inputAccount.approveLibrary(address(standardBridgeTransferNative));
+        inputAccount.approveLibrary(address(standardBridgeTransferERC20));
+
+        vm.stopPrank();
+
+        // Get the balance before the transfer of the inputAccount
+        uint256 ethBalanceBefore = address(inputAccount).balance;
+        uint256 usdcBalanceBefore = usdc.balanceOf(address(inputAccount));
+
+        console.log("ETH balance before transfer: ", ethBalanceBefore);
+        console.log("USDC balance before transfer: ", usdcBalanceBefore);
+
+        // Execute the native ETH transfer
+        vm.prank(processor);
+        standardBridgeTransferNative.transfer();
+
+        // Execute the USDC transfer
+        vm.prank(processor);
+        standardBridgeTransferERC20.transfer();
+
+        // Get the balance after the transfers
+        uint256 ethBalanceAfter = address(inputAccount).balance;
+        uint256 usdcBalanceAfter = usdc.balanceOf(address(inputAccount));
+
+        console.log("ETH balance after transfer: ", ethBalanceAfter);
+        console.log("USDC balance after transfer: ", usdcBalanceAfter);
+
+        // Check balance changes
+        console.log("ETH used: ", ethBalanceBefore - ethBalanceAfter);
+        console.log("USDC sent: ", usdcBalanceBefore - usdcBalanceAfter);
+
+        // Verify that the balances have been correctly deducted
+        assert(ethBalanceBefore - ethBalanceAfter == ethAmount);
+        assert(usdcBalanceBefore - usdcBalanceAfter == tokenAmount);
+
+        // Deploy a new StandardBridgeTransfer contract for native ETH with full balance transfer
+        vm.startPrank(owner);
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfigFull = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 0, // 0 means transfer full balance
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(L2_STANDARD_BRIDGE)),
+            token: address(0), // Native ETH
+            remoteToken: address(0), // Not needed for ETH
+            minGasLimit: minGasLimit,
+            extraData: ""
+        });
+        bytes memory ethConfigFullBytes = abi.encode(ethConfigFull);
+        standardBridgeTransferNativeFull = new StandardBridgeTransfer(owner, processor, ethConfigFullBytes);
+
+        // Approve the library from the input account
+        inputAccount.approveLibrary(address(standardBridgeTransferNativeFull));
+        vm.stopPrank();
+
+        uint256 ethBalanceBeforeFullTransfer = address(inputAccount).balance;
+        console.log("ETH balance before full transfer: ", ethBalanceBeforeFullTransfer);
+
+        // Execute the native ETH transfer for full amount
+        vm.prank(processor);
+        standardBridgeTransferNativeFull.transfer();
+
+        uint256 ethBalanceAfterFullTransfer = address(inputAccount).balance;
+        console.log("ETH balance after full transfer: ", ethBalanceAfterFullTransfer);
+
+        assert(ethBalanceAfterFullTransfer == 0); // All ETH should be transferred
+    }
+}

--- a/solidity/src/libraries/StandardBridgeTransfer.sol
+++ b/solidity/src/libraries/StandardBridgeTransfer.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {Library} from "./Library.sol";
+import {BaseAccount} from "../accounts/BaseAccount.sol";
+import {IERC20} from "forge-std/src/interfaces/IERC20.sol";
+import {IStandardBridge} from "./interfaces/standard-bridge/IStandardBridge.sol";
+
+/**
+ * @title StandardBridgeTransfer
+ * @dev Contract for automatically transferring tokens using StandardBridge on both L1 and L2.
+ * Works with both L1StandardBridge and L2StandardBridge contracts.
+ * It allows for transferring ETH or ERC20 tokens across chains.
+ */
+contract StandardBridgeTransfer is Library {
+    /**
+     * @dev Configuration struct for StandardBridge transfer parameters.
+     * @param amount The number of tokens to transfer. If set to 0, the entire balance is transferred.
+     * @param inputAccount The account from which tokens will be transferred from.
+     * @param recipient The recipient address on the destination chain.
+     * @param standardBridge The StandardBridge contract address (L1 or L2 version).
+     * @param token The ERC20 token address to transfer (or address(0) for ETH).
+     * @param remoteToken Address of the corresponding token on the destination chain (for ERC20).
+     * @param minGasLimit Gas limit for the transaction execution on the destination chain.
+     * @param extraData Additional data to be forwarded with the transaction.
+     */
+    struct StandardBridgeConfig {
+        uint256 amount;
+        BaseAccount inputAccount;
+        address recipient;
+        IStandardBridge standardBridge;
+        address token;
+        address remoteToken;
+        uint32 minGasLimit;
+        bytes extraData;
+    }
+
+    // Holds the current configuration for StandardBridge transfers
+    StandardBridgeConfig public config;
+
+    /**
+     * @dev Constructor initializes the contract with the owner, processor, and initial configuration.
+     * @param _owner Address of the contract owner.
+     * @param _processor Address of the designated processor that can execute functions.
+     * @param _config Encoded configuration parameters for the StandardBridge transfer.
+     */
+    constructor(address _owner, address _processor, bytes memory _config) Library(_owner, _processor, _config) {}
+
+    /**
+     * @dev Validates configuration by decoding the provided bytes and ensuring no critical addresses are zero.
+     * @param _config Raw configuration bytes.
+     * @return Decoded and validated StandardBridgeConfig struct.
+     */
+    function validateConfig(bytes memory _config) internal pure returns (StandardBridgeConfig memory) {
+        // Decode the configuration bytes into the StandardBridgeConfig struct.
+        StandardBridgeConfig memory decodedConfig = abi.decode(_config, (StandardBridgeConfig));
+
+        // Ensure the StandardBridge is a valid (non-zero) address.
+        if (decodedConfig.standardBridge == IStandardBridge(payable(address(0)))) {
+            revert("StandardBridge can't be zero address");
+        }
+
+        // Ensure the recipient address is valid (non-zero).
+        if (decodedConfig.recipient == address(0)) {
+            revert("Recipient can't be zero address");
+        }
+
+        // Ensure the input account address is valid (non-zero).
+        if (decodedConfig.inputAccount == BaseAccount(payable(address(0)))) {
+            revert("Input account can't be zero address");
+        }
+
+        // For ERC20 transfers, ensure remote token is specified
+        if (decodedConfig.token != address(0) && decodedConfig.remoteToken == address(0)) {
+            revert("Remote token must be specified for ERC20 transfers");
+        }
+
+        return decodedConfig;
+    }
+
+    /**
+     * @dev Updates the StandardBridgeTransfer configuration.
+     * Only the contract owner is authorized to call this function.
+     * @param _config New encoded configuration parameters.
+     */
+    function updateConfig(bytes memory _config) public override onlyOwner {
+        // Validate and update the configuration.
+        config = validateConfig(_config);
+    }
+
+    /**
+     * @dev Executes the token or ETH transfer using the appropriate StandardBridge functions.
+     * Works for both L1->L2 and L2->L1.
+     */
+    function transfer() external onlyProcessor {
+        // Retrieve the current configuration into a local variable.
+        StandardBridgeConfig memory _config = config;
+
+        // Check if we're transferring ETH or ERC20
+        bool isETH = _config.token == address(0);
+
+        // Get the current balance
+        uint256 balance;
+        if (isETH) {
+            balance = address(_config.inputAccount).balance;
+        } else {
+            balance = IERC20(_config.token).balanceOf(address(_config.inputAccount));
+        }
+
+        // Check balance
+        if (balance == 0) {
+            revert("No balance to transfer");
+        } else if (_config.amount > 0 && balance < _config.amount) {
+            revert("Insufficient balance");
+        }
+
+        // Determine the amount to transfer
+        uint256 _amount = _config.amount > 0 ? _config.amount : balance;
+
+        if (isETH) {
+            // ETH transfer using bridgeETHTo
+            bytes memory bridgeETHCall =
+                abi.encodeCall(IStandardBridge.bridgeETHTo, (_config.recipient, _config.minGasLimit, _config.extraData));
+
+            // Execute the ETH bridge call
+            _config.inputAccount.execute(address(_config.standardBridge), _amount, bridgeETHCall);
+        } else {
+            // ERC20 transfer
+            // First approve the bridge to spend tokens
+            bytes memory approveCall = abi.encodeCall(IERC20.approve, (address(_config.standardBridge), _amount));
+
+            // Then bridge the tokens using bridgeERC20To
+            bytes memory bridgeERC20Call = abi.encodeCall(
+                IStandardBridge.bridgeERC20To,
+                (_config.token, _config.remoteToken, _config.recipient, _amount, _config.minGasLimit, _config.extraData)
+            );
+
+            // Execute the approval and bridge calls
+            _config.inputAccount.execute(_config.token, 0, approveCall);
+            _config.inputAccount.execute(address(_config.standardBridge), 0, bridgeERC20Call);
+        }
+    }
+}

--- a/solidity/src/libraries/StandardBridgeTransfer.sol
+++ b/solidity/src/libraries/StandardBridgeTransfer.sol
@@ -20,7 +20,7 @@ contract StandardBridgeTransfer is Library {
      * @param recipient The recipient address on the destination chain.
      * @param standardBridge The StandardBridge contract address (L1 or L2 version).
      * @param token The ERC20 token address to transfer (or address(0) for ETH).
-     * @param remoteToken Address of the corresponding token on the destination chain (for ERC20).
+     * @param remoteToken Address of the corresponding token on the destination chain (only used for ERC20 transfers). Must be zero address for ETH transfers.
      * @param minGasLimit Gas to use to complete the transfer on the receiving side. Used for sequencers/relayers.
      * @param extraData Additional data to be forwarded with the transaction.
      */
@@ -73,6 +73,11 @@ contract StandardBridgeTransfer is Library {
         // For ERC20 transfers, ensure remote token is specified
         if (decodedConfig.token != address(0) && decodedConfig.remoteToken == address(0)) {
             revert("Remote token must be specified for ERC20 transfers");
+        }
+
+        // For ETH transfers, ensure remote token is not specified
+        if (decodedConfig.token == address(0) && decodedConfig.remoteToken != address(0)) {
+            revert("Remote token must not be specified for ETH transfers");
         }
 
         return decodedConfig;

--- a/solidity/src/libraries/StandardBridgeTransfer.sol
+++ b/solidity/src/libraries/StandardBridgeTransfer.sol
@@ -21,10 +21,10 @@ contract StandardBridgeTransfer is Library {
      * @param standardBridge The StandardBridge contract address (L1 or L2 version).
      * @param token The ERC20 token address to transfer (or address(0) for ETH).
      * @param remoteToken Address of the corresponding token on the destination chain (for ERC20).
-     * @param minGasLimit Gas limit for the transaction execution on the destination chain.
+     * @param minGasLimit Gas to use to complete the transfer on the receiving side. Used for sequencers/relayers.
      * @param extraData Additional data to be forwarded with the transaction.
      */
-    struct StandardBridgeConfig {
+    struct StandardBridgeTransferConfig {
         uint256 amount;
         BaseAccount inputAccount;
         address recipient;
@@ -36,7 +36,7 @@ contract StandardBridgeTransfer is Library {
     }
 
     // Holds the current configuration for StandardBridge transfers
-    StandardBridgeConfig public config;
+    StandardBridgeTransferConfig public config;
 
     /**
      * @dev Constructor initializes the contract with the owner, processor, and initial configuration.
@@ -49,11 +49,11 @@ contract StandardBridgeTransfer is Library {
     /**
      * @dev Validates configuration by decoding the provided bytes and ensuring no critical addresses are zero.
      * @param _config Raw configuration bytes.
-     * @return Decoded and validated StandardBridgeConfig struct.
+     * @return Decoded and validated StandardBridgeTransferConfig struct.
      */
-    function validateConfig(bytes memory _config) internal pure returns (StandardBridgeConfig memory) {
-        // Decode the configuration bytes into the StandardBridgeConfig struct.
-        StandardBridgeConfig memory decodedConfig = abi.decode(_config, (StandardBridgeConfig));
+    function validateConfig(bytes memory _config) internal pure returns (StandardBridgeTransferConfig memory) {
+        // Decode the configuration bytes into the StandardBridgeTransferConfig struct.
+        StandardBridgeTransferConfig memory decodedConfig = abi.decode(_config, (StandardBridgeTransferConfig));
 
         // Ensure the StandardBridge is a valid (non-zero) address.
         if (decodedConfig.standardBridge == IStandardBridge(payable(address(0)))) {
@@ -94,7 +94,7 @@ contract StandardBridgeTransfer is Library {
      */
     function transfer() external onlyProcessor {
         // Retrieve the current configuration into a local variable.
-        StandardBridgeConfig memory _config = config;
+        StandardBridgeTransferConfig memory _config = config;
 
         // Check if we're transferring ETH or ERC20
         bool isETH = _config.token == address(0);

--- a/solidity/src/libraries/interfaces/standard-bridge/IStandardBridge.sol
+++ b/solidity/src/libraries/interfaces/standard-bridge/IStandardBridge.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+/**
+ * @title IStandardBridge
+ * @notice Minimal interface for the StandardBridge contracts with only the methods
+ *         needed for the StandardBridgeTransfer contract.
+ */
+interface IStandardBridge {
+    /// @notice Sends ETH to a receiver's address on the other chain. Note that if ETH is sent to a
+    ///         smart contract and the call fails, the ETH will be temporarily locked in the
+    ///         StandardBridge on the other chain until the call is replayed. If the call cannot be
+    ///         replayed with any amount of gas (call always reverts), then the ETH will be
+    ///         permanently locked in the StandardBridge on the other chain. ETH will also
+    ///         be locked if the receiver is the other bridge, because finalizeBridgeETH will revert
+    ///         in that case.
+    /// @param _to          Address of the receiver.
+    /// @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+    /// @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+    ///                     not be triggered with this data, but it will be emitted and can be used
+    ///                     to identify the transaction.
+    function bridgeETHTo(address _to, uint32 _minGasLimit, bytes calldata _extraData) external payable;
+
+    /// @notice Sends ERC20 tokens to a receiver's address on the other chain.
+    /// @param _localToken  Address of the ERC20 on this chain.
+    /// @param _remoteToken Address of the corresponding token on the remote chain.
+    /// @param _to          Address of the receiver.
+    /// @param _amount      Amount of local tokens to deposit.
+    /// @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+    /// @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+    ///                     not be triggered with this data, but it will be emitted and can be used
+    ///                     to identify the transaction.
+    function bridgeERC20To(
+        address _localToken,
+        address _remoteToken,
+        address _to,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) external;
+}

--- a/solidity/test/libraries/StandardBridgeTransfer.t.sol
+++ b/solidity/test/libraries/StandardBridgeTransfer.t.sol
@@ -36,7 +36,8 @@ contract StandardBridgeTransferTest is Test {
         mockStandardBridge = IStandardBridge(address(bridge));
 
         // Create a valid configuration for ERC20 transfer
-        StandardBridgeTransfer.StandardBridgeConfig memory validConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory validConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -54,7 +55,8 @@ contract StandardBridgeTransferTest is Test {
     }
 
     function testUpdateConfigFailsZeroStandardBridge() public {
-        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory invalidConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -71,7 +73,8 @@ contract StandardBridgeTransferTest is Test {
     }
 
     function testUpdateConfigFailsZeroRecipient() public {
-        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory invalidConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: address(0), // Zero address (invalid)
@@ -88,7 +91,8 @@ contract StandardBridgeTransferTest is Test {
     }
 
     function testUpdateConfigFailsZeroInputAccount() public {
-        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory invalidConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: BaseAccount(payable(address(0))), // Zero address (invalid)
             recipient: recipient,
@@ -105,7 +109,8 @@ contract StandardBridgeTransferTest is Test {
     }
 
     function testUpdateConfigFailsZeroRemoteTokenForERC20() public {
-        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory invalidConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -122,7 +127,8 @@ contract StandardBridgeTransferTest is Test {
     }
 
     function testUpdateConfigSucceedsWithZeroRemoteTokenForETH() public {
-        StandardBridgeTransfer.StandardBridgeConfig memory validConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory validConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -144,7 +150,8 @@ contract StandardBridgeTransferTest is Test {
 
     function testTransferFailsNoETHBalance() public {
         // Update config to use ETH instead of ERC20
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -166,7 +173,8 @@ contract StandardBridgeTransferTest is Test {
 
     function testTransferFailsInsufficientETHBalance() public {
         // Update config to use ETH instead of ERC20
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -205,7 +213,8 @@ contract StandardBridgeTransferTest is Test {
 
     function testTransferSucceedsWithSufficientETHBalance() public {
         // Update config to use ETH instead of ERC20
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 1000,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -237,7 +246,8 @@ contract StandardBridgeTransferTest is Test {
 
     function testTransferSucceedsWithFullETHAmount() public {
         // Update config to use ETH with amount=0 (transfer full balance)
-        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 0, // Transfer full balance
             inputAccount: inputAccount,
             recipient: recipient,
@@ -261,7 +271,8 @@ contract StandardBridgeTransferTest is Test {
 
     function testTransferSucceedsWithFullERC20Amount() public {
         // Update config to transfer full token balance
-        StandardBridgeTransfer.StandardBridgeConfig memory fullConfig = StandardBridgeTransfer.StandardBridgeConfig({
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory fullConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
             amount: 0, // Transfer full balance
             inputAccount: inputAccount,
             recipient: recipient,

--- a/solidity/test/libraries/StandardBridgeTransfer.t.sol
+++ b/solidity/test/libraries/StandardBridgeTransfer.t.sol
@@ -126,6 +126,24 @@ contract StandardBridgeTransferTest is Test {
         standardBridgeTransfer.updateConfig(configBytes);
     }
 
+    function testUpdateConfigFailsRemoteTokenForETH() public {
+        StandardBridgeTransfer.StandardBridgeTransferConfig memory invalidConfig = StandardBridgeTransfer
+            .StandardBridgeTransferConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(0), // ETH transfer
+            remoteToken: address(remoteToken), // Non-zero remote token (invalid for ETH)
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(invalidConfig);
+        vm.prank(owner);
+        vm.expectRevert("Remote token must not be specified for ETH transfers");
+        standardBridgeTransfer.updateConfig(configBytes);
+    }
+
     function testUpdateConfigSucceedsWithZeroRemoteTokenForETH() public {
         StandardBridgeTransfer.StandardBridgeTransferConfig memory validConfig = StandardBridgeTransfer
             .StandardBridgeTransferConfig({

--- a/solidity/test/libraries/StandardBridgeTransfer.t.sol
+++ b/solidity/test/libraries/StandardBridgeTransfer.t.sol
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/src/Test.sol";
+import {StandardBridgeTransfer} from "../../src/libraries/StandardBridgeTransfer.sol";
+import {IStandardBridge} from "../../src/libraries/interfaces/standard-bridge/IStandardBridge.sol";
+import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
+import {MockERC20} from "../mocks/MockERC20.sol";
+
+/**
+ * @title StandardBridgeTransfer Test
+ * @dev Test suite for StandardBridgeTransfer contract functionality
+ */
+contract StandardBridgeTransferTest is Test {
+    StandardBridgeTransfer public standardBridgeTransfer;
+    BaseAccount inputAccount;
+    MockERC20 token;
+    MockERC20 remoteToken;
+
+    address owner = address(1);
+    address processor = address(2);
+    address recipient = address(3);
+    address bridge = address(4);
+    IStandardBridge mockStandardBridge;
+    uint32 minGasLimit = 200000;
+
+    /**
+     * @dev Setup test environment
+     * Deploys token, input account, a mock standard bridge and a StandardBridgeTransfer contract with initial config
+     */
+    function setUp() public {
+        vm.startPrank(owner);
+        inputAccount = new BaseAccount(owner, new address[](0));
+        token = new MockERC20("TEST", "TEST");
+        remoteToken = new MockERC20("REMOTE", "REMOTE");
+        mockStandardBridge = IStandardBridge(address(bridge));
+
+        // Create a valid configuration for ERC20 transfer
+        StandardBridgeTransfer.StandardBridgeConfig memory validConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(token),
+            remoteToken: address(remoteToken),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(validConfig);
+        standardBridgeTransfer = new StandardBridgeTransfer(owner, processor, configBytes);
+        inputAccount.approveLibrary(address(standardBridgeTransfer));
+
+        vm.stopPrank();
+    }
+
+    function testUpdateConfigFailsZeroStandardBridge() public {
+        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: IStandardBridge(payable(address(0))), // Zero address (invalid)
+            token: address(token),
+            remoteToken: address(remoteToken),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(invalidConfig);
+        vm.prank(owner);
+        vm.expectRevert("StandardBridge can't be zero address");
+        standardBridgeTransfer.updateConfig(configBytes);
+    }
+
+    function testUpdateConfigFailsZeroRecipient() public {
+        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: address(0), // Zero address (invalid)
+            standardBridge: mockStandardBridge,
+            token: address(token),
+            remoteToken: address(remoteToken),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(invalidConfig);
+        vm.prank(owner);
+        vm.expectRevert("Recipient can't be zero address");
+        standardBridgeTransfer.updateConfig(configBytes);
+    }
+
+    function testUpdateConfigFailsZeroInputAccount() public {
+        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: BaseAccount(payable(address(0))), // Zero address (invalid)
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(token),
+            remoteToken: address(remoteToken),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(invalidConfig);
+        vm.prank(owner);
+        vm.expectRevert("Input account can't be zero address");
+        standardBridgeTransfer.updateConfig(configBytes);
+    }
+
+    function testUpdateConfigFailsZeroRemoteTokenForERC20() public {
+        StandardBridgeTransfer.StandardBridgeConfig memory invalidConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(token), // Non-zero token
+            remoteToken: address(0), // Zero remote token (invalid for ERC20)
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(invalidConfig);
+        vm.prank(owner);
+        vm.expectRevert("Remote token must be specified for ERC20 transfers");
+        standardBridgeTransfer.updateConfig(configBytes);
+    }
+
+    function testUpdateConfigSucceedsWithZeroRemoteTokenForETH() public {
+        StandardBridgeTransfer.StandardBridgeConfig memory validConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(0), // ETH transfer
+            remoteToken: address(0), // Zero remote token (valid for ETH)
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(validConfig);
+        vm.prank(owner);
+        standardBridgeTransfer.updateConfig(configBytes);
+
+        // Verify config was updated successfully
+        (,,,, address newToken, address newRemoteToken,,) = standardBridgeTransfer.config();
+        assertEq(newToken, address(0), "Token should be ETH");
+        assertEq(newRemoteToken, address(0), "Remote token should be ETH");
+    }
+
+    function testTransferFailsNoETHBalance() public {
+        // Update config to use ETH instead of ERC20
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(0), // ETH transfer
+            remoteToken: address(0),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(ethConfig);
+        vm.prank(owner);
+        standardBridgeTransfer.updateConfig(configBytes);
+
+        // No ETH balance provided
+        vm.prank(processor);
+        vm.expectRevert("No balance to transfer");
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferFailsInsufficientETHBalance() public {
+        // Update config to use ETH instead of ERC20
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(0), // ETH transfer
+            remoteToken: address(0),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(ethConfig);
+        vm.prank(owner);
+        standardBridgeTransfer.updateConfig(configBytes);
+
+        // Fund the account with less than the required amount
+        vm.deal(address(inputAccount), 500);
+
+        vm.prank(processor);
+        vm.expectRevert("Insufficient balance");
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferFailsNoERC20Balance() public {
+        // No tokens provided
+        vm.prank(processor);
+        vm.expectRevert("No balance to transfer");
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferFailsInsufficientERC20Balance() public {
+        // Mint less than the required amount of tokens
+        token.mint(address(inputAccount), 500);
+        vm.prank(processor);
+        vm.expectRevert("Insufficient balance");
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferSucceedsWithSufficientETHBalance() public {
+        // Update config to use ETH instead of ERC20
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 1000,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(0), // ETH transfer
+            remoteToken: address(0),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(ethConfig);
+        vm.prank(owner);
+        standardBridgeTransfer.updateConfig(configBytes);
+
+        // Fund the account with sufficient ETH
+        vm.deal(address(inputAccount), 1500);
+
+        vm.prank(processor);
+        // This call should succeed because the balance is sufficient
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferSucceedsWithSufficientERC20Balance() public {
+        // Mint more than the required amount of tokens
+        token.mint(address(inputAccount), 1500);
+        vm.prank(processor);
+        // This call should succeed because the balance is sufficient
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferSucceedsWithFullETHAmount() public {
+        // Update config to use ETH with amount=0 (transfer full balance)
+        StandardBridgeTransfer.StandardBridgeConfig memory ethConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 0, // Transfer full balance
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(0), // ETH transfer
+            remoteToken: address(0),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(ethConfig);
+        vm.prank(owner);
+        standardBridgeTransfer.updateConfig(configBytes);
+
+        // Fund the account with some ETH
+        vm.deal(address(inputAccount), 500);
+
+        vm.prank(processor);
+        // This call should succeed and transfer the full balance
+        standardBridgeTransfer.transfer();
+    }
+
+    function testTransferSucceedsWithFullERC20Amount() public {
+        // Update config to transfer full token balance
+        StandardBridgeTransfer.StandardBridgeConfig memory fullConfig = StandardBridgeTransfer.StandardBridgeConfig({
+            amount: 0, // Transfer full balance
+            inputAccount: inputAccount,
+            recipient: recipient,
+            standardBridge: mockStandardBridge,
+            token: address(token),
+            remoteToken: address(remoteToken),
+            minGasLimit: minGasLimit,
+            extraData: bytes("")
+        });
+        bytes memory configBytes = abi.encode(fullConfig);
+        vm.prank(owner);
+        standardBridgeTransfer.updateConfig(configBytes);
+
+        // Mint some tokens to the input account
+        token.mint(address(inputAccount), 500);
+
+        vm.prank(processor);
+        // This call should succeed and transfer the full balance
+        standardBridgeTransfer.transfer();
+    }
+}


### PR DESCRIPTION
Adds the StandardBridgeTransfer library which leverages the Standard Bridge (https://docs.optimism.io/app-developers/bridging/standard-bridge) to perform transfer between EVM L1s and L2s (and viceversa).

Includes: library with unit tests for validations and e2e tests for protocol interaction (a test between OP and Ethereum to test the L2->L1 interaction and a test between Base and Ethereum to test the L2->L1 interaction).

This library works for both L1StandardBridge and L2StandardBridge due to how this bridge is designed (it inherits from a StandardBridge contract) that is indirectly called by L1StandardBridge and L2StandardBridge functions, therefore we can interact with StandardBridge directly to support bridging in both directions.

Added @uditvira and @hxrts for the doc section review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Standard Bridge Transfer capability for secure cross-chain transfers, supporting both native ETH and ERC20 tokens.
	- Added enhanced encoding and configuration for seamless asset bridging across Layer 1 and Layer 2 networks.
	- Provided Solidity scripts to demonstrate and test transfers between L1 and L2 networks using the Standard Bridge.
  
- **Documentation**
	- Updated documentation to include comprehensive guidance on the Standard Bridge Transfer process, its configuration, and usage scenarios.
  
- **Tests**
	- Expanded test coverage to ensure correct address parsing and robust transfer functionality under various conditions.
	- Added tests to validate the behavior of the `StandardBridgeTransfer` contract, including error handling and successful transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->