### PR TITLE
chore: update rust cache

### DIFF
--- a/.github/actions/run-local-ic-example/action.yml
+++ b/.github/actions/run-local-ic-example/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Build artefacts
-      uses: Swatinem/rust-cache@v2.7.5
+      uses: Swatinem/rust-cache@v2.7.8
       with:
         cache-on-failure: true
         shared-key: ${{ github.event.pull_request.number || github.ref }}

--- a/.github/actions/run-local-ic-test/action.yml
+++ b/.github/actions/run-local-ic-test/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Build artefacts
-      uses: Swatinem/rust-cache@v2.7.5
+      uses: Swatinem/rust-cache@v2.7.8
       with:
         cache-on-failure: true
         shared-key: ${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Build artifacts
-        uses: Swatinem/rust-cache@v2.7.5
+        uses: Swatinem/rust-cache@v2.7.8
         with:
           cache-on-failure: true
           shared-key: ${{ github.event.pull_request.number || github.ref }}
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Build artifacts
-        uses: Swatinem/rust-cache@v2.7.5
+        uses: Swatinem/rust-cache@v2.7.8
         with:
           cache-on-failure: true
           shared-key: ${{ github.event.pull_request.number || github.ref }}
@@ -147,7 +147,7 @@ jobs:
         uses: "./.github/actions/free-disk-space"
 
       - name: Cache Build artifacts
-        uses: Swatinem/rust-cache@v2.7.5
+        uses: Swatinem/rust-cache@v2.7.8
         with:
           cache-on-failure: true
           shared-key: ${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
We're getting timeouts in our CI because of a deprecated service that was shut down (https://github.com/orgs/community/discussions/160793#discussioncomment-13312469). Updating this in our CI to see if fixes