### PR TITLE
fix: allow deploying libraries with different owner than sender

### DIFF
--- a/solidity/src/libraries/AavePositionManager.sol
+++ b/solidity/src/libraries/AavePositionManager.sol
@@ -240,6 +240,14 @@ contract AavePositionManager is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates the AavePositionManager configuration.
      * Only the contract owner is authorized to call this function.
      * @param _config New encoded configuration parameters.

--- a/solidity/src/libraries/BalancerV2Swap.sol
+++ b/solidity/src/libraries/BalancerV2Swap.sol
@@ -66,6 +66,14 @@ contract BalancerV2Swap is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates the BalancerV2Swap configuration.
      * Only the contract owner is authorized to call this function.
      * @param _config New encoded configuration parameters.

--- a/solidity/src/libraries/CCTPTransfer.sol
+++ b/solidity/src/libraries/CCTPTransfer.sol
@@ -70,6 +70,14 @@ contract CCTPTransfer is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates the CCTPTransfer configuration.
      * Only the contract owner is authorized to call this function.
      * @param _config New encoded configuration parameters.

--- a/solidity/src/libraries/Forwarder.sol
+++ b/solidity/src/libraries/Forwarder.sol
@@ -87,6 +87,14 @@ contract Forwarder is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates forwarder configuration
      * @param _config New configuration
      */

--- a/solidity/src/libraries/IBCEurekaTransfer.sol
+++ b/solidity/src/libraries/IBCEurekaTransfer.sol
@@ -77,6 +77,14 @@ contract IBCEurekaTransfer is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates the IBCEurekaTransfer configuration.
      * Only the contract owner is authorized to call this function.
      * @param _config New encoded configuration parameters.

--- a/solidity/src/libraries/Library.sol
+++ b/solidity/src/libraries/Library.sol
@@ -31,8 +31,8 @@ abstract contract Library is Ownable {
     constructor(address _owner, address _processor, bytes memory _config) Ownable(_owner) {
         // Set the processor address
         processor = _processor;
-        // Initialize configuration by calling updateConfig
-        updateConfig(_config);
+        // Initialize configuration using internal initialization (no access control)
+        _initConfig(_config);
     }
 
     /**
@@ -42,6 +42,12 @@ abstract contract Library is Ownable {
     function updateProcessor(address _processor) external onlyOwner {
         processor = _processor;
     }
+
+    /**
+     * @dev Internal function for initialization during construction
+     * @param _config Configuration data to be applied
+     */
+    function _initConfig(bytes memory _config) internal virtual;
 
     /**
      * @dev Updates the library configuration

--- a/solidity/src/libraries/PancakeSwapV3PositionManager.sol
+++ b/solidity/src/libraries/PancakeSwapV3PositionManager.sol
@@ -127,6 +127,14 @@ contract PancakeSwapV3PositionManager is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @notice Updates the contract configuration
      * @param _config New configuration bytes
      * @dev Can only be called by the contract owner

--- a/solidity/src/libraries/StandardBridgeTransfer.sol
+++ b/solidity/src/libraries/StandardBridgeTransfer.sol
@@ -84,6 +84,14 @@ contract StandardBridgeTransfer is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates the StandardBridgeTransfer configuration.
      * Only the contract owner is authorized to call this function.
      * @param _config New encoded configuration parameters.

--- a/solidity/src/libraries/StargateTransfer.sol
+++ b/solidity/src/libraries/StargateTransfer.sol
@@ -83,6 +83,14 @@ contract StargateTransfer is Library {
     }
 
     /**
+     * @dev Internal initialization function called during construction
+     * @param _config New configuration
+     */
+    function _initConfig(bytes memory _config) internal override {
+        config = validateConfig(_config);
+    }
+
+    /**
      * @dev Updates the StargateTransfer configuration.
      * Only the contract owner is authorized to call this function.
      * @param _config New encoded configuration parameters.


### PR DESCRIPTION
currently libraries cant be deployed with a different owner than the sender because it calls updateConfig which has access control. Therefore when we deploy, it sets the owner to the specific address but then when calling update it fails because the sender is not the owner. This fixes it by creating a config initializer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved contract initialization by introducing dedicated internal configuration methods across multiple smart contracts. This enhances the setup process during contract deployment and ensures configuration validation at initialization.
- **Refactor**
  - Centralized and streamlined configuration logic for contract deployment, separating initial setup from public configuration updates for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->