### PR TITLE
feat: add ZK authorizations to CW

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1687,26 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "byteorder"
@@ -3126,6 +3155,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -3502,6 +3532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
 name = "generate_local_ic_config"
 version = "0.2.0"
 dependencies = [
@@ -3737,6 +3773,15 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -4946,6 +4991,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -5570,6 +5618,118 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecc3edc6fb8186268e05031c26a8b2b1e567957d63adcae1026d55d6bb189b"
+dependencies = [
+ "num-bigint",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eece7b035978976138622b116fefe6c4cc372b1ce70739c40e7a351a9bb68f1f"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f0edf3fde4fd0d1455e901fc871c558010ae18db6e68f1b0fa111391855316"
+dependencies = [
+ "itertools 0.12.1",
+ "num-bigint",
+ "num-traits",
+ "p3-util",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60961b4d7ffd2e8412ce4e66e213de610356df71cc4e396519c856a664138a27"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbe762738c382c9483410f52348ab9de41bb42c391e8171643a71486cf1ef8f"
+
+[[package]]
+name = "p3-mds"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4127956cc6c783b7d021c5c42d5d89456d5f3bda4a7b165fcc2a3fd4e78fbede"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be09497da406a98e89dc05c1ce539eeef29541bad61a5b2108a44ffe94dd0b4c"
+dependencies = [
+ "gcd",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7d954033f657d48490344ca4b3dbcc054962a0e92831b736666bb2f5e5820b"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.2.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6ce0b6bee23fd54e05306f6752ae80b0b71a91166553ab39d7899801497237"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7167,6 +7327,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-lib"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
+dependencies = [
+ "bincode",
+ "elliptic-curve",
+ "serde",
+ "sp1-primitives",
+]
+
+[[package]]
+name = "sp1-primitives"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc282347d405f23fc8a7cfe93c82e772920bf2e0722cf828eaea69ed530e49"
+dependencies = [
+ "bincode",
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "num-bigint",
+ "p3-baby-bear",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "sp1-verifier"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb25158884b67ee1fc6af7e4e79951aa9906e20e78980b881ea9b31550453ea"
+dependencies = [
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "sha2 0.10.8",
+ "substrate-bn-succinct",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "speedate"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7264,6 +7471,23 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "substrate-bn-succinct"
+version = "0.6.0-v4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ac8ce0a40e721f790e2ef99beab32b99b3121c58edaaa140ffd8f1795a6af7"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint",
+ "rand 0.8.5",
+ "rustc-hex",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -8469,6 +8693,7 @@ dependencies = [
  "valence-processor",
  "valence-processor-utils",
  "valence-test-library",
+ "valence-verification-gateway",
 ]
 
 [[package]]
@@ -8482,6 +8707,7 @@ dependencies = [
  "serde_json",
  "valence-gmp-utils",
  "valence-library-utils",
+ "valence-verification-gateway",
 ]
 
 [[package]]
@@ -9334,6 +9560,17 @@ dependencies = [
  "cw-storage-plus 2.0.0",
  "thiserror 1.0.69",
  "valence-processor-utils",
+]
+
+[[package]]
+name = "valence-verification-gateway"
+version = "0.2.0"
+dependencies = [
+ "cosmwasm-schema 2.2.1",
+ "cosmwasm-std 2.2.1",
+ "cw2 2.0.0",
+ "sp1-verifier",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,21 @@
 [workspace]
 members = [
-    "contracts/accounts/*",
-    "contracts/libraries/*",
-    "contracts/encoders/*",
-    "contracts/authorization",
-    "contracts/processor",
-    "contracts/testing/*",
-    "contracts/program-registry",
-    "contracts/middleware/type-registries/osmosis/osmo-26-0-0",
-    "contracts/middleware/broker",
-    "contracts/middleware/asserter",
-    "packages/*",
-    "program-manager",
-    "e2e",
-    "examples/*",
-    "deployment/scripts/*",
+  "contracts/accounts/*",
+  "contracts/libraries/*",
+  "contracts/encoders/*",
+  "contracts/authorization",
+  "contracts/processor",
+  "contracts/testing/*",
+  "contracts/program-registry",
+  "contracts/verification-gateway",
+  "contracts/middleware/type-registries/osmosis/osmo-26-0-0",
+  "contracts/middleware/broker",
+  "contracts/middleware/asserter",
+  "packages/*",
+  "program-manager",
+  "e2e",
+  "examples/*",
+  "deployment/scripts/*",
 ]
 resolver = "2"
 
@@ -91,7 +92,7 @@ valence-ica-ibc-transfer             = { path = "contracts/libraries/ica-ibc-tra
 
 # middleware
 valence-middleware-osmosis = { path = "contracts/middleware/type-registries/osmosis/osmo-26-0-0", features = [
-    "library",
+  "library",
 ] }
 valence-middleware-broker = { path = "contracts/middleware/broker", features = ["library"] }
 valence-middleware-asserter = { path = "contracts/middleware/asserter", features = ["library"] }
@@ -111,6 +112,7 @@ valence-library-utils          = { path = "packages/library-utils" }
 valence-program-registry-utils = { path = "packages/program-registry-utils" }
 valence-program-manager        = { path = "program-manager" }
 valence-program-registry       = { path = "contracts/program-registry", features = ["library"] }
+valence-verification-gateway   = { path = "contracts/verification-gateway", features = ["library"] }
 valence-middleware-utils       = { path = "packages/middleware-utils" }
 valence-chain-client-utils     = { path = "packages/chain-client-utils" }
 valence-liquid-staking-utils   = { path = "packages/liquid-staking-utils" }

--- a/contracts/authorization/Cargo.toml
+++ b/contracts/authorization/Cargo.toml
@@ -12,21 +12,22 @@ crate-type = ["cdylib", "rlib"]
 library = []
 
 [dependencies]
-cosmwasm-std                = { workspace = true }
-cw-storage-plus             = { workspace = true }
-cosmwasm-schema             = { workspace = true }
-thiserror                   = { workspace = true }
-cw2                         = { workspace = true }
-cw-ownable                  = { workspace = true }
-valence-authorization-utils = { workspace = true }
-valence-processor-utils     = { workspace = true }
-valence-gmp-utils           = { workspace = true }
-valence-encoder-broker      = { workspace = true }
-valence-encoder-utils       = { workspace = true }
-cw-utils                    = { workspace = true }
-serde_json                  = { workspace = true }
-neutron-sdk                 = { workspace = true }
-cosmos-sdk-proto            = { workspace = true }
+cosmwasm-std                 = { workspace = true }
+cw-storage-plus              = { workspace = true }
+cosmwasm-schema              = { workspace = true }
+thiserror                    = { workspace = true }
+cw2                          = { workspace = true }
+cw-ownable                   = { workspace = true }
+valence-authorization-utils  = { workspace = true }
+valence-processor-utils      = { workspace = true }
+valence-gmp-utils            = { workspace = true }
+valence-encoder-broker       = { workspace = true }
+valence-encoder-utils        = { workspace = true }
+valence-verification-gateway = { workspace = true }
+cw-utils                     = { workspace = true }
+serde_json                   = { workspace = true }
+neutron-sdk                  = { workspace = true }
+cosmos-sdk-proto             = { workspace = true }
 
 [dev-dependencies]
 neutron-test-tube     = { workspace = true }

--- a/contracts/authorization/schema/valence-authorization.json
+++ b/contracts/authorization/schema/valence-authorization.json
@@ -1304,6 +1304,30 @@
           {
             "type": "object",
             "required": [
+              "create_zk_authorizations"
+            ],
+            "properties": {
+              "create_zk_authorizations": {
+                "type": "object",
+                "required": [
+                  "zk_authorizations"
+                ],
+                "properties": {
+                  "zk_authorizations": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/ZkAuthorizationInfo"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
               "modify_authorization"
             ],
             "properties": {
@@ -1352,6 +1376,41 @@
                       {
                         "type": "null"
                       }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "modify_zk_authorization"
+            ],
+            "properties": {
+              "modify_zk_authorization": {
+                "type": "object",
+                "required": [
+                  "label"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "max_concurrent_executions": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "validate_last_block_execution": {
+                    "type": [
+                      "boolean",
+                      "null"
                     ]
                   }
                 },
@@ -1540,6 +1599,27 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "set_verification_gateway"
+            ],
+            "properties": {
+              "set_verification_gateway": {
+                "type": "object",
+                "required": [
+                  "verification_gateway"
+                ],
+                "properties": {
+                  "verification_gateway": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -1620,6 +1700,35 @@
                 "properties": {
                   "domain_name": {
                     "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "execute_zk_authorization"
+            ],
+            "properties": {
+              "execute_zk_authorization": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "message",
+                  "proof"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "proof": {
+                    "$ref": "#/definitions/Binary"
                   }
                 },
                 "additionalProperties": false
@@ -1941,6 +2050,64 @@
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
+      },
+      "VerifyingKey": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "s_p1_verifying_key_hash"
+            ],
+            "properties": {
+              "s_p1_verifying_key_hash": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ZkAuthorizationInfo": {
+        "type": "object",
+        "required": [
+          "domain",
+          "label",
+          "mode",
+          "registry",
+          "validate_last_block_execution",
+          "vk"
+        ],
+        "properties": {
+          "domain": {
+            "$ref": "#/definitions/Domain"
+          },
+          "label": {
+            "type": "string"
+          },
+          "max_concurrent_executions": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "mode": {
+            "$ref": "#/definitions/AuthorizationModeInfo"
+          },
+          "registry": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "validate_last_block_execution": {
+            "type": "boolean"
+          },
+          "vk": {
+            "$ref": "#/definitions/VerifyingKey"
+          }
+        },
+        "additionalProperties": false
       }
     }
   },
@@ -2048,6 +2215,48 @@
                 ]
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "zk_authorizations"
+        ],
+        "properties": {
+          "zk_authorizations": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "verification_gateway"
+        ],
+        "properties": {
+          "verification_gateway": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -4093,6 +4302,185 @@
         "Addr": {
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
+        }
+      }
+    },
+    "verification_gateway": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "zk_authorizations": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_ZkAuthorization",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ZkAuthorization"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "AuthorizationMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "permissionless"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "permissioned"
+              ],
+              "properties": {
+                "permissioned": {
+                  "$ref": "#/definitions/PermissionType"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "AuthorizationState": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
+        },
+        "Domain": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "main"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "external"
+              ],
+              "properties": {
+                "external": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "PermissionType": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "with_call_limit"
+              ],
+              "properties": {
+                "with_call_limit": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "$ref": "#/definitions/Addr"
+                      },
+                      {
+                        "$ref": "#/definitions/Uint128"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "without_call_limit"
+              ],
+              "properties": {
+                "without_call_limit": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Addr"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "VerifyingKey": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "s_p1_verifying_key_hash"
+              ],
+              "properties": {
+                "s_p1_verifying_key_hash": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ZkAuthorization": {
+          "type": "object",
+          "required": [
+            "domain",
+            "label",
+            "max_concurrent_executions",
+            "mode",
+            "registry",
+            "state",
+            "validate_last_block_execution",
+            "vk"
+          ],
+          "properties": {
+            "domain": {
+              "$ref": "#/definitions/Domain"
+            },
+            "label": {
+              "type": "string"
+            },
+            "max_concurrent_executions": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "mode": {
+              "$ref": "#/definitions/AuthorizationMode"
+            },
+            "registry": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "state": {
+              "$ref": "#/definitions/AuthorizationState"
+            },
+            "validate_last_block_execution": {
+              "type": "boolean"
+            },
+            "vk": {
+              "$ref": "#/definitions/VerifyingKey"
+            }
+          },
+          "additionalProperties": false
         }
       }
     }

--- a/contracts/authorization/src/authorization.rs
+++ b/contracts/authorization/src/authorization.rs
@@ -366,6 +366,7 @@ impl Validate for Authorization {
                         }
                     }
                 }
+                ProcessorMessage::CosmWasmZKMsg { .. } => unreachable!(),
             }
         }
         Ok(())
@@ -382,13 +383,7 @@ impl Validate for Authorization {
         self.ensure_enabled()?;
         self.ensure_active(block)?;
         self.ensure_not_expired(block)?;
-        validate_permission(
-            &self.label,
-            &self.mode,
-            querier,
-            contract_address,
-            info,
-        )?;
+        validate_permission(&self.label, &self.mode, querier, contract_address, info)?;
         self.validate_messages(messages)?;
 
         Ok(())

--- a/contracts/authorization/src/authorization.rs
+++ b/contracts/authorization/src/authorization.rs
@@ -366,7 +366,6 @@ impl Validate for Authorization {
                         }
                     }
                 }
-                ProcessorMessage::CosmWasmZKMsg { .. } => unreachable!(),
             }
         }
         Ok(())

--- a/contracts/authorization/src/authorization.rs
+++ b/contracts/authorization/src/authorization.rs
@@ -46,12 +46,6 @@ pub trait Validate {
     fn ensure_enabled(&self) -> Result<(), ContractError>;
     fn ensure_active(&self, block: &BlockInfo) -> Result<(), ContractError>;
     fn ensure_not_expired(&self, block: &BlockInfo) -> Result<(), ContractError>;
-    fn validate_permission(
-        &self,
-        querier: QuerierWrapper,
-        contract_address: &str,
-        info: &MessageInfo,
-    ) -> Result<(), ContractError>;
     fn validate_messages(&self, messages: &[ProcessorMessage]) -> Result<(), ContractError>;
     fn validate_messages_generic<T: Function>(
         messages: &[ProcessorMessage],
@@ -296,41 +290,6 @@ impl Validate for Authorization {
         Ok(())
     }
 
-    fn validate_permission(
-        &self,
-        querier: QuerierWrapper,
-        contract_address: &str,
-        info: &MessageInfo,
-    ) -> Result<(), ContractError> {
-        let token_factory_denom = build_tokenfactory_denom(contract_address, &self.label);
-        match self.mode {
-            // If the authorization is permissionless, it's always valid
-            AuthorizationMode::Permissionless => (),
-            // If the authorization is permissioned without call limit, we check that the sender has the token corresponding to that authorization in his wallet
-            AuthorizationMode::Permissioned(PermissionType::WithoutCallLimit(_)) => {
-                let balance = querier.query_balance(info.sender.clone(), token_factory_denom)?;
-                if balance.amount.is_zero() {
-                    return Err(ContractError::Unauthorized(
-                        UnauthorizedReason::NotAllowed {},
-                    ));
-                }
-            }
-            // If the authorization is permissioned with call limit, the sender must pay one token to execute the authorization, which will be burned
-            // if it executes (or partially executes) and will be refunded if it doesn't.
-            AuthorizationMode::Permissioned(PermissionType::WithCallLimit(_)) => {
-                let funds = must_pay(info, &token_factory_denom)
-                    .map_err(|_| ContractError::Unauthorized(UnauthorizedReason::NotAllowed {}))?;
-
-                if funds.ne(&Uint128::one()) {
-                    return Err(ContractError::Unauthorized(
-                        UnauthorizedReason::RequiresOneToken {},
-                    ));
-                }
-            }
-        }
-        Ok(())
-    }
-
     fn validate_messages(&self, messages: &[ProcessorMessage]) -> Result<(), ContractError> {
         match &self.subroutine {
             Subroutine::Atomic(config) => {
@@ -423,7 +382,13 @@ impl Validate for Authorization {
         self.ensure_enabled()?;
         self.ensure_active(block)?;
         self.ensure_not_expired(block)?;
-        self.validate_permission(querier, contract_address, info)?;
+        validate_permission(
+            &self.label,
+            &self.mode,
+            querier,
+            contract_address,
+            info,
+        )?;
         self.validate_messages(messages)?;
 
         Ok(())
@@ -502,6 +467,42 @@ fn check_bytes_restriction(
         }
         // We should never get here because we validate authorizations to not have these restrictions for raw bytes messages
         _ => return Err(ContractError::Message(MessageErrorReason::InvalidType {})),
+    }
+    Ok(())
+}
+
+pub fn validate_permission(
+    label: &str,
+    authorization_mode: &AuthorizationMode,
+    querier: QuerierWrapper,
+    contract_address: &str,
+    info: &MessageInfo,
+) -> Result<(), ContractError> {
+    let token_factory_denom = build_tokenfactory_denom(contract_address, label);
+    match authorization_mode {
+        // If the authorization is permissionless, it's always valid
+        AuthorizationMode::Permissionless => (),
+        // If the authorization is permissioned without call limit, we check that the sender has the token corresponding to that authorization in his wallet
+        AuthorizationMode::Permissioned(PermissionType::WithoutCallLimit(_)) => {
+            let balance = querier.query_balance(info.sender.clone(), token_factory_denom)?;
+            if balance.amount.is_zero() {
+                return Err(ContractError::Unauthorized(
+                    UnauthorizedReason::NotAllowed {},
+                ));
+            }
+        }
+        // If the authorization is permissioned with call limit, the sender must pay one token to execute the authorization, which will be burned
+        // if it executes (or partially executes) and will be refunded if it doesn't.
+        AuthorizationMode::Permissioned(PermissionType::WithCallLimit(_)) => {
+            let funds = must_pay(info, &token_factory_denom)
+                .map_err(|_| ContractError::Unauthorized(UnauthorizedReason::NotAllowed {}))?;
+
+            if funds.ne(&Uint128::one()) {
+                return Err(ContractError::Unauthorized(
+                    UnauthorizedReason::RequiresOneToken {},
+                ));
+            }
+        }
     }
     Ok(())
 }

--- a/contracts/authorization/src/contract.rs
+++ b/contracts/authorization/src/contract.rs
@@ -996,11 +996,16 @@ fn execute_zk_authorization(
             let current_executions = CURRENT_EXECUTIONS
                 .load(deps.storage, label.clone())
                 .unwrap_or_default();
-            if current_executions >= zk_authorization.max_concurrent_executions {
-                return Err(ContractError::Authorization(
-                    AuthorizationErrorReason::MaxConcurrentExecutionsReached {},
-                ));
+
+            // Only check max concurrent executions for EnqueueMsgs
+            if let AuthorizationMsg::EnqueueMsgs { .. } = zk_message.message {
+                if current_executions >= zk_authorization.max_concurrent_executions {
+                    return Err(ContractError::Authorization(
+                        AuthorizationErrorReason::MaxConcurrentExecutionsReached {},
+                    ));
+                }
             }
+
             CURRENT_EXECUTIONS.save(
                 deps.storage,
                 label.clone(),

--- a/contracts/authorization/src/error.rs
+++ b/contracts/authorization/src/error.rs
@@ -149,4 +149,7 @@ pub enum ZKErrorReason {
 
     #[error("Proof no longer valid")]
     ProofNoLongerValid {},
+
+    #[error("Invalid domain, execution environment should be CosmWasm")]
+    InvalidDomain {},
 }

--- a/contracts/authorization/src/error.rs
+++ b/contracts/authorization/src/error.rs
@@ -24,6 +24,9 @@ pub enum ContractError {
     #[error("Message error: {0}")]
     Message(#[from] MessageErrorReason),
 
+    #[error("Authorization error: {0}")]
+    ZK(#[from] ZKErrorReason),
+
     #[error("External domain already exists")]
     ExternalDomainAlreadyExists(String),
 
@@ -131,4 +134,13 @@ pub enum MessageErrorReason {
 
     #[error("Messages are not retriable")]
     NotRetriable {},
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ZKErrorReason {
+    #[error("Verification gateway not set")]
+    VerificationGatewayNotSet {},
+
+    #[error("Invalid ZK Proof")]
+    InvalidZKProof {},
 }

--- a/contracts/authorization/src/error.rs
+++ b/contracts/authorization/src/error.rs
@@ -143,4 +143,10 @@ pub enum ZKErrorReason {
 
     #[error("Invalid ZK Proof")]
     InvalidZKProof {},
+
+    #[error("Invalid ZK registry of the message for this authorization execution")]
+    InvalidZKRegistry {},
+
+    #[error("Proof no longer valid")]
+    ProofNoLongerValid {},
 }

--- a/contracts/authorization/src/state.rs
+++ b/contracts/authorization/src/state.rs
@@ -1,16 +1,20 @@
 use cosmwasm_std::{Addr, Empty};
 use cw_storage_plus::{Item, Map};
 use valence_authorization_utils::{
-    authorization::Authorization, callback::ProcessorCallbackInfo, domain::ExternalDomain,
+    authorization::Authorization, callback::ProcessorCallbackInfo, domain::ExternalDomain, zk_authorization::ZkAuthorization,
 };
 
 pub const FIRST_OWNERSHIP: Item<bool> = Item::new("first_ownership");
 pub const SUB_OWNERS: Map<Addr, Empty> = Map::new("sub_owners");
 pub const AUTHORIZATIONS: Map<String, Authorization> = Map::new("authorizations");
+pub const VERIFICATION_GATEWAY: Item<Addr> = Item::new("verification_gateway");
+pub const ZK_AUTHORIZATIONS: Map<String, ZkAuthorization> = Map::new("zk_authorizations");
 pub const PROCESSOR_ON_MAIN_DOMAIN: Item<Addr> = Item::new("processor_on_main_domain");
 pub const EXTERNAL_DOMAINS: Map<String, ExternalDomain> = Map::new("external_domains");
 pub const EXECUTION_ID: Item<u64> = Item::new("execution_id");
 // To track how many of each authorization are pending completion
 pub const CURRENT_EXECUTIONS: Map<String, u64> = Map::new("current_executions");
+// To track the last block execution for a specific registry of a ZK program
+pub const REGISTRY_LAST_BLOCK_EXECUTION: Map<u64, u64> = Map::new("registry_last_block_execution");
 // Track all the callbacks for the processor, if they haven't been processed yet they will be in ExecutionResult::InProcess
 pub const PROCESSOR_CALLBACKS: Map<u64, ProcessorCallbackInfo> = Map::new("processor_callbacks");

--- a/contracts/authorization/src/state.rs
+++ b/contracts/authorization/src/state.rs
@@ -1,7 +1,8 @@
 use cosmwasm_std::{Addr, Empty};
 use cw_storage_plus::{Item, Map};
 use valence_authorization_utils::{
-    authorization::Authorization, callback::ProcessorCallbackInfo, domain::ExternalDomain, zk_authorization::ZkAuthorization,
+    authorization::Authorization, callback::ProcessorCallbackInfo, domain::ExternalDomain,
+    zk_authorization::ZkAuthorization,
 };
 
 pub const FIRST_OWNERSHIP: Item<bool> = Item::new("first_ownership");

--- a/contracts/processor/src/contract.rs
+++ b/contracts/processor/src/contract.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 
 use cw_storage_plus::Bound;
 use valence_authorization_utils::{
-    authorization::{Priority, Subroutine},
+    authorization::{AuthorizationMsg, Priority, Subroutine},
     callback::ExecutionResult,
     domain::PolytoneProxyState,
     msg::ProcessorMessage,
@@ -18,10 +18,7 @@ use valence_processor_utils::{
     callback::{
         PendingCallback, PendingPolytoneCallbackInfo, PolytoneCallbackMsg, PolytoneCallbackState,
     },
-    msg::{
-        AuthorizationMsg, ExecuteMsg, InstantiateMsg, InternalProcessorMsg, PermissionlessMsg,
-        QueryMsg,
-    },
+    msg::{ExecuteMsg, InstantiateMsg, InternalProcessorMsg, PermissionlessMsg, QueryMsg},
     processor::{Config, MessageBatch, Polytone, ProcessorDomain, State},
 };
 

--- a/contracts/verification-gateway/.cargo/config.toml
+++ b/contracts/verification-gateway/.cargo/config.toml
@@ -1,0 +1,3 @@
+[alias]
+wasm   = "build --release --lib --target wasm32-unknown-unknown"
+schema = "run --bin schema"

--- a/contracts/verification-gateway/Cargo.toml
+++ b/contracts/verification-gateway/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name    = "valence-verification-gateway"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-schema             = { workspace = true }
+cosmwasm-std                = { workspace = true }
+cw2                         = { workspace = true }
+thiserror                   = { workspace = true }
+sp1-verifier                = "4.2.0"

--- a/contracts/verification-gateway/README.md
+++ b/contracts/verification-gateway/README.md
@@ -1,0 +1,3 @@
+# Verification Gateway
+
+This contract is a simple contract that will perform the verification of ZK proofs. It's separated into a singleton contract to decouple the verification to the rest of the contracts and therefore can be extended with different verifying methods for different types of proofs.

--- a/contracts/verification-gateway/schema/valence-verification-gateway.json
+++ b/contracts/verification-gateway/schema/valence-verification-gateway.json
@@ -1,0 +1,83 @@
+{
+  "contract_name": "valence-verification-gateway",
+  "contract_version": "0.2.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "type": "string",
+    "enum": []
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "verify_proof"
+        ],
+        "properties": {
+          "verify_proof": {
+            "type": "object",
+            "required": [
+              "inputs",
+              "proof",
+              "vk"
+            ],
+            "properties": {
+              "inputs": {
+                "$ref": "#/definitions/Binary"
+              },
+              "proof": {
+                "$ref": "#/definitions/Binary"
+              },
+              "vk": {
+                "$ref": "#/definitions/VerifyingKey"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "VerifyingKey": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "s_p1_verifying_key_hash"
+            ],
+            "properties": {
+              "s_p1_verifying_key_hash": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "verify_proof": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/verification-gateway/src/bin/schema.rs
+++ b/contracts/verification-gateway/src/bin/schema.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::write_api;
+use valence_verification_gateway::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/contracts/verification-gateway/src/contract.rs
+++ b/contracts/verification-gateway/src/contract.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
 use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use sp1_verifier::{Groth16Verifier, GROTH16_VK_BYTES};
 

--- a/contracts/verification-gateway/src/contract.rs
+++ b/contracts/verification-gateway/src/contract.rs
@@ -1,0 +1,61 @@
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use sp1_verifier::{Groth16Verifier, GROTH16_VK_BYTES};
+
+use crate::{
+    error::ContractError,
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    VerifyingKey,
+};
+
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new().add_attribute("action", "instantiate_verification_gateway"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: ExecuteMsg,
+) -> StdResult<Response> {
+    unimplemented!("This contract does not handle any execute messages, only queries")
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::VerifyProof { vk, proof, inputs } => {
+            to_json_binary(&verify_proof(&vk, proof, inputs)?)
+        }
+    }
+}
+
+fn verify_proof(vk: &VerifyingKey, proof: Binary, inputs: Binary) -> StdResult<bool> {
+    match vk {
+        VerifyingKey::SP1VerifyingKeyHash(sp1_vkey_hash) => Groth16Verifier::verify(
+            proof.as_slice(),
+            inputs.as_slice(),
+            sp1_vkey_hash,
+            &GROTH16_VK_BYTES,
+        )
+        .map_err(|e| {
+            cosmwasm_std::StdError::generic_err(format!(
+                "Failed to verify SP1 proof with vk hash {}: {}",
+                sp1_vkey_hash, e
+            ))
+        })?,
+    }
+
+    Ok(true)
+}

--- a/contracts/verification-gateway/src/error.rs
+++ b/contracts/verification-gateway/src/error.rs
@@ -1,0 +1,8 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+}

--- a/contracts/verification-gateway/src/lib.rs
+++ b/contracts/verification-gateway/src/lib.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::cw_serde;
+
+pub mod contract;
+pub mod error;
+pub mod msg;
+
+#[cw_serde]
+pub enum VerifyingKey {
+    SP1VerifyingKeyHash(String),
+}

--- a/contracts/verification-gateway/src/msg.rs
+++ b/contracts/verification-gateway/src/msg.rs
@@ -1,0 +1,21 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Binary;
+
+use crate::VerifyingKey;
+
+#[cw_serde]
+pub struct InstantiateMsg {}
+
+#[cw_serde]
+pub enum ExecuteMsg {}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(bool)]
+    VerifyProof {
+        vk: VerifyingKey,
+        proof: Binary,
+        inputs: Binary,
+    },
+}

--- a/packages/authorization-utils/Cargo.toml
+++ b/packages/authorization-utils/Cargo.toml
@@ -6,10 +6,11 @@ authors     = { workspace = true }
 description = "Helpers for authorization contract"
 
 [dependencies]
-cosmwasm-std          = { workspace = true }
-cw-utils              = { workspace = true }
-cosmwasm-schema       = { workspace = true }
-cw-ownable            = { workspace = true }
-valence-gmp-utils     = { workspace = true }
-valence-library-utils = { workspace = true }
-serde_json            = { workspace = true }
+cosmwasm-std                 = { workspace = true }
+cw-utils                     = { workspace = true }
+cosmwasm-schema              = { workspace = true }
+cw-ownable                   = { workspace = true }
+valence-gmp-utils            = { workspace = true }
+valence-library-utils        = { workspace = true }
+valence-verification-gateway = { workspace = true }
+serde_json                   = { workspace = true }

--- a/packages/authorization-utils/src/authorization.rs
+++ b/packages/authorization-utils/src/authorization.rs
@@ -2,7 +2,10 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api, BlockInfo, Uint128};
 use cw_utils::Expiration;
 
-use crate::{function::{AtomicFunction, Function, NonAtomicFunction, RetryLogic}, msg::ProcessorMessage};
+use crate::{
+    function::{AtomicFunction, Function, NonAtomicFunction, RetryLogic},
+    msg::ProcessorMessage,
+};
 
 #[cw_serde]
 // What an owner or subowner can pass to the contract to create an authorization

--- a/packages/authorization-utils/src/authorization.rs
+++ b/packages/authorization-utils/src/authorization.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api, BlockInfo, Uint128};
 use cw_utils::Expiration;
 
-use crate::function::{AtomicFunction, Function, NonAtomicFunction, RetryLogic};
+use crate::{function::{AtomicFunction, Function, NonAtomicFunction, RetryLogic}, msg::ProcessorMessage};
 
 #[cw_serde]
 // What an owner or subowner can pass to the contract to create an authorization
@@ -180,4 +180,30 @@ pub enum Priority {
 pub enum AuthorizationState {
     Enabled,
     Disabled,
+}
+
+#[cw_serde]
+pub enum AuthorizationMsg {
+    EnqueueMsgs {
+        // Used for the callback or to remove the messages
+        id: u64,
+        msgs: Vec<ProcessorMessage>,
+        subroutine: Subroutine,
+        priority: Priority,
+        expiration_time: Option<u64>,
+    },
+    EvictMsgs {
+        queue_position: u64,
+        priority: Priority,
+    },
+    InsertMsgs {
+        queue_position: u64,
+        id: u64,
+        msgs: Vec<ProcessorMessage>,
+        subroutine: Subroutine,
+        priority: Priority,
+        expiration_time: Option<u64>,
+    },
+    Pause {},
+    Resume {},
 }

--- a/packages/authorization-utils/src/lib.rs
+++ b/packages/authorization-utils/src/lib.rs
@@ -5,3 +5,4 @@ pub mod callback;
 pub mod domain;
 pub mod function;
 pub mod msg;
+pub mod zk_authorization;

--- a/packages/authorization-utils/src/msg.rs
+++ b/packages/authorization-utils/src/msg.rs
@@ -14,6 +14,7 @@ use crate::{
         CosmwasmBridge, Domain, Encoder, EvmBridge, ExecutionEnvironment, ExternalDomain,
         HyperlaneConnector, PolytoneConnectors, PolytoneNote, PolytoneProxyState,
     },
+    zk_authorization::ZkAuthorization,
 };
 
 #[cw_serde]
@@ -189,6 +190,11 @@ pub enum PermissionedMsg {
         max_concurrent_executions: Option<u64>,
         priority: Option<Priority>,
     },
+    ModifyZkAuthorization {
+        label: String,
+        max_concurrent_executions: Option<u64>,
+        validate_last_block_execution: Option<bool>,
+    },
     DisableAuthorization {
         label: String,
     },
@@ -227,6 +233,10 @@ pub enum PermissionedMsg {
     ResumeProcessor {
         domain: Domain,
     },
+    // Set a verification gateway contract for ZK authorizations
+    SetVerificationGateway {
+        verification_gateway: String,
+    },
 }
 
 #[cw_serde]
@@ -251,6 +261,12 @@ pub enum PermissionlessMsg {
     },
     RetryBridgeCreation {
         domain_name: String,
+    },
+    // Execute ZK authorization
+    ExecuteZkAuthorization {
+        label: String,
+        message: Binary,
+        proof: Binary,
     },
 }
 
@@ -344,6 +360,13 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    #[returns(Vec<ZkAuthorization>)]
+    ZkAuthorizations {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    #[returns(Addr)]
+    VerificationGateway {},
     #[returns(Vec<ProcessorCallbackInfo>)]
     ProcessorCallbacks {
         start_after: Option<u64>,

--- a/packages/authorization-utils/src/msg.rs
+++ b/packages/authorization-utils/src/msg.rs
@@ -285,7 +285,6 @@ pub enum InternalAuthorizationMsg {
 pub enum ProcessorMessage {
     CosmwasmExecuteMsg { msg: Binary },
     CosmwasmMigrateMsg { code_id: u64, msg: Binary },
-    CosmWasmZKMsg { msg: Binary },
     EvmCall { msg: Binary },
     EvmRawCall { msg: Binary },
 }
@@ -311,7 +310,6 @@ impl ProcessorMessage {
         match self {
             ProcessorMessage::CosmwasmExecuteMsg { msg } => msg,
             ProcessorMessage::CosmwasmMigrateMsg { msg, .. } => msg,
-            ProcessorMessage::CosmWasmZKMsg { msg } => msg,
             ProcessorMessage::EvmCall { msg } => msg,
             ProcessorMessage::EvmRawCall { msg } => msg,
         }
@@ -321,7 +319,6 @@ impl ProcessorMessage {
         match self {
             ProcessorMessage::CosmwasmExecuteMsg { msg: msg_ref } => *msg_ref = msg,
             ProcessorMessage::CosmwasmMigrateMsg { msg: msg_ref, .. } => *msg_ref = msg,
-            ProcessorMessage::CosmWasmZKMsg { msg: msg_ref } => *msg_ref = msg,
             ProcessorMessage::EvmCall { msg: msg_ref } => *msg_ref = msg,
             ProcessorMessage::EvmRawCall { msg: msg_ref } => *msg_ref = msg,
         }
@@ -339,9 +336,6 @@ impl ProcessorMessage {
                 new_code_id: *code_id,
                 msg: msg.clone(),
             }),
-            ProcessorMessage::CosmWasmZKMsg { .. } => {
-                Err(StdError::generic_err("Msg type not supported"))
-            }
             ProcessorMessage::EvmCall { .. } | ProcessorMessage::EvmRawCall { .. } => {
                 Err(StdError::generic_err("Msg type not supported"))
             }

--- a/packages/authorization-utils/src/zk_authorization.rs
+++ b/packages/authorization-utils/src/zk_authorization.rs
@@ -21,7 +21,7 @@ pub struct ZkAuthorizationInfo {
     pub domain: Domain,
     // ZK Specific:
     // The registry of the guest program that will be executed
-    pub zk_program_registry: u64,
+    pub registry: u64,
     // The Verifying Key to be used
     pub vk: VerifyingKey,
     // Flag to indicate if we need to validate the last block execution of a specific ZK authorization
@@ -35,7 +35,7 @@ impl ZkAuthorizationInfo {
             mode: self.mode.into_mode_validated(api),
             max_concurrent_executions: self.max_concurrent_executions.unwrap_or(1),
             domain: self.domain,
-            zk_program_registry: self.zk_program_registry,
+            registry: self.registry,
             vk: self.vk,
             validate_last_block_execution: self.validate_last_block_execution,
             state: AuthorizationState::Enabled,
@@ -49,7 +49,7 @@ pub struct ZkAuthorization {
     pub mode: AuthorizationMode,
     pub max_concurrent_executions: u64,
     pub domain: Domain,
-    pub zk_program_registry: u64,
+    pub registry: u64,
     pub vk: VerifyingKey,
     pub validate_last_block_execution: bool,
     pub state: AuthorizationState,

--- a/packages/authorization-utils/src/zk_authorization.rs
+++ b/packages/authorization-utils/src/zk_authorization.rs
@@ -1,0 +1,63 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Api;
+use valence_verification_gateway::VerifyingKey;
+
+use crate::{
+    authorization::{
+        AuthorizationMode, AuthorizationModeInfo, AuthorizationMsg, AuthorizationState,
+    },
+    domain::Domain,
+};
+
+#[cw_serde]
+// What an owner or subowner can pass to the contract to create a ZK authorization
+pub struct ZkAuthorizationInfo {
+    // Unique ID for the authorization, will be used as denom of the TokenFactory token if needed
+    pub label: String,
+    pub mode: AuthorizationModeInfo,
+    // Default will be 1, defines how many times a specific authorization can be executed concurrently
+    pub max_concurrent_executions: Option<u64>,
+    // Domain this needs to be sent to
+    pub domain: Domain,
+    // ZK Specific:
+    // The registry of the guest program that will be executed
+    pub zk_program_registry: u64,
+    // The Verifying Key to be used
+    pub vk: VerifyingKey,
+    // Flag to indicate if we need to validate the last block execution of a specific ZK authorization
+    pub validate_last_block_execution: bool,
+}
+
+impl ZkAuthorizationInfo {
+    pub fn into_zk_authorization(self, api: &dyn Api) -> ZkAuthorization {
+        ZkAuthorization {
+            label: self.label,
+            mode: self.mode.into_mode_validated(api),
+            max_concurrent_executions: self.max_concurrent_executions.unwrap_or(1),
+            domain: self.domain,
+            zk_program_registry: self.zk_program_registry,
+            vk: self.vk,
+            validate_last_block_execution: self.validate_last_block_execution,
+            state: AuthorizationState::Enabled,
+        }
+    }
+}
+
+#[cw_serde]
+pub struct ZkAuthorization {
+    pub label: String,
+    pub mode: AuthorizationMode,
+    pub max_concurrent_executions: u64,
+    pub domain: Domain,
+    pub zk_program_registry: u64,
+    pub vk: VerifyingKey,
+    pub validate_last_block_execution: bool,
+    pub state: AuthorizationState,
+}
+
+#[cw_serde]
+pub struct ZkMessage {
+    pub registry: u64,
+    pub block_number: u64,
+    pub message: AuthorizationMsg,
+}

--- a/packages/processor-utils/src/msg.rs
+++ b/packages/processor-utils/src/msg.rs
@@ -1,9 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Binary;
-use valence_authorization_utils::{
-    authorization::{Priority, Subroutine},
-    msg::ProcessorMessage,
-};
+use valence_authorization_utils::authorization::{AuthorizationMsg, Priority};
 use valence_gmp_utils::polytone::CallbackMessage;
 
 use crate::{
@@ -33,32 +30,6 @@ pub enum ExecuteMsg {
     // Polytone callback listener
     #[serde(rename = "callback")]
     PolytoneCallback(CallbackMessage),
-}
-
-#[cw_serde]
-pub enum AuthorizationMsg {
-    EnqueueMsgs {
-        // Used for the callback or to remove the messages
-        id: u64,
-        msgs: Vec<ProcessorMessage>,
-        subroutine: Subroutine,
-        priority: Priority,
-        expiration_time: Option<u64>,
-    },
-    EvictMsgs {
-        queue_position: u64,
-        priority: Priority,
-    },
-    InsertMsgs {
-        queue_position: u64,
-        id: u64,
-        msgs: Vec<ProcessorMessage>,
-        subroutine: Subroutine,
-        priority: Priority,
-        expiration_time: Option<u64>,
-    },
-    Pause {},
-    Resume {},
 }
 
 #[cw_serde]


### PR DESCRIPTION
Add ZK Authorizations in a similar fashion than the EVM solution.
This allows creating authorizations with a specific VK and Registry.

Once executed, the proof is verified and registry is checked to validate that the the message is correct and was proven by the guest program.

Allows executing any processor message and the creation of the message is now done and validated inside the guest program so the authorization contract doesn't perform any validations except the proof verification.

Adds a verification-gateway contract that does simple proof verifications, decoupling the verification from the authorization contract, which just sets this contract to eventually query it. For now only SP1 4.2.0 verifier is set up to use on this gateway, but can easily be extended to verify proofs generated by other provers.

Kinda hard to test right now without writing a guest program, so next steps will be writing a guest program and generate proofs with the right inputs and verify that the interaction works as expected.