### PR TITLE
fix: improve stability of local-interchain test setup and update instructions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/strangelove-ventures/interchaintest && cd interchai
 Run one of the set-up configs we have in the `e2e/chains` folder. For example, to run the `neutron_juno.json` config, run the following command:
 
 ```bash
-./scripts/start-local-ic.sh start neutron_juno --api-port 42069
+./scripts/start-local-ic.sh neutron_juno
 ```
 
 This will start a local environment (with automatic retry mechanism as sometimes local-ic starts the http server and then crashes) with a Gaia chain, a Neutron (using ICS) chain and a Juno chain. The `--api-port` will expose the API on port 42069, we are using this port in our local-ic-utils crate so let's use the same to reuse some of the utils there.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,13 +10,13 @@ git clone https://github.com/strangelove-ventures/interchaintest && cd interchai
 
 ## Running your local environment
 
-Run one of the set-up configs we have in the `e2e/chains` folder. For example, to run the `neutron_juno.json` config, run the following command inside the `e2e` folder:
+Run one of the set-up configs we have in the `e2e/chains` folder. For example, to run the `neutron_juno.json` config, run the following command:
 
 ```bash
-local-ic start neutron_juno --api-port 42069
+./scripts/start-local-ic.sh start neutron_juno --api-port 42069
 ```
 
-This will start a local environment with a Gaia chain, a Neutron (using ICS) chain and a Juno chain. The `--api-port` will expose the API on port 42069, we are using this port in our local-ic-utils crate so let's use the same to reuse some of the utils there.
+This will start a local environment (with automatic retry mechanism as sometimes local-ic starts the http server and then crashes) with a Gaia chain, a Neutron (using ICS) chain and a Juno chain. The `--api-port` will expose the API on port 42069, we are using this port in our local-ic-utils crate so let's use the same to reuse some of the utils there.
 
 For tests that involve EVM chains, the chains and relayer are started from the test itself so no need to start them manually.
 

--- a/e2e/chains/juno_osmosis.json
+++ b/e2e/chains/juno_osmosis.json
@@ -25,7 +25,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/e2e/chains/neutron.json
+++ b/e2e/chains/neutron.json
@@ -22,7 +22,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/e2e/chains/neutron_juno.json
+++ b/e2e/chains/neutron_juno.json
@@ -23,7 +23,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/e2e/chains/neutron_noble.json
+++ b/e2e/chains/neutron_noble.json
@@ -23,7 +23,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/e2e/chains/neutron_noble_osmosis.json
+++ b/e2e/chains/neutron_noble_osmosis.json
@@ -23,7 +23,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/e2e/chains/neutron_osmosis.json
+++ b/e2e/chains/neutron_osmosis.json
@@ -25,7 +25,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/e2e/chains/neutron_persistence.json
+++ b/e2e/chains/neutron_persistence.json
@@ -22,7 +22,7 @@
         "modify": [
           {
             "key": "app_state.gov.params.voting_period",
-            "value": "3s"
+            "value": "7s"
           },
           {
             "key": "app_state.interchainaccounts.host_genesis_state.params.allow_messages",

--- a/scripts/start-local-ic.sh
+++ b/scripts/start-local-ic.sh
@@ -6,8 +6,22 @@ MAX_ATTEMPTS=10
 ATTEMPT=1
 SUCCESS=false
 
+# Determine the path to the local-ic binary
+LOCAL_IC_BIN=${LOCAL_IC_BIN:-}
+
+if [[ -z "$LOCAL_IC_BIN" ]]; then
+  if command -v local-ic &>/dev/null; then
+    LOCAL_IC_BIN=$(command -v local-ic)
+  elif [[ -x "/tmp/local-ic" ]]; then
+    LOCAL_IC_BIN="/tmp/local-ic"
+  else
+    echo "Error: local-ic binary not found in PATH or /tmp. Please set LOCAL_IC_BIN environment variable."
+    exit 1
+  fi
+fi
+
 while [[ "$SUCCESS" = false && "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]]; do
-  /tmp/local-ic start $CHAIN_CONFIG --api-port 42069 &
+  "$LOCAL_IC_BIN" start $CHAIN_CONFIG --api-port 42069 &
   curl --head -X GET --retry 200 --retry-connrefused --retry-delay 5 http://localhost:42069
   echo "$(date): Successfully queried Local-IC"
   sleep 20


### PR DESCRIPTION
## Issues
I was trying to run e2e tests locally and faced two issues that I think might be faced by others. 

1. Although I own a high-end windows machine, the `local-ic` command was consistently failing during initialization of chains. Upon investigation, I found that it was because during initialization the transaction to vote on the proposal to add a chain on cosmos is being sent after 5-6s while the voting period in the chains config is set at 3s.
2. Sometimes local-ic starts normally but crashes immediately after starting the web server.

## Remedies:
1. Increased the `voting-period` to 7s
2. I found that a auto-retry script is being used in CI to overcome this challenge so I adjusted the script a bit and updated the setup instructions in README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for running the local environment, including details about automatic retries for server startup and revised command usage.
- **Chores**
  - Improved local environment startup script to dynamically locate the required binary, enhancing compatibility across different setups.
- **Refactor**
  - Extended governance voting period from 3 to 7 seconds across multiple chain configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->