### PR TITLE
refactor: replace etch by funding from whale in script tests

### DIFF
--- a/solidity/script/BalancerV2Swap.script.sol
+++ b/solidity/script/BalancerV2Swap.script.sol
@@ -7,7 +7,6 @@ import {BalancerV2Swap} from "../src/libraries/BalancerV2Swap.sol";
 import {BaseAccount} from "../src/accounts/BaseAccount.sol";
 import {IAsset, IBalancerVault} from "../src/libraries/interfaces/balancerV2/IBalancerVault.sol";
 import {IERC20} from "forge-std/src/interfaces/IERC20.sol";
-import {MockERC20} from "../test/mocks/MockERC20.sol";
 
 contract BalancerV2SwapScript is Script {
     // Berachain Balancer addresses
@@ -17,6 +16,9 @@ contract BalancerV2SwapScript is Script {
     address constant HONEY_ADDR = 0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce;
     address constant USDCE_ADDR = 0x549943e04f40284185054145c6E4e9568C1D3241;
     address constant BYUSD_ADDR = 0x688e72142674041f8f6Af4c808a4045cA1D6aC82;
+
+    // Whale addresses
+    address USDCE_WHALE = 0xDc927Bd56CF9DfC2e3779C7E3D6d28dA1C219969;
 
     // Pool IDs
     bytes32 constant HONEY_USDCE_POOL_ID = 0xf961a8f6d8c69e7321e78d254ecafbcc3a637621000000000000000000000001;
@@ -41,13 +43,11 @@ contract BalancerV2SwapScript is Script {
         outputAccount = new BaseAccount(owner, new address[](0));
         vm.stopPrank();
 
-        // Replace the runtime code at USDCE_ADDR with our MockERC20 code so we can mint some USDC to the BaseAccount
-        bytes memory mockCode = type(MockERC20).runtimeCode;
-        vm.etch(USDCE_ADDR, mockCode);
-
-        // Mint some USDC tokens to the BaseAccount
-        MockERC20 usdc = MockERC20(USDCE_ADDR);
-        usdc.mint(address(inputAccount), 1000 * 10 ** 6); // Mint 1000 USDCe
+        // Fund the input account with USDCE
+        vm.startPrank(USDCE_WHALE);
+        uint256 amountToFund = 1000 * 10 ** 6; // 1000 USDCe
+        IERC20(USDCE_ADDR).transfer(address(inputAccount), amountToFund);
+        vm.stopPrank();
 
         // Set up the Balancer swap manager
         vm.startPrank(owner);

--- a/solidity/script/L1StandardBridgeTransfer.script.sol
+++ b/solidity/script/L1StandardBridgeTransfer.script.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {Script} from "forge-std/src/Script.sol";
-import {MockERC20} from "../test/mocks/MockERC20.sol";
+import {IERC20} from "forge-std/src/interfaces/IERC20.sol";
 import {StandardBridgeTransfer} from "../src/libraries/StandardBridgeTransfer.sol";
 import {IStandardBridge} from "../src/libraries/interfaces/standard-bridge/IStandardBridge.sol";
 import {BaseAccount} from "../src/accounts/BaseAccount.sol";
@@ -17,6 +17,9 @@ contract L1BaseBridgeTransferScript is Script {
 
     // Address of the L1StandardBridge for Base
     address constant L1_BASE_BRIDGE = 0x3154Cf16ccdb4C6d922629664174b904d80F2C35;
+
+    // Address of USDC Whale
+    address constant USDC_WHALE = 0x28C6c06298d514Db089934071355E5743bf21d60;
 
     // Example addresses for owner, processor, and recipient
     address owner = address(1);
@@ -39,22 +42,24 @@ contract L1BaseBridgeTransferScript is Script {
         uint256 forkId = vm.createFork("https://eth-mainnet.public.blastapi.io");
         vm.selectFork(forkId);
 
-        // Replace the runtime code at USDC_L1_ADDR with our MockERC20 code so we can mint some USDC
-        bytes memory mockCode = type(MockERC20).runtimeCode;
-        vm.etch(USDC_L1_ADDR, mockCode);
-
         // Start broadcasting transactions
         vm.startPrank(owner);
 
         // Deploy a new BaseAccount contract
         inputAccount = new BaseAccount(owner, new address[](0));
 
-        // Mint some USDC tokens to the BaseAccount
-        MockERC20 usdc = MockERC20(USDC_L1_ADDR);
-        usdc.mint(address(inputAccount), tokenAmount);
+        vm.stopPrank();
+
+        // Fund the input account with USDC
+        vm.startPrank(USDC_WHALE);
+        uint256 amountToFund = 1000 * 10 ** 6; // 1000 USDC
+        IERC20(USDC_L1_ADDR).transfer(address(inputAccount), amountToFund);
+        vm.stopPrank();
 
         // Send some ETH to the BaseAccount
         vm.deal(address(inputAccount), ethAmount * 3);
+
+        vm.startPrank(owner);
 
         // Deploy a new StandardBridgeTransfer contract for native ETH with fixed amount
         StandardBridgeTransfer.StandardBridgeTransferConfig memory ethConfig = StandardBridgeTransfer
@@ -94,7 +99,7 @@ contract L1BaseBridgeTransferScript is Script {
 
         // Get the balance before the transfer of the inputAccount
         uint256 ethBalanceBefore = address(inputAccount).balance;
-        uint256 usdcBalanceBefore = usdc.balanceOf(address(inputAccount));
+        uint256 usdcBalanceBefore = IERC20(USDC_L1_ADDR).balanceOf(address(inputAccount));
 
         console.log("ETH balance before transfer: ", ethBalanceBefore);
         console.log("USDC balance before transfer: ", usdcBalanceBefore);
@@ -109,7 +114,7 @@ contract L1BaseBridgeTransferScript is Script {
 
         // Get the balance after the transfers
         uint256 ethBalanceAfter = address(inputAccount).balance;
-        uint256 usdcBalanceAfter = usdc.balanceOf(address(inputAccount));
+        uint256 usdcBalanceAfter = IERC20(USDC_L1_ADDR).balanceOf(address(inputAccount));
 
         console.log("ETH balance after transfer: ", ethBalanceAfter);
         console.log("USDC balance after transfer: ", usdcBalanceAfter);


### PR DESCRIPTION
Remove the MockERC20 dependency in script e2e tests and instead fund from whale. Since we are changing the Mock to work with all our tests I removed this dependency in our scripts as they might break. Instead I fund from a whale account and use the real runtime code of the tokens.