### PR TITLE
feat: clearing queue v2

### DIFF
--- a/contracts/libraries/clearing-queue/README.md
+++ b/contracts/libraries/clearing-queue/README.md
@@ -2,6 +2,9 @@
 
 The **Valence Clearing Queue** library allows **registration and settlement of withdrawal obligations** in a FIFO (First-In-First-Out) manner. It maintains a queue of pending withdrawal obligations, with each obligation containing recipient information, payout amounts, and a unique identifier. When settling obligations, funds are pulled from a **settlement input account** and sent to the specified recipients.
 
+The queue processes obligations based on a strict, monotonically increasing order of the obligation ids.
+This is meant to prevent any out-of-order errors that may arise from latency or other issues.
+
 ## High-level flow
 
 ```mermaid
@@ -30,7 +33,17 @@ pub struct LibraryConfig {
     /// settlement input account which we tap into in order
     /// to settle the obligations
     pub settlement_acc_addr: LibraryAccountType,
+    /// obligation base denom
+    pub denom: String,
+    /// latest registered obligation id.
+    /// if `None`, defaults to 0
+    pub latest_id: Option<Uint64>,
 }
 ```
 
 The `settlement_acc_addr` specifies the account from which funds will be pulled to fulfill settlement obligations. The library will check that this account has sufficient balance before attempting to settle each obligation.
+
+Configured `denom` is the base clearing denomination which will be applied to all obligation amounts.
+
+Lastly, the optional `latest_id` field allows to configure the library order to start from a specific id.
+If `None`, latest id defaults to 0. Otherwise, it will start from the specified id.

--- a/contracts/libraries/clearing-queue/schema/valence-clearing-queue.json
+++ b/contracts/libraries/clearing-queue/schema/valence-clearing-queue.json
@@ -72,9 +72,25 @@
       "LibraryConfig": {
         "type": "object",
         "required": [
+          "denom",
           "settlement_acc_addr"
         ],
         "properties": {
+          "denom": {
+            "description": "obligation base denom",
+            "type": "string"
+          },
+          "latest_id": {
+            "description": "latest registered obligation id. if `None`, defaults to 0",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "settlement_acc_addr": {
             "description": "settlement input account which we tap into in order to settle the obligations",
             "allOf": [
@@ -85,6 +101,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
       }
     }
   },
@@ -212,22 +232,6 @@
           }
         ]
       },
-      "Coin": {
-        "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
-        "properties": {
-          "amount": {
-            "$ref": "#/definitions/Uint128"
-          },
-          "denom": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "Expiration": {
         "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
         "oneOf": [
@@ -288,7 +292,7 @@
                 "type": "object",
                 "required": [
                   "id",
-                  "payout_coins",
+                  "payout_amount",
                   "recipient"
                 ],
                 "properties": {
@@ -300,12 +304,13 @@
                       }
                     ]
                   },
-                  "payout_coins": {
-                    "description": "what is owed to the recipient",
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/Coin"
-                    }
+                  "payout_amount": {
+                    "description": "amount of the config denom owed to the recipient",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Uint128"
+                      }
+                    ]
                   },
                   "recipient": {
                     "description": "where the payout is to be routed",
@@ -380,7 +385,19 @@
       },
       "LibraryConfigUpdate": {
         "type": "object",
+        "required": [
+          "latest_id"
+        ],
         "properties": {
+          "denom": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_id": {
+            "$ref": "#/definitions/OptionUpdate_for_Uint64"
+          },
           "settlement_acc_addr": {
             "anyOf": [
               {
@@ -393,6 +410,35 @@
           }
         },
         "additionalProperties": false
+      },
+      "OptionUpdate_for_Uint64": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "none"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "set"
+            ],
+            "properties": {
+              "set": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Uint64"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Timestamp": {
         "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
@@ -554,9 +600,23 @@
       "description": "Validated library configuration",
       "type": "object",
       "required": [
+        "denom",
+        "latest_id",
         "settlement_acc_addr"
       ],
       "properties": {
+        "denom": {
+          "description": "obligation base denom",
+          "type": "string"
+        },
+        "latest_id": {
+          "description": "latest registered obligation id",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
         "settlement_acc_addr": {
           "description": "settlement input account which we tap into in order to settle the obligations",
           "allOf": [
@@ -570,6 +630,10 @@
       "definitions": {
         "Addr": {
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
         }
       }
@@ -585,9 +649,25 @@
       "title": "LibraryConfig",
       "type": "object",
       "required": [
+        "denom",
         "settlement_acc_addr"
       ],
       "properties": {
+        "denom": {
+          "description": "obligation base denom",
+          "type": "string"
+        },
+        "latest_id": {
+          "description": "latest registered obligation id. if `None`, defaults to 0",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "settlement_acc_addr": {
           "description": "settlement input account which we tap into in order to settle the obligations",
           "allOf": [
@@ -643,6 +723,10 @@
               "additionalProperties": false
             }
           ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
         }
       }
     },
@@ -843,7 +927,7 @@
           "required": [
             "enqueue_block",
             "id",
-            "payout_coins",
+            "payout_coin",
             "recipient"
           ],
           "properties": {
@@ -863,12 +947,13 @@
                 }
               ]
             },
-            "payout_coins": {
+            "payout_coin": {
               "description": "what is owed to the recipient",
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Coin"
-              }
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Coin"
+                }
+              ]
             },
             "recipient": {
               "description": "where the payout is to be routed",

--- a/contracts/libraries/clearing-queue/schema/valence-clearing-queue.json
+++ b/contracts/libraries/clearing-queue/schema/valence-clearing-queue.json
@@ -732,18 +732,29 @@
     },
     "obligation_status": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "ObligationStatusResponse",
-      "type": "object",
-      "required": [
-        "settled"
-      ],
-      "properties": {
-        "settled": {
-          "description": "boolean status of a given obligation where `false` indicates that the obligation is registered, and `true` indicates that the obligation is settled.",
-          "type": "boolean"
+      "title": "ObligationStatus",
+      "description": "obligation status enum",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "in_queue",
+            "processed"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "error"
+          ],
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     },
     "ownership": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -857,10 +868,6 @@
       },
       "additionalProperties": false,
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
-        },
         "BlockInfo": {
           "type": "object",
           "required": [
@@ -957,11 +964,7 @@
             },
             "recipient": {
               "description": "where the payout is to be routed",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Addr"
-                }
-              ]
+              "type": "string"
             }
           },
           "additionalProperties": false

--- a/contracts/libraries/clearing-queue/schema/valence-clearing-queue.json
+++ b/contracts/libraries/clearing-queue/schema/valence-clearing-queue.json
@@ -868,6 +868,10 @@
       },
       "additionalProperties": false,
       "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
         "BlockInfo": {
           "type": "object",
           "required": [
@@ -964,7 +968,11 @@
             },
             "recipient": {
               "description": "where the payout is to be routed",
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
             }
           },
           "additionalProperties": false

--- a/contracts/libraries/clearing-queue/src/msg.rs
+++ b/contracts/libraries/clearing-queue/src/msg.rs
@@ -139,7 +139,7 @@ pub enum QueryMsg {
     /// if status of more than one obligations will be relevant,
     /// this information can be inferred from the `Obligations` query
     /// (if obligation is in the queue then it is not yet settled).
-    #[returns(ObligationStatusResponse)]
+    #[returns(crate::state::ObligationStatus)]
     ObligationStatus { id: u64 },
 }
 
@@ -147,14 +147,6 @@ pub enum QueryMsg {
 pub struct QueueInfoResponse {
     /// total number of obligations in the queue
     pub len: u64,
-}
-
-#[cw_serde]
-pub struct ObligationStatusResponse {
-    /// boolean status of a given obligation where
-    /// `false` indicates that the obligation is registered,
-    /// and `true` indicates that the obligation is settled.
-    pub settled: bool,
 }
 
 #[cw_serde]

--- a/contracts/libraries/clearing-queue/src/state.rs
+++ b/contracts/libraries/clearing-queue/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{BlockInfo, Coin, Uint64};
+use cosmwasm_std::{Addr, BlockInfo, Coin, Uint64};
 use cw_storage_plus::Map;
 use valence_processor_utils::queue::QueueMap;
 
@@ -27,7 +27,7 @@ pub enum ObligationStatus {
 #[cw_serde]
 pub struct WithdrawalObligation {
     /// where the payout is to be routed
-    pub recipient: String,
+    pub recipient: Addr,
     /// what is owed to the recipient
     pub payout_coin: Coin,
     /// some unique identifier for the request

--- a/contracts/libraries/clearing-queue/src/state.rs
+++ b/contracts/libraries/clearing-queue/src/state.rs
@@ -24,7 +24,7 @@ pub struct WithdrawalObligation {
     /// where the payout is to be routed
     pub recipient: Addr,
     /// what is owed to the recipient
-    pub payout_coins: Vec<Coin>,
+    pub payout_coin: Coin,
     /// some unique identifier for the request
     pub id: Uint64,
     /// block when registration was enqueued

--- a/contracts/libraries/clearing-queue/src/state.rs
+++ b/contracts/libraries/clearing-queue/src/state.rs
@@ -1,15 +1,12 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, BlockInfo, Coin, Uint64};
+use cosmwasm_std::{BlockInfo, Coin, Uint64};
 use cw_storage_plus::Map;
 use valence_processor_utils::queue::QueueMap;
 
-/// map of registered obligation id -> settlement status where
-/// value of `false` indicates that the obligation is still to be
-/// settled, and `true` indicates that the obligation had been
-/// settled successfully.
+/// map of registered obligation id -> settlement status.
 /// this map is also used for obligation registration checks to
 /// ensure that any given obligation can be registered at most once.
-pub const REGISTERED_OBLIGATION_IDS: Map<u64, bool> = Map::new("reg_obl_id");
+pub const OBLIGATION_ID_TO_STATUS_MAP: Map<u64, ObligationStatus> = Map::new("reg_obl_id");
 
 /// fifo queue storing the pending obligations
 pub const CLEARING_QUEUE: QueueMap<WithdrawalObligation> = QueueMap::new(
@@ -18,11 +15,19 @@ pub const CLEARING_QUEUE: QueueMap<WithdrawalObligation> = QueueMap::new(
     "clearing_queue_end_index",
 );
 
+/// obligation status enum
+#[cw_serde]
+pub enum ObligationStatus {
+    InQueue,
+    Processed,
+    Error(String),
+}
+
 /// unsettled liability sitting in the clearing queue
 #[cw_serde]
 pub struct WithdrawalObligation {
     /// where the payout is to be routed
-    pub recipient: Addr,
+    pub recipient: String,
     /// what is owed to the recipient
     pub payout_coin: Coin,
     /// some unique identifier for the request

--- a/contracts/libraries/clearing-queue/src/testing/builder.rs
+++ b/contracts/libraries/clearing-queue/src/testing/builder.rs
@@ -59,7 +59,8 @@ impl Default for ClearingQueueTestingSuiteBuilder {
             crate::contract::execute,
             crate::contract::instantiate,
             crate::contract::query,
-        );
+        )
+        .with_reply(crate::contract::reply);
 
         let clearing_code_id = inner
             .app_mut()

--- a/contracts/libraries/clearing-queue/src/testing/builder.rs
+++ b/contracts/libraries/clearing-queue/src/testing/builder.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Coin, Empty};
+use cosmwasm_std::{coin, Addr, Coin, Empty};
 use cw_multi_test::{App, ContractWrapper};
 use valence_library_utils::{
     msg::InstantiateMsg,
@@ -7,7 +7,7 @@ use valence_library_utils::{
 
 use crate::msg::LibraryConfig;
 
-use super::suite::ClearingQueueTestingSuite;
+use super::suite::{ClearingQueueTestingSuite, DENOM_1};
 
 const USER_1: &str = "USER_1";
 const USER_2: &str = "USER_2";
@@ -15,7 +15,7 @@ const USER_3: &str = "USER_3";
 
 pub struct ClearingQueueTestingSuiteBuilder {
     pub inner: LibraryTestSuiteBase,
-    pub input_balances: Vec<Coin>,
+    pub input_bal: Coin,
     pub input_addr: Addr,
     pub processor: Addr,
     pub code_id: u64,
@@ -68,7 +68,7 @@ impl Default for ClearingQueueTestingSuiteBuilder {
 
         Self {
             inner,
-            input_balances: vec![],
+            input_bal: coin(1_000, DENOM_1),
             input_addr,
             code_id: clearing_code_id,
             processor,
@@ -77,9 +77,8 @@ impl Default for ClearingQueueTestingSuiteBuilder {
 }
 
 impl ClearingQueueTestingSuiteBuilder {
-    pub fn with_input_balances(mut self, input_coins: Vec<Coin>) -> Self {
-        self.input_balances = input_coins;
-        println!("input balances = {:?}", self.input_balances);
+    pub fn with_input_balance(mut self, input_bal: Coin) -> Self {
+        self.input_bal = input_bal;
         self
     }
 
@@ -89,9 +88,10 @@ impl ClearingQueueTestingSuiteBuilder {
     }
 
     pub fn build(mut self) -> ClearingQueueTestingSuite {
-        let cfg = LibraryConfig::new(valence_library_utils::LibraryAccountType::Addr(
-            self.input_addr.to_string(),
-        ));
+        let cfg = LibraryConfig::new(
+            valence_library_utils::LibraryAccountType::Addr(self.input_addr.to_string()),
+            self.input_bal.denom.to_string(),
+        );
 
         let init_msg = InstantiateMsg {
             owner: self.owner().to_string(),
@@ -107,8 +107,8 @@ impl ClearingQueueTestingSuiteBuilder {
             let account_addr = self.account_init("input_account", vec![addr.to_string()]);
             assert_eq!(account_addr, input_addr);
 
-            if !self.input_balances.is_empty() {
-                self.init_balance(&input_addr, self.input_balances.clone());
+            if !self.input_bal.amount.is_zero() {
+                self.init_balance(&input_addr, vec![self.input_bal.clone()]);
             }
         }
 

--- a/contracts/libraries/clearing-queue/src/testing/builder.rs
+++ b/contracts/libraries/clearing-queue/src/testing/builder.rs
@@ -59,8 +59,7 @@ impl Default for ClearingQueueTestingSuiteBuilder {
             crate::contract::execute,
             crate::contract::instantiate,
             crate::contract::query,
-        )
-        .with_reply(crate::contract::reply);
+        );
 
         let clearing_code_id = inner
             .app_mut()

--- a/contracts/libraries/clearing-queue/src/testing/builder.rs
+++ b/contracts/libraries/clearing-queue/src/testing/builder.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{coin, Addr, Coin, Empty};
+use cosmwasm_std::{coin, Addr, Coin, Empty, Uint64};
 use cw_multi_test::{App, ContractWrapper};
 use valence_library_utils::{
     msg::InstantiateMsg,
@@ -19,6 +19,7 @@ pub struct ClearingQueueTestingSuiteBuilder {
     pub input_addr: Addr,
     pub processor: Addr,
     pub code_id: u64,
+    pub latest_id: Option<Uint64>,
 }
 
 impl LibraryTestSuite<Empty, Empty> for ClearingQueueTestingSuiteBuilder {
@@ -72,6 +73,7 @@ impl Default for ClearingQueueTestingSuiteBuilder {
             input_addr,
             code_id: clearing_code_id,
             processor,
+            latest_id: None,
         }
     }
 }
@@ -87,10 +89,16 @@ impl ClearingQueueTestingSuiteBuilder {
         self
     }
 
+    pub fn with_latest_obligation_id(mut self, obligation_id: u64) -> Self {
+        self.latest_id = Some(obligation_id.into());
+        self
+    }
+
     pub fn build(mut self) -> ClearingQueueTestingSuite {
         let cfg = LibraryConfig::new(
             valence_library_utils::LibraryAccountType::Addr(self.input_addr.to_string()),
             self.input_bal.denom.to_string(),
+            self.latest_id,
         );
 
         let init_msg = InstantiateMsg {

--- a/contracts/libraries/clearing-queue/src/testing/suite.rs
+++ b/contracts/libraries/clearing-queue/src/testing/suite.rs
@@ -3,6 +3,7 @@ use cw_multi_test::{error::AnyResult, App, AppResponse, Executor};
 use valence_library_utils::{
     msg::ExecuteMsg,
     testing::{LibraryTestSuite, LibraryTestSuiteBase},
+    OptionUpdate,
 };
 
 use crate::msg::{
@@ -67,7 +68,9 @@ impl ClearingQueueTestingSuite {
         let updated_config = LibraryConfigUpdate {
             settlement_acc_addr: Some(new_config.settlement_acc_addr),
             denom: Some(new_config.denom),
+            latest_id: OptionUpdate::Set(new_config.latest_id),
         };
+
         self.app_mut().execute_contract(
             owner,
             clearing_lib,

--- a/contracts/libraries/clearing-queue/src/testing/suite.rs
+++ b/contracts/libraries/clearing-queue/src/testing/suite.rs
@@ -6,9 +6,12 @@ use valence_library_utils::{
     OptionUpdate,
 };
 
-use crate::msg::{
-    FunctionMsgs, LibraryConfig, LibraryConfigUpdate, ObligationStatusResponse,
-    ObligationsResponse, QueryMsg, QueueInfoResponse,
+use crate::{
+    msg::{
+        FunctionMsgs, LibraryConfig, LibraryConfigUpdate, ObligationsResponse, QueryMsg,
+        QueueInfoResponse,
+    },
+    state::ObligationStatus,
 };
 
 pub(crate) const DENOM_1: &str = "DENOM_1";
@@ -96,7 +99,7 @@ impl ClearingQueueTestingSuite {
             .query_wasm(&self.clearing_queue, &QueryMsg::QueueInfo {})
     }
 
-    pub fn query_obligation_status(&self, obligation_id: u64) -> ObligationStatusResponse {
+    pub fn query_obligation_status(&self, obligation_id: u64) -> ObligationStatus {
         self.inner.query_wasm(
             &self.clearing_queue,
             &QueryMsg::ObligationStatus { id: obligation_id },

--- a/contracts/libraries/clearing-queue/src/testing/suite.rs
+++ b/contracts/libraries/clearing-queue/src/testing/suite.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Coin, Empty};
+use cosmwasm_std::{Addr, Coin, Empty, Uint128};
 use cw_multi_test::{error::AnyResult, App, AppResponse, Executor};
 use valence_library_utils::{
     msg::ExecuteMsg,
@@ -11,7 +11,6 @@ use crate::msg::{
 };
 
 pub(crate) const DENOM_1: &str = "DENOM_1";
-pub(crate) const DENOM_2: &str = "DENOM_2";
 
 pub struct ClearingQueueTestingSuite {
     pub inner: LibraryTestSuiteBase,
@@ -27,7 +26,7 @@ impl ClearingQueueTestingSuite {
     pub fn register_new_obligation(
         &mut self,
         recipient: String,
-        payout_coins: Vec<Coin>,
+        payout_amount: Uint128,
         id: u64,
     ) -> AnyResult<AppResponse> {
         let processor = self.processor.clone();
@@ -39,7 +38,7 @@ impl ClearingQueueTestingSuite {
             &ExecuteMsg::<FunctionMsgs, LibraryConfigUpdate>::ProcessFunction(
                 FunctionMsgs::RegisterObligation {
                     recipient,
-                    payout_coins,
+                    payout_amount,
                     id: id.into(),
                 },
             ),
@@ -67,6 +66,7 @@ impl ClearingQueueTestingSuite {
 
         let updated_config = LibraryConfigUpdate {
             settlement_acc_addr: Some(new_config.settlement_acc_addr),
+            denom: Some(new_config.denom),
         };
         self.app_mut().execute_contract(
             owner,

--- a/contracts/libraries/clearing-queue/src/testing/tests.rs
+++ b/contracts/libraries/clearing-queue/src/testing/tests.rs
@@ -1,12 +1,9 @@
-use cosmwasm_std::{coin, coins};
+use cosmwasm_std::{coin, Uint128};
 use valence_library_utils::LibraryAccountType;
 
 use crate::{
     msg::LibraryConfig,
-    testing::{
-        builder::ClearingQueueTestingSuiteBuilder,
-        suite::{DENOM_1, DENOM_2},
-    },
+    testing::{builder::ClearingQueueTestingSuiteBuilder, suite::DENOM_1},
 };
 
 const INVALID_ADDR: &str = "invalid_addr";
@@ -29,6 +26,7 @@ fn test_update_validates_input_acc() {
     suite
         .update_clearing_config(LibraryConfig {
             settlement_acc_addr: new_settlement_acc_addr,
+            denom: "denom".to_string(),
         })
         .unwrap();
 }
@@ -43,32 +41,18 @@ fn test_settling_obligations_requires_nonempty_queue() {
 
 #[test]
 #[should_panic(
-    expected = "insufficient settlement acc balance to fulfill obligation: 100DENOM_2 < 150DENOM_2"
+    expected = "insufficient settlement acc balance to fulfill obligation: 100DENOM_1 < 150DENOM_1"
 )]
 fn test_settling_obligations_requires_funded_settlement_account() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default()
-        .with_input_balances(vec![coin(100, DENOM_1), coin(100, DENOM_2)])
+        .with_input_balance(coin(100, DENOM_1))
         .build();
 
     suite
-        .register_new_obligation(
-            suite.user_1.to_string(),
-            vec![coin(100, DENOM_1), coin(150, DENOM_2)],
-            1,
-        )
+        .register_new_obligation(suite.user_1.to_string(), 150u128.into(), 1)
         .unwrap();
 
     suite.settle_next_obligation().unwrap();
-}
-
-#[test]
-#[should_panic(expected = "obligation must have payout coins in order to be registered")]
-fn test_registering_obligation_validates_payout_coins_len() {
-    let mut suite = ClearingQueueTestingSuiteBuilder::default().build();
-
-    suite
-        .register_new_obligation(suite.user_1.to_string(), vec![], 1)
-        .unwrap();
 }
 
 #[test]
@@ -77,21 +61,17 @@ fn test_registering_obligation_validates_recipient_addr() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default().build();
 
     suite
-        .register_new_obligation(
-            "invalid_addr".to_string(),
-            vec![coin(100, DENOM_1), coin(150, DENOM_2)],
-            1,
-        )
+        .register_new_obligation("invalid_addr".to_string(), 100u128.into(), 1)
         .unwrap();
 }
 
 #[test]
-#[should_panic(expected = "obligation payout coin DENOM_1 amount cannot be zero")]
+#[should_panic(expected = "obligation amount must be greater than 0 in order to be registered")]
 fn test_registering_obligation_validates_payout_coins_nonzero_amounts() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default().build();
 
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(0, DENOM_1), 1)
+        .register_new_obligation(suite.user_1.to_string(), Uint128::zero(), 1)
         .unwrap();
 }
 
@@ -106,7 +86,7 @@ fn test_register_withdraw_obligation_happy() {
     assert!(queue_resp_0.obligations.is_empty());
 
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(100, DENOM_1), 10)
+        .register_new_obligation(suite.user_1.to_string(), 100u128.into(), 10)
         .unwrap();
 
     let queue_len = suite.query_queue_info().len;
@@ -121,7 +101,7 @@ fn test_register_withdraw_obligation_happy() {
 #[test]
 fn test_queue_operates_in_fifo_manner() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default()
-        .with_input_balances(vec![coin(1_000, DENOM_1), coin(1_000, DENOM_2)])
+        .with_input_balance(coin(1_000, DENOM_1))
         .build();
 
     let queue_len_0 = suite.query_queue_info().len;
@@ -132,13 +112,13 @@ fn test_queue_operates_in_fifo_manner() {
 
     //  user_2 -> user_3 -> user_1 -> head
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(100, DENOM_1), 1)
+        .register_new_obligation(suite.user_1.to_string(), 100u128.into(), 1)
         .unwrap();
     suite
-        .register_new_obligation(suite.user_3.to_string(), coins(200, DENOM_2), 2)
+        .register_new_obligation(suite.user_3.to_string(), 200u128.into(), 2)
         .unwrap();
     suite
-        .register_new_obligation(suite.user_2.to_string(), coins(420, DENOM_1), 3)
+        .register_new_obligation(suite.user_2.to_string(), 420u128.into(), 3)
         .unwrap();
 
     let queue_len = suite.query_queue_info().len;
@@ -177,10 +157,10 @@ fn test_double_accounting_errors() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default().build();
 
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(100, DENOM_1), 10)
+        .register_new_obligation(suite.user_1.to_string(), 100u128.into(), 10)
         .unwrap();
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(200, DENOM_1), 10)
+        .register_new_obligation(suite.user_1.to_string(), 200u128.into(), 10)
         .unwrap();
 }
 
@@ -188,78 +168,34 @@ fn test_double_accounting_errors() {
 #[should_panic(expected = "obligation #10 is already registered in the queue")]
 fn test_double_accounting_errors_after_obligation_settlement() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default()
-        .with_input_balances(vec![coin(1_000, DENOM_1), coin(1_000, DENOM_2)])
+        .with_input_balance(coin(1_000, DENOM_1))
         .build();
 
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(100, DENOM_1), 10)
+        .register_new_obligation(suite.user_1.to_string(), 100u128.into(), 10)
         .unwrap();
 
     suite.settle_next_obligation().unwrap();
 
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(200, DENOM_1), 10)
+        .register_new_obligation(suite.user_1.to_string(), 200u128.into(), 10)
         .unwrap();
-}
-
-#[test]
-fn test_user_obligation_with_multiple_denoms() {
-    let mut suite = ClearingQueueTestingSuiteBuilder::default()
-        .with_input_balances(vec![coin(100, DENOM_1), coin(100, DENOM_2)])
-        .build();
-
-    let input_acc_d1_bal = suite.query_input_acc_bal(DENOM_1);
-    let input_acc_d2_bal = suite.query_input_acc_bal(DENOM_2);
-    let u1_d1_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_1);
-    let u1_d2_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_2);
-
-    assert_eq!(input_acc_d1_bal.amount.u128(), 100);
-    assert_eq!(input_acc_d2_bal.amount.u128(), 100);
-    assert!(u1_d1_bal.amount.is_zero());
-    assert!(u1_d2_bal.amount.is_zero());
-
-    suite
-        .register_new_obligation(
-            suite.user_1.to_string(),
-            vec![coin(100, DENOM_1), coin(100, DENOM_2)],
-            1,
-        )
-        .unwrap();
-
-    let obligation_status = suite.query_obligation_status(1);
-    assert!(!obligation_status.settled);
-
-    suite.settle_next_obligation().unwrap();
-
-    let obligation_status = suite.query_obligation_status(1);
-    assert!(obligation_status.settled);
-
-    let input_acc_d1_bal = suite.query_input_acc_bal(DENOM_1);
-    let input_acc_d2_bal = suite.query_input_acc_bal(DENOM_2);
-    let u1_d1_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_1);
-    let u1_d2_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_2);
-
-    assert!(input_acc_d1_bal.amount.is_zero());
-    assert!(input_acc_d2_bal.amount.is_zero());
-
-    assert_eq!(u1_d1_bal.amount.u128(), 100);
-    assert_eq!(u1_d2_bal.amount.u128(), 100);
 }
 
 #[test]
 fn test_multi_user_settlement() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default()
-        .with_input_balances(coins(1_000, DENOM_1))
+        .with_input_balance(coin(1_000, DENOM_1))
         .build();
 
     suite
-        .register_new_obligation(suite.user_1.to_string(), coins(100, DENOM_1), 1)
+        .register_new_obligation(suite.user_1.to_string(), 100u128.into(), 1)
         .unwrap();
     suite
-        .register_new_obligation(suite.user_2.to_string(), coins(300, DENOM_1), 2)
+        .register_new_obligation(suite.user_2.to_string(), 300u128.into(), 2)
         .unwrap();
     suite
-        .register_new_obligation(suite.user_3.to_string(), coins(400, DENOM_1), 3)
+        .register_new_obligation(suite.user_3.to_string(), 400u128.into(), 3)
         .unwrap();
 
     let input_acc_d1_bal = suite.query_input_acc_bal(DENOM_1);
@@ -297,44 +233,4 @@ fn test_multi_user_settlement() {
     assert_eq!(u1_d1_bal.amount.u128(), 100);
     assert_eq!(u2_d1_bal.amount.u128(), 300);
     assert_eq!(u3_d1_bal.amount.u128(), 400);
-}
-
-#[test]
-fn test_multi_denom_settlement() {
-    let mut suite = ClearingQueueTestingSuiteBuilder::default()
-        .with_input_balances(vec![coin(1_000, DENOM_1), coin(1_000, DENOM_2)])
-        .build();
-
-    suite
-        .register_new_obligation(suite.user_1.to_string(), coins(100, DENOM_1), 1)
-        .unwrap();
-    suite
-        .register_new_obligation(suite.user_1.to_string(), coins(300, DENOM_2), 2)
-        .unwrap();
-
-    let input_acc_d1_bal = suite.query_input_acc_bal(DENOM_1);
-    let input_acc_d2_bal = suite.query_input_acc_bal(DENOM_2);
-    let u1_d1_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_1);
-    let u1_d2_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_2);
-
-    assert_eq!(input_acc_d1_bal.amount.u128(), 1_000);
-    assert_eq!(input_acc_d2_bal.amount.u128(), 1_000);
-    assert!(u1_d1_bal.amount.is_zero());
-    assert!(u1_d2_bal.amount.is_zero());
-
-    // settle all existing obligations
-    suite.settle_next_obligation().unwrap();
-    suite.settle_next_obligation().unwrap();
-
-    let input_acc_d1_bal = suite.query_input_acc_bal(DENOM_1);
-    let input_acc_d2_bal = suite.query_input_acc_bal(DENOM_2);
-    let u1_d1_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_1);
-    let u1_d2_bal = suite.query_user_bal(suite.user_1.as_str(), DENOM_2);
-
-    assert_eq!(input_acc_d1_bal.amount.u128(), 1_000 - 100);
-    assert_eq!(input_acc_d2_bal.amount.u128(), 1_000 - 300);
-
-    // assert that user was credited as expected
-    assert_eq!(u1_d1_bal.amount.u128(), 100);
-    assert_eq!(u1_d2_bal.amount.u128(), 300);
 }

--- a/contracts/libraries/clearing-queue/src/testing/tests.rs
+++ b/contracts/libraries/clearing-queue/src/testing/tests.rs
@@ -58,6 +58,7 @@ fn test_settling_obligations_requires_funded_settlement_account() {
 }
 
 #[test]
+#[should_panic(expected = "no pending obligations")]
 fn test_processing_invalid_obligation_with_zero_amount_works() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default()
         .with_input_balance(coin(1_000, DENOM_1))
@@ -68,15 +69,13 @@ fn test_processing_invalid_obligation_with_zero_amount_works() {
         .unwrap();
 
     let obligation_status = suite.query_obligation_status(1);
-    assert!(matches!(obligation_status, ObligationStatus::InQueue));
+    assert!(matches!(obligation_status, ObligationStatus::Error(_)));
 
     suite.settle_next_obligation().unwrap();
-
-    let obligation_status = suite.query_obligation_status(1);
-    assert!(matches!(obligation_status, ObligationStatus::Error(_)));
 }
 
 #[test]
+#[should_panic(expected = "no pending obligations")]
 fn test_processing_invalid_obligation_with_invalid_addr_works() {
     let mut suite = ClearingQueueTestingSuiteBuilder::default()
         .with_input_balance(coin(1_000, DENOM_1))
@@ -87,13 +86,9 @@ fn test_processing_invalid_obligation_with_invalid_addr_works() {
         .unwrap();
 
     let obligation_status = suite.query_obligation_status(1);
-    assert!(matches!(obligation_status, ObligationStatus::InQueue));
+    assert!(matches!(obligation_status, ObligationStatus::Error(_)));
 
     suite.settle_next_obligation().unwrap();
-
-    // assert that the obligation is no longer in the queue
-    let obligation_status = suite.query_obligation_status(1);
-    assert!(!matches!(obligation_status, ObligationStatus::InQueue));
 }
 
 #[test]
@@ -152,20 +147,11 @@ fn test_queue_operates_in_fifo_manner() {
     assert_eq!(queue_resp.obligations.len(), 3);
 
     // first obligation was user_1
-    assert_eq!(
-        queue_resp.obligations[0].recipient,
-        suite.user_1.to_string()
-    );
+    assert_eq!(queue_resp.obligations[0].recipient, suite.user_1);
     // second obligation was user_3
-    assert_eq!(
-        queue_resp.obligations[1].recipient,
-        suite.user_3.to_string()
-    );
+    assert_eq!(queue_resp.obligations[1].recipient, suite.user_3);
     // third obligation was user_2
-    assert_eq!(
-        queue_resp.obligations[2].recipient,
-        suite.user_2.to_string()
-    );
+    assert_eq!(queue_resp.obligations[2].recipient, suite.user_2);
 
     // we settle an obligation in order to assert that queue is processed fifo
     suite.settle_next_obligation().unwrap();
@@ -178,15 +164,9 @@ fn test_queue_operates_in_fifo_manner() {
     assert_eq!(queue_resp.obligations.len(), 2);
 
     // user_3 should be the oldest
-    assert_eq!(
-        queue_resp.obligations[0].recipient,
-        suite.user_3.to_string()
-    );
+    assert_eq!(queue_resp.obligations[0].recipient, suite.user_3);
     // user_2 should be the latest
-    assert_eq!(
-        queue_resp.obligations[1].recipient,
-        suite.user_2.to_string()
-    );
+    assert_eq!(queue_resp.obligations[1].recipient, suite.user_2);
 }
 
 #[test]
@@ -273,6 +253,9 @@ fn test_multi_user_settlement() {
     let u3_d1_bal = suite.query_user_bal(suite.user_3.as_str(), DENOM_1);
 
     // assert that the obligations are now considered as settled
+    let obligation_status_1 = suite.query_obligation_status(1);
+    println!("obligation status 1 : {:?} ", obligation_status_1);
+
     assert!(matches!(
         suite.query_obligation_status(1),
         ObligationStatus::Processed

--- a/docs/src/libraries/cosmwasm/clearing_queue.md
+++ b/docs/src/libraries/cosmwasm/clearing_queue.md
@@ -2,6 +2,9 @@
 
 The **Valence Clearing Queue** library allows **registration and settlement of withdrawal obligations** in a FIFO (First-In-First-Out) manner. It maintains a queue of pending withdrawal obligations, with each obligation containing recipient information, payout amounts, and a unique identifier. When settling obligations, funds are pulled from a **settlement input account** and sent to the specified recipients.
 
+The queue processes obligations based on a strict, monotonically increasing order of the obligation ids.
+This is meant to prevent any out-of-order errors that may arise from latency or other issues.
+
 > **Important:**
 > This library functions solely as a settlement engine. The settlement account funding (liquidity-management) flow is outside of its scope and is managed by a strategist. This management process likely involves monitoring both the settlement account balance and the obligation queue in order to ensure the settlement account maintains sufficient liquidity for obligation settlements.
 
@@ -28,7 +31,7 @@ graph LR
 
 | Function               | Parameters                                          | Description                                                                                                                                            |
 |------------------------|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **RegisterObligation** | `recipient: String`<br>`payout_coins: Vec<Coin>`<br>`id: Uint64` | Registers a new withdrawal obligation in the queue with the specified recipient, payout coins, and unique ID. Each obligation must have non-zero payout amounts. Recipient must be a valid bech32 address. |
+| **RegisterObligation** | `recipient: String`<br>`payout_amount: Uint128`<br>`id: Uint64` | Registers a new withdrawal obligation in the queue with the specified recipient, payout coins, and unique ID. Each obligation must have a non-zero payout amount. Recipient must be a valid bech32 address. Obligation id must equal the latest registered obligation id plus 1. |
 | **SettleNextObligation** | -                                                   | Settles the oldest withdrawal obligation in the queue by transferring funds from the **settlement input account** to the specified recipient. Fails if there are no pending obligations or if the input account has insufficient balance. |
 
 ## Configuration
@@ -40,7 +43,17 @@ pub struct LibraryConfig {
     /// settlement input account which we tap into in order
     /// to settle the obligations
     pub settlement_acc_addr: LibraryAccountType,
+    /// obligation base denom
+    pub denom: String,
+    /// latest registered obligation id.
+    /// if `None`, defaults to 0
+    pub latest_id: Option<Uint64>,
 }
 ```
 
 The `settlement_acc_addr` specifies the account from which funds will be pulled to fulfill settlement obligations. The library will check that this account has sufficient balance before attempting to settle each obligation.
+
+Configured `denom` is the base clearing denomination which will be applied to all obligation amounts.
+
+Lastly, the optional `latest_id` field allows to configure the library order to start from a specific id.
+If `None`, latest id defaults to 0. Otherwise, it will start from the specified id.


### PR DESCRIPTION
closes #366 

# Description

Updates the clearing queue library.

Main changes are as follows:

- library `Config` now stores two new fields: `denom: String` to identify the clearing denom, and `latest_id: Uint64` to track the latest registered obligation id
- `LibraryConfig` takes in a `latest_id: Option<Uint64>`: if set to `None`, the obligation queue starts processing withdraw obligations from id 0. Otherwise, it allows to configure a "starting point" id and beings incrementing it from there.
- `FunctionMsgs::RegisterObligation` now accepts `payout_amount: Uint128` instead of a vector of coins to match the coprocessor capabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a base denomination and an optional starting obligation ID for the clearing queue.
  - Obligations are now processed in strict, monotonically increasing order of IDs to prevent out-of-order errors.

- **Refactor**
  - Simplified obligation payouts to use a single amount in a fixed denomination instead of multiple coins.
  - Introduced richer obligation status tracking with explicit states: InQueue, Processed, and Error.
  - Updated related configuration, message structures, state management, and testing suite to reflect these changes.

- **Documentation**
  - Enhanced documentation to clarify obligation ordering, denomination configuration, and updated function parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->