### PR TITLE
vaults: add additional vk to verify coprocessor

### DIFF
--- a/contracts/authorization/src/contract.rs
+++ b/contracts/authorization/src/contract.rs
@@ -176,7 +176,18 @@ pub fn execute(
                 label,
                 message,
                 proof,
-            } => execute_zk_authorization(deps, env, info, label, message, proof),
+                domain_message,
+                domain_proof,
+            } => execute_zk_authorization(
+                deps,
+                env,
+                info,
+                label,
+                message,
+                proof,
+                domain_message,
+                domain_proof,
+            ),
         },
         ExecuteMsg::InternalAuthorizationAction(internal_authorization_msg) => {
             match internal_authorization_msg {
@@ -910,6 +921,7 @@ fn set_verification_gateway(
         .add_attribute("verification_gateway", verification_gateway))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_zk_authorization(
     deps: DepsMut,
     env: Env,
@@ -917,6 +929,8 @@ fn execute_zk_authorization(
     label: String,
     message: Binary,
     proof: Binary,
+    domain_message: Binary,
+    domain_proof: Binary,
 ) -> Result<Response, ContractError> {
     let zk_authorization = ZK_AUTHORIZATIONS
         .load(deps.storage, label.clone())
@@ -946,7 +960,7 @@ fn execute_zk_authorization(
 
     // Verify the proof with the verification gateway
     let valid: bool = deps.querier.query_wasm_smart(
-        verification_gateway,
+        verification_gateway.clone(),
         &valence_verification_gateway::msg::QueryMsg::VerifyProof {
             vk: zk_authorization.vk,
             proof,
@@ -955,6 +969,28 @@ fn execute_zk_authorization(
     )?;
     if !valid {
         return Err(ContractError::ZK(ZKErrorReason::InvalidZKProof {}));
+    }
+
+    // Verify the domain proof with the verification gateway
+    let valid_domain: bool = deps.querier.query_wasm_smart(
+        verification_gateway,
+        &valence_verification_gateway::msg::QueryMsg::VerifyProof {
+            vk: zk_authorization.domain_vk,
+            proof: domain_proof,
+            inputs: domain_message.clone(),
+        },
+    )?;
+    if !valid_domain {
+        return Err(ContractError::ZK(ZKErrorReason::InvalidZKProof {}));
+    }
+
+    // Compare the first 32 bytes of both messages to ensure the coprocessor root is the same
+    let message_slice = message.as_slice();
+    let domain_message_slice = domain_message.as_slice();
+    let message_coprocessor_root = &message_slice[..32];
+    let domain_message_coprocessor_root = &domain_message_slice[..32];
+    if message_coprocessor_root != domain_message_coprocessor_root {
+        return Err(ContractError::ZK(ZKErrorReason::InvalidCoprocessorRoot {}));
     }
 
     // Now that proof is validated we are going to extract the ZkMessage from the message

--- a/contracts/authorization/src/error.rs
+++ b/contracts/authorization/src/error.rs
@@ -155,4 +155,7 @@ pub enum ZKErrorReason {
 
     #[error("This message is not for this authorization contract!")]
     InvalidAuthorizationContract {},
+
+    #[error("Invalid Coprocessor root")]
+    InvalidCoprocessorRoot {},
 }

--- a/contracts/authorization/src/tests/builders.rs
+++ b/contracts/authorization/src/tests/builders.rs
@@ -12,7 +12,7 @@ impl NeutronTestAppBuilder {
     pub fn new() -> Self {
         NeutronTestAppBuilder {
             fee_denom: FEE_DENOM.to_string(),
-            initial_balance: 100_000_000_000,
+            initial_balance: 100_000_000_000_000,
             num_accounts: 5,
         }
     }

--- a/contracts/authorization/src/tests/user_actions.rs
+++ b/contracts/authorization/src/tests/user_actions.rs
@@ -853,10 +853,6 @@ fn pause_and_resume_processor_using_zk_authorizations() {
     )
     .unwrap();
 
-    println!("vk: {}", Binary::from(sp1_vk.bytes32().into_bytes()));
-    println!("message: {}", Binary::from(proof_pause_inputs.clone()));
-    println!("proof: {}", Binary::from(proof_pause_bytes.clone()));
-
     // Check that the processor is paused
     let processor_config = wasm
         .query::<valence_processor_utils::msg::QueryMsg, valence_processor_utils::processor::Config>(

--- a/contracts/authorization/src/tests/user_actions.rs
+++ b/contracts/authorization/src/tests/user_actions.rs
@@ -803,6 +803,7 @@ fn pause_and_resume_processor_using_zk_authorizations() {
         mode: AuthorizationModeInfo::Permissionless,
         registry: 1,
         vk: Binary::from(sp1_vk.bytes32().into_bytes()),
+        domain_vk: Binary::from(sp1_vk.bytes32().into_bytes()),
         validate_last_block_execution: false,
     };
     let zk_authorization_resume = ZkAuthorizationInfo {
@@ -810,6 +811,7 @@ fn pause_and_resume_processor_using_zk_authorizations() {
         mode: AuthorizationModeInfo::Permissionless,
         registry: 2,
         vk: Binary::from(sp1_vk.bytes32().into_bytes()),
+        domain_vk: Binary::from(sp1_vk.bytes32().into_bytes()),
         validate_last_block_execution: false,
     };
     let zk_authorizations = vec![zk_authorization_pause, zk_authorization_resume];
@@ -843,11 +845,17 @@ fn pause_and_resume_processor_using_zk_authorizations() {
             label: "pause".to_string(),
             message: Binary::from(proof_pause_inputs.clone()),
             proof: Binary::from(proof_pause_bytes.clone()),
+            domain_message: Binary::from(proof_pause_inputs.clone()),
+            domain_proof: Binary::from(proof_pause_bytes.clone()),
         }),
         &[],
         &setup.user_accounts[0],
     )
     .unwrap();
+
+    println!("vk: {}", Binary::from(sp1_vk.bytes32().into_bytes()));
+    println!("message: {}", Binary::from(proof_pause_inputs.clone()));
+    println!("proof: {}", Binary::from(proof_pause_bytes.clone()));
 
     // Check that the processor is paused
     let processor_config = wasm
@@ -867,8 +875,10 @@ fn pause_and_resume_processor_using_zk_authorizations() {
         &authorization,
         &ExecuteMsg::PermissionlessAction(PermissionlessMsg::ExecuteZkAuthorization {
             label: "resume".to_string(),
-            message: Binary::from(proof_resume_inputs),
-            proof: Binary::from(proof_resume_bytes),
+            message: Binary::from(proof_resume_inputs.clone()),
+            proof: Binary::from(proof_resume_bytes.clone()),
+            domain_message: Binary::from(proof_resume_inputs),
+            domain_proof: Binary::from(proof_resume_bytes),
         }),
         &[],
         &setup.user_accounts[0],
@@ -903,8 +913,10 @@ fn pause_and_resume_processor_using_zk_authorizations() {
             &authorization,
             &ExecuteMsg::PermissionlessAction(PermissionlessMsg::ExecuteZkAuthorization {
                 label: "pause".to_string(),
-                message: Binary::from(proof_pause_inputs),
-                proof: Binary::from(proof_pause_bytes),
+                message: Binary::from(proof_pause_inputs.clone()),
+                proof: Binary::from(proof_pause_bytes.clone()),
+                domain_message: Binary::from(proof_pause_inputs),
+                domain_proof: Binary::from(proof_pause_bytes),
             }),
             &[],
             &setup.user_accounts[0],

--- a/packages/authorization-utils/src/msg.rs
+++ b/packages/authorization-utils/src/msg.rs
@@ -269,6 +269,10 @@ pub enum PermissionlessMsg {
         label: String,
         message: Binary,
         proof: Binary,
+        // Public inputs of domain proof
+        domain_message: Binary,
+        // Domain proof
+        domain_proof: Binary,
     },
 }
 

--- a/packages/authorization-utils/src/zk_authorization.rs
+++ b/packages/authorization-utils/src/zk_authorization.rs
@@ -17,8 +17,10 @@ pub struct ZkAuthorizationInfo {
     // ZK Specific:
     // The registry of the guest program that will be executed
     pub registry: u64,
-    // The Verifying Key to be used
+    // The Verifying Key to be used for the Message
     pub vk: Binary,
+    // The VK that will be used to verify the domain
+    pub domain_vk: Binary,
     // Flag to indicate if we need to validate the last block execution of a specific ZK authorization
     pub validate_last_block_execution: bool,
 }
@@ -30,6 +32,7 @@ impl ZkAuthorizationInfo {
             mode: self.mode.into_mode_validated(api),
             registry: self.registry,
             vk: self.vk,
+            domain_vk: self.domain_vk,
             validate_last_block_execution: self.validate_last_block_execution,
             state: AuthorizationState::Enabled,
         }
@@ -42,6 +45,7 @@ pub struct ZkAuthorization {
     pub mode: AuthorizationMode,
     pub registry: u64,
     pub vk: Binary,
+    pub domain_vk: Binary,
     pub validate_last_block_execution: bool,
     pub state: AuthorizationState,
 }

--- a/solidity/src/authorization/Authorization.sol
+++ b/solidity/src/authorization/Authorization.sol
@@ -550,26 +550,28 @@ contract Authorization is Ownable, ICallback, ReentrancyGuard {
      * @param registries Array of registry IDs to be added
      * @param users Array of arrays of user addresses associated with each registry
      * @param vks Array of verification keys associated with each registry
+     * @param domainVks Array of domain verification keys associated with each registry
      * @param validateBlockNumber Array of booleans indicating if we need to validate the last block execution for each registry
      */
     function addRegistries(
         uint64[] memory registries,
         address[][] memory users,
         bytes32[] calldata vks,
+        bytes32[] calldata domainVks,
         bool[] memory validateBlockNumber
     ) external onlyOwner {
         // Since we are allowing multiple registries to be added at once, we need to check that the arrays are the same length
         // because for each registry we have a list of users, a verification key and a boolean
         // Allowing multiple to be added is useful for gas optimization
         require(
-            users.length == registries.length && users.length == vks.length
+            users.length == registries.length && users.length == vks.length && users.length == domainVks.length
                 && users.length == validateBlockNumber.length,
             "Array lengths must match"
         );
 
         for (uint256 i = 0; i < registries.length; i++) {
             // Add the registry to the verification gateway
-            verificationGateway.addRegistry(registries[i], vks[i]);
+            verificationGateway.addRegistry(registries[i], vks[i], domainVks[i]);
             zkAuthorizations[registries[i]] = users[i];
             // Only store if true because default is false
             if (validateBlockNumber[i]) {
@@ -612,11 +614,25 @@ contract Authorization is Ownable, ICallback, ReentrancyGuard {
      * @dev The proof is verified using the verification gateway before executing the message
      * @param _message Encoded ZK message to be executed
      * @param _proof Proof associated with the ZK message
+     * @param _domainMessage Encoded domain message associated with the domain proof
+     * @param _domainProof domain proof to verify the coprocessor root
      */
-    function executeZKMessage(bytes calldata _message, bytes calldata _proof) external nonReentrant {
+    function executeZKMessage(
+        bytes calldata _message,
+        bytes calldata _proof,
+        bytes calldata _domainMessage,
+        bytes calldata _domainProof
+    ) external nonReentrant {
         // Check that the verification gateway is set
         if (address(verificationGateway) == address(0)) {
             revert("Verification gateway not set");
+        }
+
+        // Verify that the first 32 bytes of both messages is the same (coprocessor root)
+        bytes32 first32BytesMessage = bytes32(_message[0:32]);
+        bytes32 first32BytesDomain = bytes32(_domainMessage[0:32]);
+        if (first32BytesMessage != first32BytesDomain) {
+            revert("Coprocessor root mismatch");
         }
 
         // Decode the message to check authorization and apply modifications
@@ -656,7 +672,7 @@ contract Authorization is Ownable, ICallback, ReentrancyGuard {
         }
 
         // Verify the proof using the verification gateway
-        if (!verificationGateway.verify(decodedZKMessage.registry, _proof, _message)) {
+        if (!verificationGateway.verify(decodedZKMessage.registry, _proof, _message, _domainProof, _domainMessage)) {
             revert("Proof verification failed");
         }
 

--- a/solidity/src/verification/SP1VerificationGateway.sol
+++ b/solidity/src/verification/SP1VerificationGateway.sol
@@ -36,23 +36,30 @@ contract SP1VerificationGateway is VerificationGateway {
      * @param registry The registry used in verification
      * @param proof The proof to verify
      * @param message The message associated with the proof
+     * @param domainProof The domain proof to verify
+     * @param domainMessage The domain message associated with the domain proof
      */
-    function verify(uint64 registry, bytes calldata proof, bytes calldata message)
-        external
-        view
-        override
-        returns (bool)
-    {
+    function verify(
+        uint64 registry,
+        bytes calldata proof,
+        bytes calldata message,
+        bytes calldata domainProof,
+        bytes calldata domainMessage
+    ) external view override returns (bool) {
         // Get the VK for the sender and the registry
         bytes32 vk = programVKs[msg.sender][registry];
 
         // If the VK is not set, revert
         require(vk != bytes32(0), "VK not set for sender and registry");
 
+        // Get the domain VK for the sender and the registry
+        bytes32 domainVk = domainVKs[msg.sender][registry];
+
         // Call the specific verifier
         ISP1Verifier sp1Verifier = getVerifier();
 
         sp1Verifier.verifyProof(vk, proof, message);
+        sp1Verifier.verifyProof(domainVk, domainProof, domainMessage);
 
         return true;
     }

--- a/solidity/src/verification/VerificationGateway.sol
+++ b/solidity/src/verification/VerificationGateway.sol
@@ -23,6 +23,12 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      */
     mapping(address => mapping(uint64 => bytes32)) public programVKs;
 
+    /**
+     * @notice Mapping of domain verification keys by user address and registry ID
+     * @dev Maps: user address => registry ID => domain verification key
+     */
+    mapping(address => mapping(uint64 => bytes32)) public domainVKs;
+
     // Storage gap - reserves slots for future versions
     uint256[50] private __gap;
 
@@ -59,9 +65,11 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      * @dev Only the sender can add a VK for their own address
      * @param registry The registry ID to associate with the verification key
      * @param vk The verification key to register
+     * @param domainVk The domain verification key
      */
-    function addRegistry(uint64 registry, bytes32 vk) external {
+    function addRegistry(uint64 registry, bytes32 vk, bytes32 domainVk) external {
         programVKs[msg.sender][registry] = vk;
+        domainVKs[msg.sender][registry] = domainVk;
     }
 
     /**
@@ -71,6 +79,7 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      */
     function removeRegistry(uint64 registry) external {
         delete programVKs[msg.sender][registry];
+        delete domainVKs[msg.sender][registry];
     }
 
     /**
@@ -79,7 +88,15 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      * @param registry The registry data used in verification
      * @param proof The proof to verify
      * @param message The message associated with the proof
+     * @param domainProof The domain proof to verify against the domain verification key
+     * @param domainMessage The message associated with the domain proof
      * @return True if the proof is valid, false or revert otherwise
      */
-    function verify(uint64 registry, bytes calldata proof, bytes calldata message) external virtual returns (bool);
+    function verify(
+        uint64 registry,
+        bytes calldata proof,
+        bytes calldata message,
+        bytes calldata domainProof,
+        bytes calldata domainMessage
+    ) external virtual returns (bool);
 }

--- a/solidity/test/authorization/AuthorizationZK.t.sol
+++ b/solidity/test/authorization/AuthorizationZK.t.sol
@@ -95,7 +95,7 @@ contract AuthorizationZKTest is Test {
         validateBlockNumbers[1] = validateBlockNumber2;
 
         // Add registries
-        auth.addRegistries(registries, users, vks, validateBlockNumbers);
+        auth.addRegistries(registries, users, vks, vks, validateBlockNumbers);
 
         // Verify registry 1
         bytes32 storedVk1 = verificationGateway.programVKs(address(auth), registryId1);
@@ -144,7 +144,7 @@ contract AuthorizationZKTest is Test {
         validateBlockNumbers[0] = validateBlockNumber1;
         validateBlockNumbers[1] = validateBlockNumber2;
 
-        auth.addRegistries(registriesToAdd, users, vks, validateBlockNumbers);
+        auth.addRegistries(registriesToAdd, users, vks, vks, validateBlockNumbers);
 
         // Verify registries were added
         bytes32 storedVk1 = verificationGateway.programVKs(address(auth), registryId1);
@@ -196,7 +196,7 @@ contract AuthorizationZKTest is Test {
         validateBlockNumbers[1] = validateBlockNumber2;
 
         vm.expectRevert();
-        auth.addRegistries(registries, users, vks, validateBlockNumbers);
+        auth.addRegistries(registries, users, vks, vks, validateBlockNumbers);
 
         vm.stopPrank();
     }
@@ -240,7 +240,7 @@ contract AuthorizationZKTest is Test {
         validateBlockNumbers[1] = validateBlockNumber2;
 
         vm.expectRevert("Array lengths must match");
-        auth.addRegistries(registries, users, vks, validateBlockNumbers);
+        auth.addRegistries(registries, users, vks, vks, validateBlockNumbers);
 
         vm.stopPrank();
     }
@@ -259,7 +259,7 @@ contract AuthorizationZKTest is Test {
 
         // Should fail because verification gateway is not set
         vm.expectRevert("Verification gateway not set");
-        authWithoutGateway.executeZKMessage(zkMessage, dummyProof);
+        authWithoutGateway.executeZKMessage(zkMessage, dummyProof, zkMessage, dummyProof);
 
         vm.stopPrank();
     }
@@ -281,7 +281,7 @@ contract AuthorizationZKTest is Test {
         bool[] memory validateBlockNumbers = new bool[](1);
         validateBlockNumbers[0] = validateBlockNumber1;
 
-        auth.addRegistries(registries, users, vks, validateBlockNumbers);
+        auth.addRegistries(registries, users, vks, vks, validateBlockNumbers);
 
         // Create a ZK message with an invalid authorization contract
         bytes memory zkMessage = createDummyZKMessage(registryId1, address(user1));
@@ -289,7 +289,7 @@ contract AuthorizationZKTest is Test {
 
         // Should fail because address is not the authorization contract
         vm.expectRevert("Invalid authorization contract");
-        auth.executeZKMessage(zkMessage, dummyProof);
+        auth.executeZKMessage(zkMessage, dummyProof, zkMessage, dummyProof);
 
         vm.stopPrank();
     }
@@ -314,7 +314,7 @@ contract AuthorizationZKTest is Test {
         bool[] memory validateBlockNumbers = new bool[](1);
         validateBlockNumbers[0] = validateBlockNumber1;
 
-        auth.addRegistries(registries, users, vks, validateBlockNumbers);
+        auth.addRegistries(registries, users, vks, vks, validateBlockNumbers);
 
         vm.stopPrank();
 
@@ -327,7 +327,7 @@ contract AuthorizationZKTest is Test {
 
         // Should fail because address is unauthorized
         vm.expectRevert("Unauthorized address for this registry");
-        auth.executeZKMessage(zkMessage, dummyProof);
+        auth.executeZKMessage(zkMessage, dummyProof, zkMessage, dummyProof);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
Adds an additional VK to ZkAuthorizations that will used to verify the Coprocessor. This means when executing authorizations we verify two proofs now and we check that the first 32 bytes of the public inputs (coprocessor root) match. This is added to both the cosmwasm and solidity implementation.
