### PR TITLE
fix: check zk authorization is enabled

### DIFF
--- a/contracts/authorization/src/contract.rs
+++ b/contracts/authorization/src/contract.rs
@@ -924,6 +924,12 @@ fn execute_zk_authorization(
             ContractError::Authorization(AuthorizationErrorReason::DoesNotExist(label.clone()))
         })?;
 
+    if zk_authorization.state.ne(&AuthorizationState::Enabled) {
+        return Err(ContractError::Unauthorized(
+            UnauthorizedReason::NotEnabled {},
+        ));
+    }
+
     // Get the verification gateway address
     let verification_gateway = VERIFICATION_GATEWAY
         .load(deps.storage)


### PR DESCRIPTION
Fix a bug where we were not checking if the authorization was enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented execution of zk authorizations that are not enabled, displaying an appropriate error message if attempted.

- **Tests**
  - Enhanced tests to verify that disabled zk authorizations cannot be executed, ensuring correct error handling and improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->