### PR TITLE
chore: update supervault libraries to use queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,8 +5669,8 @@ dependencies = [
 
 [[package]]
 name = "mmvault"
-version = "0.1.4"
-source = "git+https://github.com/neutron-org/slinky-vault#0432ad77ca44c8166401a31e4b7319cbf9cdebeb"
+version = "0.1.6"
+source = "git+https://github.com/neutron-org/slinky-vault#8511585e564bca12e814e0c8692add7ae7e3f536"
 dependencies = [
  "cosmwasm-std 2.2.1",
  "cw-storage-plus 2.0.0",

--- a/contracts/libraries/supervaults-withdrawer/src/contract.rs
+++ b/contracts/libraries/supervaults-withdrawer/src/contract.rs
@@ -1,12 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    ensure, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdResult,
-};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use valence_library_utils::{
     error::LibraryError,
-    execute_on_behalf_of,
     msg::{ExecuteMsg, InstantiateMsg},
 };
 
@@ -15,7 +11,6 @@ use crate::msg::{Config, FunctionMsgs, LibraryConfig, LibraryConfigUpdate, Query
 // version info for migration info
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const LW_REPLY_ID: u64 = 1414;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -63,16 +58,12 @@ mod execute {
 mod functions {
 
     use cosmwasm_std::{
-        ensure, to_json_binary, to_json_string, DepsMut, Env, MessageInfo, Response, SubMsg,
-        WasmMsg,
+        coin, ensure, to_json_binary, BankMsg, Coin, DepsMut, Env, MessageInfo, Response, WasmMsg,
     };
-    use valence_library_utils::{error::LibraryError, execute_submsgs_on_behalf_of};
+    use valence_library_utils::{error::LibraryError, execute_on_behalf_of};
     use valence_supervaults_utils::prec_dec_range::PrecDecimalRange;
 
-    use crate::{
-        contract::LW_REPLY_ID,
-        msg::{Config, FunctionMsgs},
-    };
+    use crate::msg::{Config, FunctionMsgs};
 
     pub fn process_function(
         deps: DepsMut,
@@ -123,64 +114,48 @@ mod functions {
             msg: to_json_binary(&valence_supervaults_utils::msg::get_mmvault_withdraw_msg(
                 input_acc_lp_bal.amount,
             ))?,
-            funds: vec![input_acc_lp_bal],
-        };
-
-        // delegate the supervaults withdraw request to the input account
-        // as a submessage
-        let delegated_input_account_submsgs = execute_submsgs_on_behalf_of(
-            vec![SubMsg::reply_on_success(withdraw_msg, LW_REPLY_ID)],
-            Some(to_json_string(&cfg)?),
-            &cfg.input_addr,
-        )?;
-
-        Ok(Response::new().add_submessage(SubMsg::reply_on_success(
-            delegated_input_account_submsgs,
-            LW_REPLY_ID,
-        )))
-    }
-}
-
-#[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, LibraryError> {
-    match msg.id {
-        LW_REPLY_ID => {
-            // extract configuration from the reply payload
-            let cfg: Config = valence_account_utils::msg::parse_valence_payload(&msg.result)?;
-
-            // query the input account resulting asset balance after withdrawal
-            let asset1_balance = deps
-                .querier
-                .query_balance(&cfg.input_addr, &cfg.lw_config.asset_data.asset1)?;
-            let asset2_balance = deps
-                .querier
-                .query_balance(&cfg.input_addr, &cfg.lw_config.asset_data.asset2)?;
-
-            // filter out zero-amount balances
-            let available_assets: Vec<Coin> = [asset1_balance, asset2_balance]
-                .into_iter()
-                .filter(|c| !c.amount.is_zero())
-                .collect();
-
-            ensure!(
-                !available_assets.is_empty(),
-                LibraryError::ExecutionError(
-                    "supervaults liquidity withdrawal resulted in no expected assets".to_string()
-                )
-            );
-
-            // construct the resulting asset transfer message to the output account
-            let asset_transfer_msg: CosmosMsg = BankMsg::Send {
-                to_address: cfg.output_addr.to_string(),
-                amount: available_assets,
-            }
-            .into();
-
-            let delegated_msg = execute_on_behalf_of(vec![asset_transfer_msg], &cfg.input_addr)?;
-
-            Ok(Response::default().add_message(delegated_msg))
+            funds: vec![input_acc_lp_bal.clone()],
         }
-        _ => Err(LibraryError::ExecutionError("unknown reply id".to_string())),
+        .into();
+
+        // Check how much we are going to receive by simulating the withdraw
+        let (amount_asset1, amount_asset2) =
+            valence_supervaults_utils::queries::query_simulate_withdraw_liquidity(
+                deps.as_ref(),
+                cfg.vault_addr.to_string(),
+                input_acc_lp_bal.amount,
+            )?;
+
+        // Construct the array of coins to be sent from the input account to the output account
+        // If for some reason any of the amounts is zero, we do not include it in the withdraw assets
+        // Shouldn't happen, but it's a sanity check
+        let withdrawn_assets: Vec<Coin> = [
+            (amount_asset1, cfg.lw_config.asset_data.asset1),
+            (amount_asset2, cfg.lw_config.asset_data.asset2),
+        ]
+        .into_iter()
+        .filter_map(|(amount, asset)| (!amount.is_zero()).then(|| coin(amount.u128(), asset)))
+        .collect();
+
+        ensure!(
+            !withdrawn_assets.is_empty(),
+            LibraryError::ExecutionError("Nothing is being withdrawn!".to_string())
+        );
+
+        // Construct the bank message to transfer the withdrawn assets to the output account
+        let transfer_assets_msg = BankMsg::Send {
+            to_address: cfg.output_addr.to_string(),
+            amount: withdrawn_assets.clone(),
+        }
+        .into();
+
+        // Execute both messages on behalf of input_addr
+        let execute_msg =
+            execute_on_behalf_of(vec![withdraw_msg, transfer_assets_msg], &cfg.input_addr)?;
+
+        Ok(Response::new()
+            .add_message(execute_msg)
+            .add_attribute("method", "withdraw_liquidity"))
     }
 }
 

--- a/packages/supervaults-utils/src/queries.rs
+++ b/packages/supervaults-utils/src/queries.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Deps;
+use cosmwasm_std::{Addr, CosmosMsg, Deps, Uint128};
 use neutron_std::types::neutron::util::precdec::PrecDec;
 use valence_library_utils::error::LibraryError;
 
@@ -8,4 +8,36 @@ pub fn query_vault_price(deps: Deps, vault_addr: String) -> Result<PrecDec, Libr
         .query_wasm_smart(vault_addr, &mmvault::msg::QueryMsg::GetPrices {})?;
 
     Ok(price_response.price_0_to_1)
+}
+
+pub fn query_simulate_provide_liquidity(
+    deps: Deps,
+    vault_addr: String,
+    sender: Addr,
+    amount_0: Uint128,
+    amount_1: Uint128,
+) -> Result<Uint128, LibraryError> {
+    let simulate_response: Uint128 = deps.querier.query_wasm_smart(
+        vault_addr,
+        &mmvault::msg::QueryMsg::SimulateProvideLiquidity {
+            amount_0,
+            amount_1,
+            sender,
+        },
+    )?;
+
+    Ok(simulate_response)
+}
+
+pub fn query_simulate_withdraw_liquidity(
+    deps: Deps,
+    vault_addr: String,
+    amount: Uint128,
+) -> Result<(Uint128, Uint128), LibraryError> {
+    let simulate_response: (Vec<CosmosMsg>, Uint128, Uint128) = deps.querier.query_wasm_smart(
+        vault_addr,
+        &mmvault::msg::QueryMsg::SimulateWithdrawLiquidity { amount },
+    )?;
+
+    Ok((simulate_response.1, simulate_response.2))
 }


### PR DESCRIPTION
Update the supervault lper and withdrawer to use the simulate queries to know how much is going to be deposited/withdrawn and don't rely on the reply entry points to transfer the funds to the output account there