### PR TITLE
feat: supervaults clearing queue internalize phase flag

### DIFF
--- a/contracts/authorization/schema/valence-authorization.json
+++ b/contracts/authorization/schema/valence-authorization.json
@@ -1708,11 +1708,19 @@
               "execute_zk_authorization": {
                 "type": "object",
                 "required": [
+                  "domain_message",
+                  "domain_proof",
                   "label",
                   "message",
                   "proof"
                 ],
                 "properties": {
+                  "domain_message": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "domain_proof": {
+                    "$ref": "#/definitions/Binary"
+                  },
                   "label": {
                     "type": "string"
                   },
@@ -2046,6 +2054,7 @@
       "ZkAuthorizationInfo": {
         "type": "object",
         "required": [
+          "domain_vk",
           "label",
           "mode",
           "registry",
@@ -2053,6 +2062,9 @@
           "vk"
         ],
         "properties": {
+          "domain_vk": {
+            "$ref": "#/definitions/Binary"
+          },
           "label": {
             "type": "string"
           },
@@ -4371,6 +4383,7 @@
         "ZkAuthorization": {
           "type": "object",
           "required": [
+            "domain_vk",
             "label",
             "mode",
             "registry",
@@ -4379,6 +4392,9 @@
             "vk"
           ],
           "properties": {
+            "domain_vk": {
+              "$ref": "#/definitions/Binary"
+            },
             "label": {
               "type": "string"
             },

--- a/contracts/libraries/clearing-queue-supervaults/schema/valence-clearing-queue-supervaults.json
+++ b/contracts/libraries/clearing-queue-supervaults/schema/valence-clearing-queue-supervaults.json
@@ -75,6 +75,7 @@
           "denom",
           "settlement_acc_addr",
           "supervault_addr",
+          "supervaults_phase",
           "supervaults_sender"
         ],
         "properties": {
@@ -104,6 +105,10 @@
           "supervault_addr": {
             "description": "supervaults address",
             "type": "string"
+          },
+          "supervaults_phase": {
+            "description": "vault phase flag: - true -> supervaults phase - false -> mars phase",
+            "type": "boolean"
           },
           "supervaults_sender": {
             "description": "supervaults provider addr",
@@ -424,6 +429,12 @@
               "null"
             ]
           },
+          "supervaults_phase": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "supervaults_sender": {
             "type": [
               "string",
@@ -626,7 +637,8 @@
         "latest_id",
         "settlement_acc_addr",
         "supervault_addr",
-        "supervault_sender"
+        "supervault_sender",
+        "supervaults_phase"
       ],
       "properties": {
         "denom": {
@@ -664,6 +676,10 @@
               "$ref": "#/definitions/Addr"
             }
           ]
+        },
+        "supervaults_phase": {
+          "description": "vault phase flag: - true -> supervaults phase - false -> mars phase",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -692,6 +708,7 @@
         "denom",
         "settlement_acc_addr",
         "supervault_addr",
+        "supervaults_phase",
         "supervaults_sender"
       ],
       "properties": {
@@ -721,6 +738,10 @@
         "supervault_addr": {
           "description": "supervaults address",
           "type": "string"
+        },
+        "supervaults_phase": {
+          "description": "vault phase flag: - true -> supervaults phase - false -> mars phase",
+          "type": "boolean"
         },
         "supervaults_sender": {
           "description": "supervaults provider addr",


### PR DESCRIPTION
# Description

- adds `supervaults_phase` bool flag to the library config
- clearing queue obligation registration now branches into different handlers (mars/supervaults) based on the flag which indicates the phase
