### PR TITLE
feat: update supervaults clearing queue to allow multiple supervaults

### DIFF
--- a/contracts/libraries/clearing-queue-supervaults/schema/valence-clearing-queue-supervaults.json
+++ b/contracts/libraries/clearing-queue-supervaults/schema/valence-clearing-queue-supervaults.json
@@ -24,6 +24,10 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
       "LibraryAccountType": {
         "description": "A helper type that is used to associate an account or library with an id When a program is not instantiated yet, ids will be used to reference accounts and libraries When a program is instantiated, the ids will be replaced by the instantiated addresses",
         "oneOf": [
@@ -73,10 +77,9 @@
         "type": "object",
         "required": [
           "denom",
+          "mars_settlement_ratio",
           "settlement_acc_addr",
-          "supervault_addr",
-          "supervaults_phase",
-          "supervaults_sender"
+          "supervaults_settlement_info"
         ],
         "properties": {
           "denom": {
@@ -84,13 +87,21 @@
             "type": "string"
           },
           "latest_id": {
-            "description": "latest registered obligation id. if `None`, defaults to 0",
+            "description": "latest registered obligation id.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Uint64"
               },
               {
                 "type": "null"
+              }
+            ]
+          },
+          "mars_settlement_ratio": {
+            "description": "mars settlement ratio",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Decimal"
               }
             ]
           },
@@ -102,17 +113,47 @@
               }
             ]
           },
+          "supervaults_settlement_info": {
+            "description": "supervaults settlement information",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SupervaultSettlementInfo"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupervaultSettlementInfo": {
+        "type": "object",
+        "required": [
+          "settlement_ratio",
+          "supervault_addr",
+          "supervault_sender"
+        ],
+        "properties": {
+          "settlement_ratio": {
+            "description": "settlement ratio",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Decimal"
+              }
+            ]
+          },
           "supervault_addr": {
             "description": "supervaults address",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
           },
-          "supervaults_phase": {
-            "description": "vault phase flag: - true -> supervaults phase - false -> mars phase",
-            "type": "boolean"
-          },
-          "supervaults_sender": {
-            "description": "supervaults provider addr",
-            "type": "string"
+          "supervault_sender": {
+            "description": "supervault provider address",
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -246,6 +287,10 @@
             ]
           }
         ]
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
       },
       "Expiration": {
         "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
@@ -413,6 +458,16 @@
           "latest_id": {
             "$ref": "#/definitions/OptionUpdate_for_Uint64"
           },
+          "mars_settlement_ratio": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Decimal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "settlement_acc_addr": {
             "anyOf": [
               {
@@ -423,23 +478,14 @@
               }
             ]
           },
-          "supervault_addr": {
+          "supervaults_settlement_info": {
             "type": [
-              "string",
+              "array",
               "null"
-            ]
-          },
-          "supervaults_phase": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "supervaults_sender": {
-            "type": [
-              "string",
-              "null"
-            ]
+            ],
+            "items": {
+              "$ref": "#/definitions/SupervaultSettlementInfo"
+            }
           }
         },
         "additionalProperties": false
@@ -472,6 +518,41 @@
             "additionalProperties": false
           }
         ]
+      },
+      "SupervaultSettlementInfo": {
+        "type": "object",
+        "required": [
+          "settlement_ratio",
+          "supervault_addr",
+          "supervault_sender"
+        ],
+        "properties": {
+          "settlement_ratio": {
+            "description": "settlement ratio",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Decimal"
+              }
+            ]
+          },
+          "supervault_addr": {
+            "description": "supervaults address",
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
+          },
+          "supervault_sender": {
+            "description": "supervault provider address",
+            "allOf": [
+              {
+                "$ref": "#/definitions/LibraryAccountType"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
       },
       "Timestamp": {
         "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
@@ -634,11 +715,9 @@
       "type": "object",
       "required": [
         "denom",
-        "latest_id",
+        "mars_settlement_ratio",
         "settlement_acc_addr",
-        "supervault_addr",
-        "supervault_sender",
-        "supervaults_phase"
+        "supervaults_settlement_info"
       ],
       "properties": {
         "denom": {
@@ -646,10 +725,21 @@
           "type": "string"
         },
         "latest_id": {
-          "description": "latest registered obligation id",
-          "allOf": [
+          "description": "latest registered obligation id. `None` indicates that no obligations have been registered yet (and expects id=0 for next).",
+          "anyOf": [
             {
               "$ref": "#/definitions/Uint64"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mars_settlement_ratio": {
+          "description": "mars settlement ratio",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Decimal"
             }
           ]
         },
@@ -661,25 +751,12 @@
             }
           ]
         },
-        "supervault_addr": {
-          "description": "supervaults address",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            }
-          ]
-        },
-        "supervault_sender": {
-          "description": "supervaults provider addr",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            }
-          ]
-        },
-        "supervaults_phase": {
-          "description": "vault phase flag: - true -> supervaults phase - false -> mars phase",
-          "type": "boolean"
+        "supervaults_settlement_info": {
+          "description": "supervaults settlement information",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValidatedSupervaultSettlementInfo"
+          }
         }
       },
       "additionalProperties": false,
@@ -688,9 +765,48 @@
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
         "Uint64": {
           "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
+        },
+        "ValidatedSupervaultSettlementInfo": {
+          "type": "object",
+          "required": [
+            "settlement_ratio",
+            "supervault_addr",
+            "supervault_sender"
+          ],
+          "properties": {
+            "settlement_ratio": {
+              "description": "settlement ratio",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                }
+              ]
+            },
+            "supervault_addr": {
+              "description": "supervaults address",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            },
+            "supervault_sender": {
+              "description": "supervault provider address",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -706,10 +822,9 @@
       "type": "object",
       "required": [
         "denom",
+        "mars_settlement_ratio",
         "settlement_acc_addr",
-        "supervault_addr",
-        "supervaults_phase",
-        "supervaults_sender"
+        "supervaults_settlement_info"
       ],
       "properties": {
         "denom": {
@@ -717,13 +832,21 @@
           "type": "string"
         },
         "latest_id": {
-          "description": "latest registered obligation id. if `None`, defaults to 0",
+          "description": "latest registered obligation id.",
           "anyOf": [
             {
               "$ref": "#/definitions/Uint64"
             },
             {
               "type": "null"
+            }
+          ]
+        },
+        "mars_settlement_ratio": {
+          "description": "mars settlement ratio",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Decimal"
             }
           ]
         },
@@ -735,21 +858,20 @@
             }
           ]
         },
-        "supervault_addr": {
-          "description": "supervaults address",
-          "type": "string"
-        },
-        "supervaults_phase": {
-          "description": "vault phase flag: - true -> supervaults phase - false -> mars phase",
-          "type": "boolean"
-        },
-        "supervaults_sender": {
-          "description": "supervaults provider addr",
-          "type": "string"
+        "supervaults_settlement_info": {
+          "description": "supervaults settlement information",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SupervaultSettlementInfo"
+          }
         }
       },
       "additionalProperties": false,
       "definitions": {
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
         "LibraryAccountType": {
           "description": "A helper type that is used to associate an account or library with an id When a program is not instantiated yet, ids will be used to reference accounts and libraries When a program is instantiated, the ids will be replaced by the instantiated addresses",
           "oneOf": [
@@ -794,6 +916,41 @@
               "additionalProperties": false
             }
           ]
+        },
+        "SupervaultSettlementInfo": {
+          "type": "object",
+          "required": [
+            "settlement_ratio",
+            "supervault_addr",
+            "supervault_sender"
+          ],
+          "properties": {
+            "settlement_ratio": {
+              "description": "settlement ratio",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                }
+              ]
+            },
+            "supervault_addr": {
+              "description": "supervaults address",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/LibraryAccountType"
+                }
+              ]
+            },
+            "supervault_sender": {
+              "description": "supervault provider address",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/LibraryAccountType"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         },
         "Uint64": {
           "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -1009,7 +1166,7 @@
           "required": [
             "enqueue_block",
             "id",
-            "payout_coin",
+            "payout_coins",
             "recipient"
           ],
           "properties": {
@@ -1029,13 +1186,12 @@
                 }
               ]
             },
-            "payout_coin": {
+            "payout_coins": {
               "description": "what is owed to the recipient",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Coin"
-                }
-              ]
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Coin"
+              }
             },
             "recipient": {
               "description": "where the payout is to be routed",

--- a/contracts/libraries/clearing-queue-supervaults/src/contract.rs
+++ b/contracts/libraries/clearing-queue-supervaults/src/contract.rs
@@ -161,8 +161,8 @@ mod functions {
         // we do not swallow the error here because any error here means a config error.
         let mars_amount = payout_amount
             .checked_multiply_ratio(
-                cfg.settlement_ratio.numerator(),
-                cfg.settlement_ratio.denominator(),
+                cfg.mars_settlement_ratio.numerator(),
+                cfg.mars_settlement_ratio.denominator(),
             )
             .map_err(|e| LibraryError::ExecutionError(e.to_string()))?;
 
@@ -181,46 +181,49 @@ mod functions {
 
         // if supervaults amount is non-zero, we perform the deposit simulation
         // to estimate the supervaults lp shares amount equivalent to the supervaults_amount
-        // of deposit token
+        // of deposit token. We do this for each of the supervaults we are withdrawing from.
         if !supervaults_amount.is_zero() {
-            // first we query the supervaults to pairwise match the config denom
-            // to the supervault pair data
-            let supervaults_config: mmvault::state::Config = deps
-                .querier
-                .query_wasm_smart(&cfg.supervault_addr, &mmvault::msg::QueryMsg::GetConfig {})?;
+            for info in cfg.supervaults_settlement_info.iter() {
+                // first we query the supervaults to pairwise match the config denom
+                // to the supervault pair data
+                let supervaults_config: mmvault::state::Config = deps.querier.query_wasm_smart(
+                    &info.supervault_addr,
+                    &mmvault::msg::QueryMsg::GetConfig {},
+                )?;
 
-            let supervaults_simulate_lp_msg =
-                if cfg.denom.eq(&supervaults_config.pair_data.token_0.denom) {
-                    mmvault::msg::QueryMsg::SimulateProvideLiquidity {
-                        amount_0: supervaults_amount,
-                        amount_1: Uint128::zero(),
-                        sender: cfg.supervault_sender.clone(),
-                    }
-                } else if cfg.denom.eq(&supervaults_config.pair_data.token_1.denom) {
-                    mmvault::msg::QueryMsg::SimulateProvideLiquidity {
-                        amount_0: Uint128::zero(),
-                        amount_1: supervaults_amount,
-                        sender: cfg.supervault_sender.clone(),
-                    }
-                } else {
-                    return Err(LibraryError::ConfigurationError(
-                        "supervault config denom mismatch".to_string(),
-                    ));
-                };
+                let supervaults_simulate_lp_msg =
+                    if cfg.denom.eq(&supervaults_config.pair_data.token_0.denom) {
+                        mmvault::msg::QueryMsg::SimulateProvideLiquidity {
+                            amount_0: supervaults_amount,
+                            amount_1: Uint128::zero(),
+                            sender: info.supervault_sender.clone(),
+                        }
+                    } else if cfg.denom.eq(&supervaults_config.pair_data.token_1.denom) {
+                        mmvault::msg::QueryMsg::SimulateProvideLiquidity {
+                            amount_0: Uint128::zero(),
+                            amount_1: supervaults_amount,
+                            sender: info.supervault_sender.clone(),
+                        }
+                    } else {
+                        return Err(LibraryError::ConfigurationError(
+                            "supervault config denom mismatch".to_string(),
+                        ));
+                    };
 
-            // perform the supervaults liquidity provision simulation.
-            // we know that the offer_amount here is non-zero, so we surface
-            // any errors that may happen during this query (e.g. due to
-            // exceeded cap, changed api, etc)
-            let supervaults_lp_equivalent: Uint128 = deps
-                .querier
-                .query_wasm_smart(&cfg.supervault_addr, &supervaults_simulate_lp_msg)?;
+                // perform the supervaults liquidity provision simulation.
+                // we know that the offer_amount here is non-zero, so we surface
+                // any errors that may happen during this query (e.g. due to
+                // exceeded cap, changed api, etc)
+                let supervaults_lp_equivalent: Uint128 = deps
+                    .querier
+                    .query_wasm_smart(&info.supervault_addr, &supervaults_simulate_lp_msg)?;
 
-            // push the supervaults obligation to the payout coins array
-            payout_coins.push(Coin {
-                denom: supervaults_config.lp_denom,
-                amount: supervaults_lp_equivalent,
-            });
+                // push the supervaults obligation to the payout coins array
+                payout_coins.push(Coin {
+                    denom: supervaults_config.lp_denom,
+                    amount: supervaults_lp_equivalent,
+                });
+            }
         }
 
         // filter out any zero-amount denoms as attempting to settle them later
@@ -230,12 +233,12 @@ mod functions {
             .filter(|c| !c.amount.is_zero())
             .collect();
 
-        // if both coins were 0-amount, there is nothing to transfer; return
+        // if all coins are 0-amount, there is nothing to transfer; return
         if filtered_payout.is_empty() {
             return swallow_obligation_registration_err(
                 deps,
                 id,
-                "both obligations 0-amount".to_string(),
+                "all obligations 0-amount".to_string(),
             );
         }
 

--- a/contracts/libraries/clearing-queue-supervaults/src/msg.rs
+++ b/contracts/libraries/clearing-queue-supervaults/src/msg.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{ensure, Addr, Decimal, Deps, DepsMut, Uint128, Uint64};
 use cw_ownable::cw_ownable_query;
@@ -21,11 +23,29 @@ pub struct Config {
     /// `None` indicates that no obligations have been
     /// registered yet (and expects id=0 for next).
     pub latest_id: Option<Uint64>,
+    /// mars settlement ratio
+    pub mars_settlement_ratio: Decimal,
+    /// supervaults settlement information
+    pub supervaults_settlement_info: Vec<ValidatedSupervaultSettlementInfo>,
+}
+
+#[cw_serde]
+pub struct SupervaultSettlementInfo {
+    /// supervaults address
+    pub supervault_addr: LibraryAccountType,
+    /// supervault provider address
+    pub supervault_sender: LibraryAccountType,
+    /// settlement ratio
+    pub settlement_ratio: Decimal,
+}
+
+#[cw_serde]
+pub struct ValidatedSupervaultSettlementInfo {
     /// supervaults address
     pub supervault_addr: Addr,
-    /// supervaults provider addr
+    /// supervault provider address
     pub supervault_sender: Addr,
-    /// settlement ratio (w.r.t. Mars position)
+    /// settlement ratio
     pub settlement_ratio: Decimal,
 }
 
@@ -39,12 +59,10 @@ pub struct LibraryConfig {
     pub denom: String,
     /// latest registered obligation id.
     pub latest_id: Option<Uint64>,
-    /// supervaults address
-    pub supervault_addr: String,
-    /// supervaults provider addr
-    pub supervaults_sender: String,
-    /// settlement ratio (w.r.t. Mars position)
-    pub settlement_ratio: Decimal,
+    /// mars settlement ratio
+    pub mars_settlement_ratio: Decimal,
+    /// supervaults settlement information
+    pub supervaults_settlement_info: Vec<SupervaultSettlementInfo>,
 }
 
 #[cw_serde]
@@ -67,17 +85,15 @@ impl LibraryConfig {
         settlement_acc_addr: impl Into<LibraryAccountType>,
         denom: String,
         latest_id: Option<Uint64>,
-        supervault_addr: String,
-        supervaults_sender: String,
-        settlement_ratio: Decimal,
+        mars_settlement_ratio: Decimal,
+        supervaults_settlement_info: Vec<SupervaultSettlementInfo>,
     ) -> Self {
         LibraryConfig {
             settlement_acc_addr: settlement_acc_addr.into(),
             denom,
             latest_id,
-            supervault_addr,
-            supervaults_sender,
-            settlement_ratio,
+            mars_settlement_ratio,
+            supervaults_settlement_info,
         }
     }
 
@@ -85,7 +101,16 @@ impl LibraryConfig {
     fn do_validate(
         &self,
         api: &dyn cosmwasm_std::Api,
-    ) -> Result<(Addr, String, Option<Uint64>, Addr, Addr, Decimal), LibraryError> {
+    ) -> Result<
+        (
+            Addr,
+            String,
+            Option<Uint64>,
+            Decimal,
+            Vec<ValidatedSupervaultSettlementInfo>,
+        ),
+        LibraryError,
+    > {
         // validate the input account
         let settlement_acc_addr = self.settlement_acc_addr.to_addr(api)?;
 
@@ -94,21 +119,72 @@ impl LibraryConfig {
             LibraryError::ConfigurationError("input denom cannot be empty".to_string())
         );
 
-        let validated_supervault_addr = api.addr_validate(&self.supervault_addr)?;
-        let validated_supervaults_sender = api.addr_validate(&self.supervaults_sender)?;
+        // validate the mars settlement ratio
+        DecimalRange::new(Decimal::zero(), Decimal::one()).contains(self.mars_settlement_ratio)?;
 
-        // validate that the settlement ratio is between 0 and 1
-        DecimalRange::new(Decimal::zero(), Decimal::one()).contains(self.settlement_ratio)?;
+        // check that the supervaults settlement information is not empty
+        ensure!(
+            !self.supervaults_settlement_info.is_empty(),
+            LibraryError::ConfigurationError(
+                "supervaults settlement information cannot be empty".to_string()
+            )
+        );
+
+        // validate supervaults settlement information
+        let (total_supervaults_ratio, supervaults_info) =
+            validate_supervaults_settlement_info(&self.supervaults_settlement_info, api)?;
+
+        // Finally check that adding the supervaults settlement ratios and mars settlement ratio is exactly 1
+        ensure!(
+            total_supervaults_ratio + self.mars_settlement_ratio == Decimal::one(),
+            LibraryError::ConfigurationError(format!(
+                "Total settlement ratio must be 1, got {}",
+                total_supervaults_ratio + self.mars_settlement_ratio
+            ))
+        );
 
         Ok((
             settlement_acc_addr,
-            self.denom.to_string(),
+            self.denom.clone(),
             self.latest_id,
-            validated_supervault_addr,
-            validated_supervaults_sender,
-            self.settlement_ratio,
+            self.mars_settlement_ratio,
+            supervaults_info,
         ))
     }
+}
+
+/// validate supervaults settlement information
+/// 1. Addresses are valid
+/// 2. Settlement ratios are between 0 and 1
+/// 3. No duplicate supervault addresses
+fn validate_supervaults_settlement_info(
+    supervaults_settlement_info: &[SupervaultSettlementInfo],
+    api: &dyn cosmwasm_std::Api,
+) -> Result<(Decimal, Vec<ValidatedSupervaultSettlementInfo>), LibraryError> {
+    let mut total_supervaults_ratio = Decimal::zero();
+    let mut supervaults_addrs = vec![];
+    let mut check_duplicated = HashSet::new();
+
+    for info in supervaults_settlement_info {
+        let supervault_addr = info.supervault_addr.to_addr(api)?;
+        let supervault_sender = info.supervault_sender.to_addr(api)?;
+        DecimalRange::new(Decimal::zero(), Decimal::one()).contains(info.settlement_ratio)?;
+        ensure!(
+            check_duplicated.insert(supervault_addr.to_string()),
+            LibraryError::ConfigurationError(format!(
+                "Duplicate supervault address: {}",
+                supervault_addr
+            ))
+        );
+        total_supervaults_ratio += info.settlement_ratio;
+        supervaults_addrs.push(ValidatedSupervaultSettlementInfo {
+            supervault_addr,
+            supervault_sender,
+            settlement_ratio: info.settlement_ratio,
+        });
+    }
+
+    Ok((total_supervaults_ratio, supervaults_addrs))
 }
 
 impl LibraryConfigValidation<Config> for LibraryConfig {
@@ -123,17 +199,16 @@ impl LibraryConfigValidation<Config> for LibraryConfig {
             settlement_acc_addr,
             denom,
             latest_id,
-            supervault_addr,
-            supervault_sender,
-            settlement_ratio,
+            mars_settlement_ratio,
+            supervaults_settlement_info,
         ) = self.do_validate(deps.api)?;
+
         Ok(Config {
             settlement_acc_addr,
             denom,
             latest_id,
-            supervault_addr,
-            supervault_sender,
-            settlement_ratio,
+            mars_settlement_ratio,
+            supervaults_settlement_info,
         })
     }
 }
@@ -154,19 +229,43 @@ impl LibraryConfigUpdate {
             config.denom = denom;
         }
 
-        if let Some(addr) = self.supervault_addr {
-            config.supervault_addr = deps.api.addr_validate(&addr)?;
+        if let OptionUpdate::Set(latest_id) = self.latest_id {
+            config.latest_id = latest_id;
         }
 
-        if let Some(addr) = self.supervaults_sender {
-            config.supervault_sender = deps.api.addr_validate(&addr)?;
+        if let Some(mars_settlement_ratio) = self.mars_settlement_ratio {
+            DecimalRange::new(Decimal::zero(), Decimal::one()).contains(mars_settlement_ratio)?;
+            config.mars_settlement_ratio = mars_settlement_ratio;
         }
 
-        if let Some(ratio) = self.settlement_ratio {
-            // validate that the settlement ratio is between 0 and 1
-            DecimalRange::new(Decimal::zero(), Decimal::one()).contains(ratio)?;
-            config.settlement_ratio = ratio;
+        if let Some(supervaults_settlement_info) = self.supervaults_settlement_info {
+            ensure!(
+                !supervaults_settlement_info.is_empty(),
+                LibraryError::ConfigurationError(
+                    "supervaults settlement information cannot be empty".to_string()
+                )
+            );
+
+            // validate supervaults settlement information
+            let (_, supervaults_info) =
+                validate_supervaults_settlement_info(&supervaults_settlement_info, deps.api)?;
+            config.supervaults_settlement_info = supervaults_info;
         }
+
+        // Finally check that the ratios sum to 1
+        let total_supervaults_ratio = config
+            .supervaults_settlement_info
+            .iter()
+            .map(|info| info.settlement_ratio)
+            .sum::<Decimal>();
+
+        ensure!(
+            total_supervaults_ratio + config.mars_settlement_ratio == Decimal::one(),
+            LibraryError::ConfigurationError(format!(
+                "Total settlement ratio must be 1, got {}",
+                total_supervaults_ratio + config.mars_settlement_ratio
+            ))
+        );
 
         valence_library_base::save_config(deps.storage, &config)?;
 


### PR DESCRIPTION
Updates the supervaults clearing queue to allow withdrawing from multiple supervaults instead of only one.
Most of the logic change is in the config validation where we validate that we are providing not duplicated supervault addresses and that the ratios are correct and sum up to 100%