### PR TITLE
feat: make anvil set up more flexible

### DIFF
--- a/e2e/examples/eth_vault/vault.rs
+++ b/e2e/examples/eth_vault/vault.rs
@@ -33,7 +33,7 @@ use valence_e2e::{
     async_run,
     utils::{
         authorization::set_up_authorization_and_processor,
-        ethereum as ethereum_utils,
+        ethereum::{self as ethereum_utils, ANVIL_NAME, DEFAULT_ANVIL_PORT},
         mock_cctp_relayer::MockCctpRelayer,
         parse::{get_chain_field_from_local_ic_log, get_grpc_address_and_port_from_url},
         solidity_contracts::ValenceVault,
@@ -63,7 +63,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let rt = tokio::runtime::Runtime::new()?;
 
     info!("Initializing ethereum side flow...");
-    async_run!(rt, ethereum_utils::set_up_anvil_container().await)?;
+    async_run!(
+        rt,
+        ethereum_utils::set_up_anvil_container(ANVIL_NAME, DEFAULT_ANVIL_PORT, None).await
+    )?;
 
     let eth = EthClient::new(DEFAULT_ANVIL_RPC_ENDPOINT)?;
 

--- a/e2e/examples/ethereum_integration_tests.rs
+++ b/e2e/examples/ethereum_integration_tests.rs
@@ -34,7 +34,7 @@ use valence_authorization_utils::{
 };
 use valence_e2e::utils::{
     authorization::{set_up_authorization_and_processor, verify_authorization_execution_result},
-    ethereum::set_up_anvil_container,
+    ethereum::{set_up_anvil_container, ANVIL_NAME, DEFAULT_ANVIL_PORT},
     hyperlane::{
         bech32_to_evm_bytes32, set_up_cw_hyperlane_contracts, set_up_eth_hyperlane_contracts,
         set_up_hyperlane,
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Start anvil container
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(set_up_anvil_container())?;
+    rt.block_on(set_up_anvil_container(ANVIL_NAME, DEFAULT_ANVIL_PORT, None))?;
 
     let eth = EthClient::new(DEFAULT_ANVIL_RPC_ENDPOINT)?;
 
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     set_up_hyperlane(
         "hyperlane-net",
-        vec!["localneutron-1-val-0-neutronic", "anvil"],
+        vec!["localneutron-1-val-0-neutronic", ANVIL_NAME],
         "neutron",
         "ethereum",
         &neutron_hyperlane_contracts,

--- a/e2e/examples/forked_anvil.rs
+++ b/e2e/examples/forked_anvil.rs
@@ -1,0 +1,54 @@
+use std::error::Error;
+
+use valence_chain_client_utils::{
+    ethereum::EthereumClient,
+    evm::{base_client::EvmBaseClient, request_provider_client::RequestProviderClient},
+};
+use valence_e2e::utils::ethereum::{set_up_anvil_container, ANVIL_NAME, DEFAULT_ANVIL_PORT};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let fork_url = "https://eth-mainnet.public.blastapi.io";
+    set_up_anvil_container("anvil2", "8546", Some(fork_url))
+        .await
+        .unwrap();
+
+    let client = EthereumClient::new(
+        "http://127.0.0.1:8546",
+        "test test test test test test test test test test test junk",
+    )
+    .unwrap();
+    let accounts = client.get_provider_accounts().await.unwrap();
+
+    let balance = client
+        .query_balance(&accounts[0].to_string())
+        .await
+        .unwrap();
+    println!("Balance: {:?}", balance);
+
+    // Query balance of vitalik account
+    let vitalik_address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    let vitalik_balance = client.query_balance(vitalik_address).await.unwrap();
+    println!("Vitalik Balance: {:?}", vitalik_balance);
+
+    set_up_anvil_container(ANVIL_NAME, DEFAULT_ANVIL_PORT, None)
+        .await
+        .unwrap();
+
+    let second_client = EthereumClient::new(
+        "http://127.0.0.1:8545",
+        "test test test test test test test test test test test junk",
+    )
+    .unwrap();
+
+    let second_accounts = second_client.get_provider_accounts().await.unwrap();
+    let second_balance = second_client
+        .query_balance(&second_accounts[0].to_string())
+        .await
+        .unwrap();
+    println!("Second Client Balance: {:?}", second_balance);
+
+    Ok(())
+}

--- a/e2e/src/utils/ethereum.rs
+++ b/e2e/src/utils/ethereum.rs
@@ -9,8 +9,8 @@ use futures_util::StreamExt;
 use log::{error, info};
 
 const ANVIL_IMAGE_URL: &str = "ghcr.io/foundry-rs/foundry:latest";
-const ANVIL_NAME: &str = "anvil";
-const ANVIL_PORT: &str = "8545";
+pub const ANVIL_NAME: &str = "anvil";
+pub const DEFAULT_ANVIL_PORT: &str = "8545";
 
 /// macro for executing async code in a blocking context
 #[macro_export]
@@ -20,12 +20,16 @@ macro_rules! async_run {
     }
 }
 
-pub async fn set_up_anvil_container() -> Result<(), Box<dyn Error>> {
+pub async fn set_up_anvil_container(
+    container_name: &str,
+    port: &str,
+    fork_url: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
     // Connect to the Docker daemon
     let docker = Docker::connect_with_local_defaults()?;
 
     let mut filters = HashMap::new();
-    filters.insert("name", vec![ANVIL_NAME]);
+    filters.insert("name", vec![container_name]);
     let options = ListContainersOptions {
         all: true,
         filters,
@@ -85,9 +89,15 @@ pub async fn set_up_anvil_container() -> Result<(), Box<dyn Error>> {
 
     let config = Config {
         image: Some(ANVIL_IMAGE_URL),
-        cmd: Some(vec![ANVIL_NAME]),
+        cmd: Some(if let Some(url) = fork_url {
+            vec!["--fork-url", url]
+        } else {
+            vec![]
+        }),
         env: Some(vec!["ANVIL_IP_ADDR=0.0.0.0"]),
+        entrypoint: Some(vec![ANVIL_NAME]),
         exposed_ports: {
+            // Anvil always runs on port 8545 inside the container
             let ports = HashMap::from_iter([("8545/tcp", HashMap::new())]);
             Some(ports)
         },
@@ -95,10 +105,10 @@ pub async fn set_up_anvil_container() -> Result<(), Box<dyn Error>> {
             port_bindings: {
                 let mut port_bindings = HashMap::new();
                 port_bindings.insert(
-                    format!("{ANVIL_PORT}/tcp").to_string(),
+                    "8545/tcp".to_string(),
                     Some(vec![bollard::service::PortBinding {
                         host_ip: Some("0.0.0.0".to_string()),
-                        host_port: Some(ANVIL_PORT.to_string()),
+                        host_port: Some(port.to_string()),
                     }]),
                 );
                 Some(port_bindings)
@@ -110,7 +120,7 @@ pub async fn set_up_anvil_container() -> Result<(), Box<dyn Error>> {
 
     // Create container
     let options = Some(CreateContainerOptions {
-        name: ANVIL_NAME,
+        name: container_name,
         platform: None,
     });
     let container = docker.create_container(options, config).await?;
@@ -123,23 +133,23 @@ pub async fn set_up_anvil_container() -> Result<(), Box<dyn Error>> {
     info!("Anvil container started successfully");
 
     info!("Waiting for Anvil JSON-RPC to be ready...");
-    wait_for_anvil_ready(10).await?;
+    wait_for_anvil_ready(port, 30).await?;
 
     info!("Anvil container ready!");
     Ok(())
 }
 
-async fn wait_for_anvil_ready(timeout_secs: u64) -> Result<(), Box<dyn Error>> {
+async fn wait_for_anvil_ready(port: &str, timeout_secs: u64) -> Result<(), Box<dyn Error>> {
     use std::time::{Duration, Instant};
     use tokio::time::sleep;
 
     let client = alloy::transports::http::reqwest::Client::new();
     let start = Instant::now();
-    let url = "http://localhost:8545";
+    let url = format!("http://localhost:{}", port);
 
     while start.elapsed() < Duration::from_secs(timeout_secs) {
         let poll_rx = client
-            .post(url)
+            .post(&url)
             .timeout(Duration::from_secs(1))
             .body("{}")
             .send()
@@ -154,7 +164,7 @@ async fn wait_for_anvil_ready(timeout_secs: u64) -> Result<(), Box<dyn Error>> {
         sleep(Duration::from_millis(500)).await;
     }
 
-    Err("timed out waiting for Anvil to be ready".into())
+    Err(format!("timed out waiting for Anvil to be ready on port {}", port).into())
 }
 
 pub mod valence_account {


### PR DESCRIPTION
Allows specifying the name, port and fork url to set up anvil.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new example demonstrating interaction with both default and forked Ethereum testnet nodes, including balance queries for specific accounts.

- **Improvements**
  - Enhanced Ethereum testnet container setup to allow specifying container name, port, and optional forking from a public network.
  - Made container name and port constants publicly accessible for easier configuration.
  - Increased readiness wait timeout for Ethereum testnet containers to improve reliability.
  - Updated examples and tests to use predefined constants for container name and port instead of hardcoded values.

- **Bug Fixes**
  - Replaced hardcoded values with constants for container name and port to ensure consistent configuration across examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->