### PR TITLE
feat: add lombardTransfer to IBCEureka library

### DIFF
--- a/docs/src/libraries/evm/ibc_eureka_transfer.md
+++ b/docs/src/libraries/evm/ibc_eureka_transfer.md
@@ -1,12 +1,12 @@
 # IBC Eureka Transfer Library
 
-The IBC Eureka Transfer library enables transferring ERC20 tokens from an **input account** on an EVM chain to a **recipient** on an IBC Eureka connected chain using the IBC protocol via [IBC Eureka's Solidity implementation](https://docs.skip.build/go/eureka/eureka-overview). This library also takes advantage of [Skip Go API](https://docs.skip.build/go/general/getting-started) that provides an `EurekaHandler` wrapper and the relaying service for the underlying protocol. It is typically used as part of a **Valence Program**. In that context, a **Processor** contract will be the main contract interacting with the IBC Eureka Transfer library.
+The IBC Eureka Transfer library enables transferring ERC20 tokens from an **input account** on an EVM chain to a **recipient** on an IBC Eureka connected chain using the IBC V2 protocol via [IBC Eureka's Solidity implementation](https://docs.skip.build/go/eureka/eureka-overview). This library also takes advantage of [Skip Go API](https://docs.skip.build/go/general/getting-started) that provides an `EurekaHandler` wrapper and the relaying service for the underlying protocol. It is typically used as part of a **Valence Program**. In that context, a **Processor** contract will be the main contract interacting with the IBC Eureka Transfer library.
 
 ## High-level flow
 
 ```mermaid
 ---
-title: IBC Eureka Transfer Library
+title: IBC Eureka Transfer
 ---
 graph LR
     IA((Input Account))
@@ -33,41 +33,77 @@ graph LR
     SRC --- DEST
 ```
 
+```mermaid
+---
+title: IBC Eureka Lombard Transfer
+---
+graph LR
+    IA((Input Account))
+    R((Recipient))
+    EH((Eureka Handler))
+    ICS((ICS20Transfer))
+    P[Processor]
+    I[IBCEurekaTransfer
+    Library]
+    LV[LBTC Voucher]
+
+    subgraph DEST[ Lombard Ledger ]
+    R
+    end
+
+    subgraph SRC[ Source Chain ]
+    P -- 1/LombardTransfer(fees & memo) --> I
+    I -- 2/Query LBTC balance --> IA
+    IA -- 3/Approve LBTC --> EH
+    IA -- 4/Call lombardTransfer --> EH
+    EH -- 5/Transfer LBTC --> LV
+    LV -- 6/Mint voucher --> EH
+    EH -- 7/Forward voucher to ICS20 --> ICS
+    end
+
+    ICS -.6/IBC Packet.-> R
+    SRC --- DEST
+```
+
 ## Functions
 
-| Function     | Parameters                                                    | Description                                                                                                                                                                                                                                                                                     |
-| ------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Transfer** | `fees`: Relay fee structure<br>`memo`: Additional information | Transfer tokens from the configured **input account** to the **recipient** on the destination IBC chain. The `fees` parameter specifies relay fees, fee recipient, and quote expiry. The `memo` parameter can contain additional information that might execute logic on the destination chain. |
+| Function            | Parameters                                                    | Description                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Transfer**        | `fees`: Relay fee structure<br>`memo`: Additional information | Transfer tokens from the configured **input account** to the **recipient** on the destination IBC chain. The `fees` parameter specifies relay fees, fee recipient, and quote expiry. The `memo` parameter can contain additional information that might execute logic on the destination chain.             |
+| **LombardTransfer** | `fees`: Relay fee structure<br>`memo`: Additional information | Transfers LBTC from the configured **input account** to the **recipient** on the Lombard Ledger IBC chain. Works the same way as Transfer but is specific to LBTC transfers to Lombard chain where a burn of the LBTC token and a minting of a voucher happens before triggering the transfer using Eureka. |
 
 ## Configuration
 
 The library is configured on deployment using the `IBCEurekaTransferConfig` type.
 
 ```solidity
-/**
- * @dev Configuration struct for token transfer parameters.
- * @param amount The number of tokens to transfer. If set to 0, the entire balance is transferred.
- * @param transferToken The ERC20 token address that will be transferred.
- * @param inputAccount The account from which tokens will be debited.
- * @param recipient The recipient address on the destination IBC chain (in bech32 format).
- * @param sourceClient The source client identifier (e.g. cosmoshub-0).
- * @param timeout The timeout for the IBC transfer in seconds. Skip Go uses 12 hours (43200 seconds) as the default timeout.
- * @param eurekaHandler The EurekaHandler contract which is a wrapper around the ICS20Transfer contract.
- */
-struct IBCEurekaTransferConfig {
-    uint256 amount;
-    address transferToken;
-    BaseAccount inputAccount;
-    string recipient;
-    string sourceClient;
-    uint64 timeout;
-    IEurekaHandler eurekaHandler;
-}
+    /**
+     * @dev Configuration struct for token transfer parameters.
+     * @param amount The number of tokens to transfer. If set to 0, the entire balance is transferred.
+     * @param minAmountOut The minimum amount of tokens expected to be received on the destination chain. This is only used for Lombard transfers.
+     *                     If set to 0, same as amount will be used.
+     * @param transferToken The ERC20 token address that will be transferred.
+     * @param inputAccount The account from which tokens will be debited.
+     * @param recipient The recipient address on the destination IBC chain (in bech32 format).
+     * @param sourceClient The source client identifier (e.g. cosmoshub-0).
+     * @param timeout The timeout for the IBC transfer in seconds. Skip Go uses 12 hours (43200 seconds) as the default timeout.
+     * @param eurekaHandler The EurekaHandler contract which is a wrapper around the ICS20Transfer contract.
+     */
+    struct IBCEurekaTransferConfig {
+        uint256 amount;
+        uint256 minAmountOut;
+        address transferToken;
+        BaseAccount inputAccount;
+        string recipient;
+        string sourceClient;
+        uint64 timeout;
+        IEurekaHandler eurekaHandler;
+    }
 ```
 
 ## Special Considerations
 
-- The EurekaHandler contract on Ethereum that is used to transfer from Ethereum to CosmosHub is at `0xfc2d0487a0ae42ae7329a80dc269916a9184cf7c`.
+- The EurekaHandler contract on Ethereum that is used to transfer from Ethereum to IBC chains is at `0xfc2d0487a0ae42ae7329a80dc269916a9184cf7c`.
 - The recipient address is not in Bytes32 format but in the format used by the IBC chain (e.g., bech32: `cosmos1...`).
 - To build the `Fees` structure for the transfer, we query the Skip Go API to obtain all the necessary information. Here is an example of a query:
 
@@ -89,10 +125,10 @@ curl -X POST "https://go.skip.build/api/skip/v2/fungible/route" \
       "split_routes": true,
       "evm_swaps": true
     }
-  }
+  }'
 ```
 
-This is a query to obtain the fee information for transferring 20 ATOM from Ethereum (chain ID `1`) to the Cosmos Hub (chain ID `cosmoshub-4`). This will return us a response from which we can extract the `smart_relay_fee_quote` information that contains all the information to build the `Fees` structure. Important: The `quoteExpiry` timestamp of the `Fees` is passed in seconds.
+This is an example query to obtain the fee information for transferring 20 ATOM from Ethereum (chain ID `1`) to the Cosmos Hub (chain ID `cosmoshub-4`). This will return us a response from which we can extract the `smart_relay_fee_quote` information that contains all the information to build the `Fees` structure. Important: The `quoteExpiry` timestamp of the `Fees` is passed in seconds.
 
 - The memo can be used to execute logic on the destination chain. For example, if we want to execute a hop on the destination chain, we can use the memo to specify the hop parameters. Here is an example of a memo:
 

--- a/e2e/examples/eth_eureka_vault/evm.rs
+++ b/e2e/examples/eth_eureka_vault/evm.rs
@@ -163,6 +163,7 @@ pub fn setup_eureka_forwarder(
 
     let cfg = IBCEurekaTransferConfig {
         amount: U256::ZERO,
+        minAmountOut: U256::ZERO,
         transferToken: alloy_primitives_encoder::Address::from_str(
             transfer_token.to_string().as_str(),
         )?,

--- a/packages/encoder-utils/src/libraries/ibc_eureka_transfer/solidity_types.rs
+++ b/packages/encoder-utils/src/libraries/ibc_eureka_transfer/solidity_types.rs
@@ -3,6 +3,7 @@ use alloy_sol_types::sol;
 sol! {
     struct IBCEurekaTransferConfig {
         uint256 amount;
+        uint256 minAmountOut;
         address transferToken;
         address inputAccount;
         string recipient;
@@ -18,4 +19,6 @@ sol! {
     }
 
     function transfer(Fees calldata fees, string calldata memo) external;
+
+    function lombardTransfer(Fees calldata fees, string calldata memo) external;
 }

--- a/solidity/script/IBCEurekaTransfer.script.sol
+++ b/solidity/script/IBCEurekaTransfer.script.sol
@@ -59,6 +59,7 @@ contract IBCEurekaTransferScript is Script {
         // Deploy a new IBCEurekaTransfer contract with fixed amount
         IBCEurekaTransfer.IBCEurekaTransferConfig memory wethConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: tokenAmount,
+            minAmountOut: 0, // This won't be used for standard transfers, so we can set to 0 to take the transfer amount
             transferToken: WETH_ADDR,
             inputAccount: inputAccount,
             recipient: recipient,
@@ -108,6 +109,7 @@ contract IBCEurekaTransferScript is Script {
         vm.startPrank(owner);
         IBCEurekaTransfer.IBCEurekaTransferConfig memory fullBalanceConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 0, // 0 means transfer full balance
+            minAmountOut: 0,
             transferToken: WETH_ADDR,
             inputAccount: inputAccount,
             recipient: recipient,

--- a/solidity/script/LombardIBCEurekaTransfer.script.sol
+++ b/solidity/script/LombardIBCEurekaTransfer.script.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {Script} from "forge-std/src/Script.sol";
+import {IERC20} from "forge-std/src/interfaces/IERC20.sol";
+import {IBCEurekaTransfer} from "../src/libraries/IBCEurekaTransfer.sol";
+import {IEurekaHandler} from "../src/libraries/interfaces/eureka/IEurekaHandler.sol";
+import {BaseAccount} from "../src/accounts/BaseAccount.sol";
+import {console} from "forge-std/src/console.sol";
+
+contract LombardIBCEurekaTransferScript is Script {
+    // Address of the LBTC ERC-20 token on Ethereum
+    address constant LBTC_ADDR = 0x8236a87084f8B84306f72007F36F2618A5634494;
+
+    // Address of the Eureka Handler on Ethereum
+    address constant EUREKA_HANDLER = 0xFc2d0487A0ae42ae7329a80dc269916A9184cF7C;
+
+    // Address of LBTC Whale
+    address constant LBTC_WHALE = 0x89F2de2b541C443745E180b239A8110abB9d00f4;
+
+    // Example addresses for owner, processor, and fee recipient
+    address owner = address(1);
+    address processor = address(2);
+    address feeRecipient = address(3);
+
+    // Contracts
+    IBCEurekaTransfer public ibcEurekaTransfer;
+    IBCEurekaTransfer public ibcEurekaTransferFull;
+    BaseAccount inputAccount;
+
+    // Lombard recipient address in bech32 format
+    string recipient = "lom14mlpd48k5vkeset4x7f78myz3m47jcaxp0gn00";
+    string sourceClient = "ledger-mainnet-1";
+
+    function run() external {
+        // Create a fork of Ethereum mainnet and switch to it
+        uint256 forkId = vm.createFork("https://eth-mainnet.public.blastapi.io");
+        vm.selectFork(forkId);
+
+        // Start broadcasting transactions
+        vm.startPrank(owner);
+
+        // Deploy a new BaseAccount contract
+        inputAccount = new BaseAccount(owner, new address[](0));
+
+        vm.stopPrank();
+
+        // Fund the input account with WETH
+        vm.startPrank(LBTC_WHALE);
+        uint256 amountToFund = 1 * 10 ** 8; // 1 LBTC (has 8 decimals)
+        IERC20(LBTC_ADDR).transfer(address(inputAccount), amountToFund);
+        vm.stopPrank();
+
+        uint64 timeoutTimestamp = 3600; // 1 hour timeout
+
+        vm.startPrank(owner);
+        // Deploy a new IBCEurekaTransfer contract with fixed amount
+        IBCEurekaTransfer.IBCEurekaTransferConfig memory lbtcConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
+            amount: 0, // 0 means transfer the entire amount
+            minAmountOut: 0, // Means same as amount
+            transferToken: LBTC_ADDR,
+            inputAccount: inputAccount,
+            recipient: recipient,
+            sourceClient: sourceClient,
+            timeout: timeoutTimestamp,
+            eurekaHandler: IEurekaHandler(EUREKA_HANDLER)
+        });
+        bytes memory lbtcConfigBytes = abi.encode(lbtcConfig);
+        ibcEurekaTransfer = new IBCEurekaTransfer(owner, processor, lbtcConfigBytes);
+
+        // Approve the library from the input account
+        inputAccount.approveLibrary(address(ibcEurekaTransfer));
+
+        vm.stopPrank();
+
+        // Get the balance before the transfer of the inputAccount
+        uint256 lbtcBalanceBefore = IERC20(LBTC_ADDR).balanceOf(address(inputAccount));
+        console.log("LBTC balance before transfer: ", lbtcBalanceBefore);
+
+        // Create a fee structure for the transfer
+        IEurekaHandler.Fees memory fees = IEurekaHandler.Fees({
+            relayFee: 1000, // 1000 units of LBTC as relay fee
+            relayFeeRecipient: feeRecipient,
+            quoteExpiry: uint64(block.timestamp + 300) // Quote expires in 5 minutes
+        });
+
+        // Execute the LBTC transfer
+        vm.prank(processor);
+        ibcEurekaTransfer.transfer(fees, "");
+
+        // Get the balance after the transfer
+        uint256 lbtcBalanceAfter = IERC20(LBTC_ADDR).balanceOf(address(inputAccount));
+        console.log("LBTC balance after transfer: ", lbtcBalanceAfter);
+
+        // Verify that balance was deducted
+        assert(lbtcBalanceBefore > lbtcBalanceAfter);
+        assert(lbtcBalanceAfter == 0); // All LBTC should be transferred
+
+        // Check that fee recipient received the fees
+        uint256 feeRecipientBalance = IERC20(LBTC_ADDR).balanceOf(feeRecipient);
+        console.log("Fee recipient balance: ", feeRecipientBalance);
+        assert(feeRecipientBalance == 1000); // The relay fee amount
+    }
+}

--- a/solidity/script/LombardIBCEurekaTransfer.script.sol
+++ b/solidity/script/LombardIBCEurekaTransfer.script.sol
@@ -25,7 +25,6 @@ contract LombardIBCEurekaTransferScript is Script {
 
     // Contracts
     IBCEurekaTransfer public ibcEurekaTransfer;
-    IBCEurekaTransfer public ibcEurekaTransferFull;
     BaseAccount inputAccount;
 
     // Lombard recipient address in bech32 format
@@ -84,9 +83,9 @@ contract LombardIBCEurekaTransferScript is Script {
             quoteExpiry: uint64(block.timestamp + 300) // Quote expires in 5 minutes
         });
 
-        // Execute the LBTC transfer
+        // Execute the LBTC lombard transfer
         vm.prank(processor);
-        ibcEurekaTransfer.transfer(fees, "");
+        ibcEurekaTransfer.lombardTransfer(fees, "");
 
         // Get the balance after the transfer
         uint256 lbtcBalanceAfter = IERC20(LBTC_ADDR).balanceOf(address(inputAccount));

--- a/solidity/src/libraries/IBCEurekaTransfer.sol
+++ b/solidity/src/libraries/IBCEurekaTransfer.sol
@@ -15,6 +15,8 @@ contract IBCEurekaTransfer is Library {
     /**
      * @dev Configuration struct for token transfer parameters.
      * @param amount The number of tokens to transfer. If set to 0, the entire balance is transferred.
+     * @param minAmountOut The minimum amount of tokens expected to be received on the destination chain. This is only used for Lombard transfers.
+     *                     If set to 0, same as amount will be used.
      * @param transferToken The ERC20 token address that will be transferred.
      * @param inputAccount The account from which tokens will be debited.
      * @param recipient The recipient address on the destination IBC chain (in bech32 format).
@@ -24,6 +26,7 @@ contract IBCEurekaTransfer is Library {
      */
     struct IBCEurekaTransferConfig {
         uint256 amount;
+        uint256 minAmountOut;
         address transferToken;
         BaseAccount inputAccount;
         string recipient;
@@ -75,6 +78,11 @@ contract IBCEurekaTransfer is Library {
             revert("Timeout can't be zero");
         }
 
+        // Min amount out cannot be greater than amount.
+        if (decodedConfig.minAmountOut > decodedConfig.amount) {
+            revert("Min amount out cannot be greater than amount");
+        }
+
         return decodedConfig;
     }
 
@@ -113,8 +121,86 @@ contract IBCEurekaTransfer is Library {
      * - The input account must hold enough tokens.
      */
     function transfer(IEurekaHandler.Fees calldata fees, string calldata memo) external onlyProcessor {
+        // Perform common validation and get transfer amounts and params
+        (
+            IBCEurekaTransferConfig memory _config,
+            uint256 amountToTransfer,
+            IEurekaHandler.TransferParams memory transferParams
+        ) = _validateTransferAndPrepareParams(fees, memo);
+
+        // Encode the approval call: this allows the Eureka Handler to spend the tokens.
+        bytes memory encodedApproveCall =
+            abi.encodeCall(IERC20.approve, (address(_config.eurekaHandler), amountToTransfer + fees.relayFee));
+
+        // Encode the transfer call
+        bytes memory encodedTransferCall =
+            abi.encodeCall(IEurekaHandler.transfer, (amountToTransfer, transferParams, fees));
+
+        // Execute the approval call on the input account.
+        _config.inputAccount.execute(_config.transferToken, 0, encodedApproveCall);
+        // Execute the token transfer call via the Eureka Handler.
+        _config.inputAccount.execute(address(_config.eurekaHandler), 0, encodedTransferCall);
+
+        emit EurekaTransfer(_config.recipient, amountToTransfer);
+    }
+
+    /**
+     * @dev Executes the lombard token transfer using the IBC Eureka protocol via an EurekaHandler contract.
+     *
+     * This works the same as the normal transfer but has the lombard functionality on top of it. This means there
+     * is a burning of the lombard token and a minting of the voucher to be transferred happening before the transfer itself.
+     *
+     * @param fees The fee structure containing relay fees, recipient of the relay fees and quote expiry.
+     * @param memo Additional information to be included with the transfer. Can execute logic on the destination chain. Can be empty if not required.
+     *
+     */
+    function lombardTransfer(IEurekaHandler.Fees calldata fees, string calldata memo) external onlyProcessor {
+        // Perform common validation and get transfer amounts and params
+        (
+            IBCEurekaTransferConfig memory _config,
+            uint256 amountToTransfer,
+            IEurekaHandler.TransferParams memory transferParams
+        ) = _validateTransferAndPrepareParams(fees, memo);
+
+        // Lombard transfers require a minimum amount out to be specified.
+        // If minAmountOut is not set, use the amount to transfer as the minimum.
+        uint256 minAmountOut = _config.minAmountOut > 0 ? _config.minAmountOut : amountToTransfer;
+
+        // Encode the approval call: this allows the Eureka Handler to spend the tokens.
+        bytes memory encodedApproveCall =
+            abi.encodeCall(IERC20.approve, (address(_config.eurekaHandler), amountToTransfer + fees.relayFee));
+
+        // Encode the transfer call
+        bytes memory encodedTransferCall =
+            abi.encodeCall(IEurekaHandler.lombardTransfer, (amountToTransfer, minAmountOut, transferParams, fees));
+
+        // Execute the approval call on the input account.
+        _config.inputAccount.execute(_config.transferToken, 0, encodedApproveCall);
+        // Execute the token transfer call via the Eureka Handler.
+        _config.inputAccount.execute(address(_config.eurekaHandler), 0, encodedTransferCall);
+
+        emit EurekaTransfer(_config.recipient, amountToTransfer);
+    }
+
+    /**
+     * @dev Internal function that validates transfer conditions, calculates amounts, and prepares transfer parameters.
+     * @param fees The fee structure for the transfer
+     * @param memo Additional information to be included with the transfer
+     * @return _config The loaded configuration struct
+     * @return amountToTransfer The final amount to transfer (after deducting relay fees)
+     * @return transferParams The prepared TransferParams struct for the transfer
+     */
+    function _validateTransferAndPrepareParams(IEurekaHandler.Fees calldata fees, string calldata memo)
+        internal
+        view
+        returns (
+            IBCEurekaTransferConfig memory _config,
+            uint256 amountToTransfer,
+            IEurekaHandler.TransferParams memory transferParams
+        )
+    {
         // Retrieve the current configuration into a local variable.
-        IBCEurekaTransferConfig memory _config = config;
+        _config = config;
 
         // Check the token balance of the input account.
         uint256 balance = IERC20(_config.transferToken).balanceOf(address(_config.inputAccount));
@@ -134,13 +220,10 @@ contract IBCEurekaTransfer is Library {
         }
 
         // Subtract the relay fee from the amount to be transferred.
-        uint256 amountToTransfer = amount - fees.relayFee;
-
-        // Encode the approval call: this allows the Eureka Handler to spend the tokens.
-        bytes memory encodedApproveCall = abi.encodeCall(IERC20.approve, (address(_config.eurekaHandler), amount));
+        amountToTransfer = amount - fees.relayFee;
 
         // Build the TransferParams struct for the transfer.
-        IEurekaHandler.TransferParams memory transferParams = IEurekaHandler.TransferParams({
+        transferParams = IEurekaHandler.TransferParams({
             token: _config.transferToken,
             recipient: _config.recipient,
             sourceClient: _config.sourceClient,
@@ -148,16 +231,5 @@ contract IBCEurekaTransfer is Library {
             timeoutTimestamp: uint64(block.timestamp) + _config.timeout,
             memo: memo
         });
-
-        // Encode the transfer call
-        bytes memory encodedTransferCall =
-            abi.encodeCall(IEurekaHandler.transfer, (amountToTransfer, transferParams, fees));
-
-        // Execute the approval call on the input account.
-        _config.inputAccount.execute(_config.transferToken, 0, encodedApproveCall);
-        // Execute the token transfer call via the Eureka Handler.
-        _config.inputAccount.execute(address(_config.eurekaHandler), 0, encodedTransferCall);
-
-        emit EurekaTransfer(_config.recipient, amountToTransfer);
     }
 }

--- a/solidity/src/libraries/IBCEurekaTransfer.sol
+++ b/solidity/src/libraries/IBCEurekaTransfer.sol
@@ -78,8 +78,8 @@ contract IBCEurekaTransfer is Library {
             revert("Timeout can't be zero");
         }
 
-        // Min amount out cannot be greater than amount.
-        if (decodedConfig.minAmountOut > decodedConfig.amount) {
+        // Min amount out cannot be greater than amount when amount is not zero
+        if (decodedConfig.amount > 0 && decodedConfig.minAmountOut > decodedConfig.amount) {
             revert("Min amount out cannot be greater than amount");
         }
 

--- a/solidity/src/libraries/interfaces/eureka/IEurekaHandler.sol
+++ b/solidity/src/libraries/interfaces/eureka/IEurekaHandler.sol
@@ -19,4 +19,11 @@ interface IEurekaHandler {
     }
 
     function transfer(uint256 amount, TransferParams memory transferParams, Fees memory fees) external;
+
+    function lombardTransfer(
+        uint256 amount,
+        uint256 minAmountOut,
+        TransferParams memory transferParams,
+        Fees memory fees
+    ) external;
 }

--- a/solidity/test/libraries/IBCEurekaTransfer.t.sol
+++ b/solidity/test/libraries/IBCEurekaTransfer.t.sol
@@ -181,6 +181,23 @@ contract IBCEurekaTransferTest is Test {
         assertEq(newTimeout, 1200, "Timeout should be updated");
     }
 
+    function testUpdateWithZeroAmountAndMinAmountSucceeds() public {
+        IBCEurekaTransfer.IBCEurekaTransferConfig memory validConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
+            amount: 0, // Valid case - full balance
+            minAmountOut: 2000, // Valid case - receive at least 2000
+            transferToken: address(token),
+            inputAccount: inputAccount,
+            recipient: recipient,
+            sourceClient: sourceClient,
+            timeout: timeout,
+            eurekaHandler: mockEurekaHandler
+        });
+
+        bytes memory configBytes = abi.encode(validConfig);
+        vm.prank(owner);
+        ibcEurekaTransfer.updateConfig(configBytes);
+    }
+
     function testTransferFailsNoTokenBalance() public {
         // No tokens provided to the input account
 

--- a/solidity/test/libraries/IBCEurekaTransfer.t.sol
+++ b/solidity/test/libraries/IBCEurekaTransfer.t.sol
@@ -39,6 +39,7 @@ contract IBCEurekaTransferTest is Test {
         // Create a valid configuration for token transfer
         IBCEurekaTransfer.IBCEurekaTransferConfig memory validConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 1000,
+            minAmountOut: 0,
             transferToken: address(token),
             inputAccount: inputAccount,
             recipient: recipient,
@@ -57,6 +58,7 @@ contract IBCEurekaTransferTest is Test {
     function testUpdateConfigFailsZeroEurekaHandler() public {
         IBCEurekaTransfer.IBCEurekaTransferConfig memory invalidConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 1000,
+            minAmountOut: 0,
             transferToken: address(token),
             inputAccount: inputAccount,
             recipient: recipient,
@@ -74,6 +76,7 @@ contract IBCEurekaTransferTest is Test {
     function testUpdateConfigFailsZeroTransferToken() public {
         IBCEurekaTransfer.IBCEurekaTransferConfig memory invalidConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 1000,
+            minAmountOut: 0,
             transferToken: address(0), // Zero address (invalid)
             inputAccount: inputAccount,
             recipient: recipient,
@@ -91,6 +94,7 @@ contract IBCEurekaTransferTest is Test {
     function testUpdateConfigFailsZeroInputAccount() public {
         IBCEurekaTransfer.IBCEurekaTransferConfig memory invalidConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 1000,
+            minAmountOut: 0,
             transferToken: address(token),
             inputAccount: BaseAccount(payable(address(0))), // Zero address (invalid)
             recipient: recipient,
@@ -108,6 +112,7 @@ contract IBCEurekaTransferTest is Test {
     function testUpdateConfigFailsZeroTimeout() public {
         IBCEurekaTransfer.IBCEurekaTransferConfig memory invalidConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 1000,
+            minAmountOut: 0,
             transferToken: address(token),
             inputAccount: inputAccount,
             recipient: recipient,
@@ -122,9 +127,28 @@ contract IBCEurekaTransferTest is Test {
         ibcEurekaTransfer.updateConfig(configBytes);
     }
 
+    function testUpdateConfigFailsInvalidMinAmountOut() public {
+        IBCEurekaTransfer.IBCEurekaTransferConfig memory invalidConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
+            amount: 1000,
+            minAmountOut: 20000, // Invalid min amount out (greater than amount)
+            transferToken: address(token),
+            inputAccount: inputAccount,
+            recipient: recipient,
+            sourceClient: sourceClient,
+            timeout: timeout,
+            eurekaHandler: mockEurekaHandler
+        });
+
+        bytes memory configBytes = abi.encode(invalidConfig);
+        vm.prank(owner);
+        vm.expectRevert("Min amount out cannot be greater than amount");
+        ibcEurekaTransfer.updateConfig(configBytes);
+    }
+
     function testUpdateConfigSucceeds() public {
         IBCEurekaTransfer.IBCEurekaTransferConfig memory validConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 2000, // Different amount
+            minAmountOut: 2000,
             transferToken: address(token),
             inputAccount: inputAccount,
             recipient: "cosmos1abc...", // Different recipient
@@ -140,6 +164,7 @@ contract IBCEurekaTransferTest is Test {
         // Verify config was updated successfully
         (
             uint256 newAmount,
+            uint256 newMinAmountOut,
             address newToken,
             BaseAccount newAccount,
             string memory newRecipient,
@@ -148,6 +173,7 @@ contract IBCEurekaTransferTest is Test {
         ) = ibcEurekaTransfer.config();
 
         assertEq(newAmount, 2000, "Amount should be updated");
+        assertEq(newMinAmountOut, 2000, "Min amount out should be updated");
         assertEq(newToken, address(token), "Token should be unchanged");
         assertEq(address(newAccount), address(inputAccount), "Account should be unchanged");
         assertEq(keccak256(bytes(newRecipient)), keccak256(bytes("cosmos1abc...")), "Recipient should be updated");
@@ -233,6 +259,7 @@ contract IBCEurekaTransferTest is Test {
         // Update config to transfer full token balance
         IBCEurekaTransfer.IBCEurekaTransferConfig memory fullConfig = IBCEurekaTransfer.IBCEurekaTransferConfig({
             amount: 0, // Transfer full balance
+            minAmountOut: 0,
             transferToken: address(token),
             inputAccount: inputAccount,
             recipient: recipient,


### PR DESCRIPTION
Adds the lombardTransfer function to the EurekaLibrary API.

This adds a new parameter requried for lombardTransfer (minAmountOut) to the config, that will only be used for these kind of transfers. Works the same as regular transfers but instead it's a special use case for LBTC that mints the voucher and transfers that via Eureka. All this extra functionalty is abstracted by the lombardTransfer function that was added to the EurekaHandler by Skip, so we don't need to worry about that logic, just in calling the right function.

Modified the doc section with the new use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Lombard token transfers, enabling a new transfer type with minimum output enforcement.
  - Introduced a new configuration parameter to specify the minimum amount expected on the destination chain for Lombard transfers.
  - Added a new Lombard transfer function accessible via the user interface and contract.
  - Provided a new script to simulate and test Lombard transfers on an Ethereum mainnet fork.

- **Documentation**
  - Updated documentation to describe Lombard transfers, including new diagrams and usage instructions.
  - Clarified protocol version and improved explanations for transfer flows and configuration options.

- **Bug Fixes**
  - Enhanced validation to prevent misconfiguration of minimum output amounts in transfer settings.

- **Tests**
  - Expanded test coverage to include Lombard transfer scenarios and validation of the new minimum output parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->