### PR TITLE
chore: bump valence-domain-clients version to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10424,7 +10424,7 @@ dependencies = [
 [[package]]
 name = "valence-domain-clients"
 version = "0.1.0"
-source = "git+https://github.com/timewave-computer/valence-domain-clients.git?tag=v0.1.0#2ea04c386b8bc14beb5a8234b0245011833b55cc"
+source = "git+https://github.com/timewave-computer/valence-domain-clients.git?tag=v0.1.1#fc7ee4a6589732e6fb7e3c16654762f61ca8ce57"
 dependencies = [
  "alloy",
  "alloy-primitives 0.7.7",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -65,7 +65,7 @@ valence-middleware-osmosis           = { workspace = true }
 valence-middleware-utils             = { workspace = true }
 valence-middleware-asserter          = { workspace = true }
 valence-test-icq-lib                 = { workspace = true }
-valence-domain-clients               = { git = "https://github.com/timewave-computer/valence-domain-clients.git", tag = "v0.1.0", features = ["test-utils"] }
+valence-domain-clients               = { git = "https://github.com/timewave-computer/valence-domain-clients.git", tag = "v0.1.1", features = ["test-utils"] }
 valence-ica-cctp-transfer            = { workspace = true }
 valence-ica-ibc-transfer             = { workspace = true }
 tokio                                = { workspace = true }


### PR DESCRIPTION
# Description

bumps the valence domain clients version to v0.1.1 in order to include the `WasmClient` instantiate & code storage helpers