### PR TITLE
fix: uncap e2e testing noble mint allowance

### DIFF
--- a/e2e/examples/eth_vault/strategist/example_strategy.toml
+++ b/e2e/examples/eth_vault/strategist/example_strategy.toml
@@ -1,43 +1,43 @@
 [noble]
 grpc_url = "http://0.0.0.0"
-grpc_port = "63423"
+grpc_port = "34665"
 chain_id = "localnoble-1"
 mnemonic = "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
 
 [neutron]
 grpc_url = "http://0.0.0.0"
-grpc_port = "63446"
+grpc_port = "41311"
 chain_id = "localneutron-1"
 mnemonic = "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry"
-target_pool = "neutron1qpn4xne54qpqg24shfk257crv7tzah2majqt6qq0ld4kltqmgpnq0tme2d"
+target_pool = "neutron1evdm5w4xcpwlhhe4fu5s6fwq7w44yxnrpy49ygcly730cen3lewq60uj2f"
 
 [neutron.denoms]
-lp_token = "factory/neutron1qpn4xne54qpqg24shfk257crv7tzah2majqt6qq0ld4kltqmgpnq0tme2d/astroport/share"
-usdc = "ibc/65D0BEC6DAD96C7F5043D1E54E54B6BB5D5B3AEC3FF6CEBB75B9E059F3580EA3"
+lp_token = "factory/neutron1evdm5w4xcpwlhhe4fu5s6fwq7w44yxnrpy49ygcly730cen3lewq60uj2f/astroport/share"
+usdc = "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5"
 ntrn = "untrn"
 
 [neutron.accounts]
-deposit = "neutron1s9l6t29sdprhcgygk2v0xs4kqhdjdn92c2yvauevvrmmkae0wntsyvy258"
-position = "neutron15735euhd9gtma4a4exdeketlrlxyn77k4c4a5qxgh6e9gd4ae8rs6p3vna"
-withdraw = "neutron1f2jt3f9gzajp5uupeq6xm20h90uzy6l8klvrx52ujaznc8xu8d7s3sl594"
-liquidation = "neutron1cxp485wg6lnahcw4736fna9msma7lw8lhswk94pgm7jr9gh3wraqu294k9"
+deposit = "neutron1lxf8agg0wd2m7n2ultl0yx337jw23puh0mlkkw5vhtnkkfettwfqpjdpy3"
+position = "neutron1qh7l57m2m25rwyglkcphyxjyeugdngw8k8fte7w63vm6r4z2xshsvv77n8"
+withdraw = "neutron1jeq9vpdtyh2jj3neekrzuy34jv66nxg2dvd4zx4djsetdndjzzgqkhwkm4"
+liquidation = "neutron10yd4gap0rl0q9qh5kk0zjche747rhahj3jmffvpu9287tllnyg2sdgcqtd"
 
 [neutron.accounts.noble_inbound_ica]
-library_account = "neutron1carz46ge4gpuk24ztmda7qezyhusqtppqv04h59g30f9v0tgqmnq9d6zrv"
-remote_addr = "noble1alqcufttprjmvzymmwxzqnkd05tatxdzakgczerwhh2asm509q7qvffha6"
+library_account = "neutron1wlz6jav59lghr0eemwc602zugunhu3xvgfr956zw2f87gkyc77nsq9apd2"
+remote_addr = "noble1uh26y6la46vprumttqkjl7nxyxv0sq7h6qmg7wm20gmcqn3h6ruq3xw996"
 
 [neutron.accounts.noble_outbound_ica]
-library_account = "neutron1uhf7jjfuv35hfzapy77z7q03lm3yvfajppqy4a4wuakvpnssl4fqj7gx7w"
-remote_addr = "noble1qa0thlm9ns539cv7rg35q6gu29c74wnk9en2u0tz7ttq4ewex0vq9p6ru6"
+library_account = "neutron1uf3rceau3aaefy3dxn6vfkr0k3wtxvd0va9h33famv0tmhwu5cqsczee5u"
+remote_addr = "noble1gd6yvgwkfy2hcarsqaw59m7reygwpfepe89k3vujfrqpkgzsuqcqu7lk0p"
 
 [neutron.libraries]
-neutron_ibc_transfer = "neutron14glhkhx5f7q352mley9n3jlw3fv2wzqxayk968u7jdh92w5pequs6jggsm"
-noble_inbound_transfer = "neutron1gds6svs9wcjftwyf36pr2r6sjrngxv0a3nzsy7cvzxxxr72vqxusk7jdpc"
-noble_cctp_transfer = "neutron1e3qjfcg9adrauz6jg030ptfy35r6zzplsgaavnn6xrh6686udhfq5vjq8p"
-astroport_lper = "neutron10vuejnk4kchkle2fyvdcsfrkmjau8zu8l6wlahjfrzfse6wd85tslukt8d"
+neutron_ibc_transfer = "neutron1scn7d0rhd98y4wz9nwvjky2z29hmelwmn86f6atht8vs4n9spjxq6r8f2n"
+noble_inbound_transfer = "neutron1yd948kdqeptd67r6dws2mnrwlyzrn3xvxhrfs9yzqpclux5xmaqsy4tv4u"
+noble_cctp_transfer = "neutron1wfvctd4ps6dyxrp8fk0hcv5uz64htzysm64rtt4h0j8y7p7n6assuupr29"
+astroport_lper = "neutron122ryl7pez7yjprtvjckltu2uvjxrq3kqt4nvclax2la7maj6757quaafpc"
 astroport_lwer = "neutron1clm0v8znyk9a0s3efupxaekqf6ynenhjg8965sm6dg77gs8ryqkssrhnxr"
-liquidation_forwarder = "neutron1730cx75d8uevqvrkcwxpy9trhqqfksu5u9xwqss0qe4tn7x0tt3s4hqqlq"
-authorizations = "neutron1379vh5qg0c46uyfzrcgz3rf3uytgala2l9cc0x534k8rfhz4ppxq5d020t"
+liquidation_forwarder = "neutron1knr4vkc82x5akw2m4fle22wprcs0jc8s6yxyz0rk7tzlzu7l8cqqcqqxu9"
+authorizations = "neutron1p8vdrpttvnz9k03tc0dy03vwkacl639dk86ehlk9kt65992q24dqdwd8xj"
 processor = "neutron1q85vku3dtjlttk9307v8s8k0crkqsjwtgjzkh2ywdfacazxc2axsf29dek"
 
 [ethereum]

--- a/e2e/examples/eth_vault/vault.rs
+++ b/e2e/examples/eth_vault/vault.rs
@@ -229,7 +229,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let user_1_deposit_amount = U256::from(5_000_000);
     let user_2_deposit_amount = U256::from(1_000_000);
-    let user_3_deposit_amount = U256::from(3_000_000);
+    let user_3_deposit_amount = U256::from(25_000_000);
 
     let mut eth_users = EthereumUsers::new(usdc_token_address, vault_address);
     eth_users.add_user(&rt, &eth_client, eth_accounts[2]);

--- a/e2e/hyperlane/config/config.json
+++ b/e2e/hyperlane/config/config.json
@@ -58,10 +58,10 @@
           "http": "http://localneutron-1-val-0-neutronic:9090"
         }
       ],
-      "interchainGasPaymaster": "0x4f06756658264ea0033db9e2c52e6d5ab6afc48fc64816d8d9a3c7f7ca473189",
+      "interchainGasPaymaster": "0x37ebabaa0f05ed397842238387d20cb47e21484c7616730d55c00661e6f9dd48",
       "isTestnet": false,
-      "mailbox": "0xe28f093bbaac0fbd10c826a3b216a52efb837804c74210cb5b2f937d9b5bdc26",
-      "merkleTreeHook": "0x3e2c31e5291164edd9c7af4d064f193240bf2028c5a16b3c847b04ed96fc0588",
+      "mailbox": "0x4c663d71c75a7fddd902c5ee3cbbf051cae1a5b234fdad9f17cd56c7c5146ad1",
+      "merkleTreeHook": "0xbefa31148c316b9316b0108045cb2ef066cb6f1b8ed6a37b509cffeb83a68740",
       "name": "neutron",
       "nativeToken": {
         "decimals": 6,
@@ -87,7 +87,7 @@
       },
       "slip44": 118,
       "technicalStack": "other",
-      "validatorAnnounce": "0x22e3ac757d57c8470e616552bca47842dcdc2e32a4f6d9cecaf1f441f21e92e1"
+      "validatorAnnounce": "0xc7ff1e45dc719e064f85fcc9cf576a8c494308e4657d268b449eec6422a89e38"
     }
   },
   "defaultRpcConsensusType": "fallback"

--- a/packages/chain-client-utils/src/noble.rs
+++ b/packages/chain-client-utils/src/noble.rs
@@ -10,7 +10,8 @@ use crate::{
 const CHAIN_PREFIX: &str = "noble";
 const CHAIN_DENOM: &str = "uusdc";
 const CCTP_MODULE_NAME: &str = "cctp";
-const ALLOWANCE: &str = "1000000000000000000000";
+// u128 max as str
+const ALLOWANCE: &str = "340282366920938463463374607431768211455";
 const DUMMY_ADDRESS: &[u8; 32] = &[0x01; 32];
 
 /// client for interacting with the noble chain


### PR DESCRIPTION
# Description

Previously the mint allowance was capped at a specific value. This pr sets it up so that the minting allowance is that of `u128::MAX`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated multiple configuration files with new addresses, denominations, and port values for various accounts and contracts.
	- Increased the deposit amount for the third Ethereum user in the vault setup.
	- Adjusted allowance values for minter configuration to use the maximum possible value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->