### PR TITLE
fix: force memory allocation in LiteProcessor err variable

### DIFF
--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -199,9 +199,13 @@ abstract contract ProcessorBase is Ownable {
              */
             (bool success, bytes memory err) = targetContract.call(messages[i]);
             if (!success) {
-                // Forward the original error data
-                assembly {
-                    revert(add(err, 32), mload(err))
+                // Forces the compiler to properly handle the memory allocation for err during compilation.
+                if (err.length > 0) {
+                    assembly {
+                        revert(add(32, err), mload(err))
+                    }
+                } else {
+                    revert("Contract call failed without error data");
                 }
             }
         }

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -136,14 +136,14 @@ abstract contract ProcessorBase is Ownable {
                 break;
             }
 
-            (bool success, bytes memory err) = targetContract.call(messages[i]);
+            (bool success, bytes memory data) = targetContract.call(messages[i]);
 
             if (success) {
                 executedCount++;
             } else {
                 succeeded = false;
-                // Forces the compiler to properly handle the memory allocation for err during compilation.
-                errorData = err.length > 0 ? err : bytes("Contract call failed without error data");
+                // Forces the compiler to properly handle the memory allocation for data during compilation.
+                errorData = data.length > 0 ? data : bytes("Contract call failed without error data");
                 break;
             }
         }
@@ -192,18 +192,18 @@ abstract contract ProcessorBase is Ownable {
              * @dev When a contract call fails, Solidity captures the revert data (error)
              *      in a bytes array with a 32-byte length prefix. To correctly propagate
              *      the original error, we need to:
-             *      1. Capture both success status and error data from the call
+             *      1. Capture both success status and data from the call
              *      2. If call failed, use assembly to revert with the original error:
-             *         - Skip the 32-byte length prefix in memory (add(err, 32))
-             *         - Use the length value at the start of err (mload(err))
+             *         - Skip the 32-byte length prefix in memory (add(data, 32))
+             *         - Use the length value at the start of data (mload(data))
              *         - Revert with exactly the original error data
              */
-            (bool success, bytes memory err) = targetContract.call(messages[i]);
+            (bool success, bytes memory data) = targetContract.call(messages[i]);
             if (!success) {
-                // Forces the compiler to properly handle the memory allocation for err during compilation.
-                if (err.length > 0) {
+                // Forces the compiler to properly handle the memory allocation for data during compilation.
+                if (data.length > 0) {
                     assembly {
-                        revert(add(32, err), mload(err))
+                        revert(add(32, data), mload(data))
                     }
                 } else {
                     revert("Contract call failed without error data");

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -142,7 +142,8 @@ abstract contract ProcessorBase is Ownable {
                 executedCount++;
             } else {
                 succeeded = false;
-                errorData = err;
+                // Forces the compiler to properly handle the memory allocation for err during compilation.
+                errorData = err.length > 0 ? err : bytes("Contract call failed without error data");
                 break;
             }
         }


### PR DESCRIPTION
There's an issue in the LiteProcessor where the compiler's optimizer was not properly allocating memory for the return data variable from low-level calls, causing memory corruption and unexpected reverts.

This surfaced during our lombard transfer calls, which returned data data somewhere during the calls. Without explicit usage of the return data variable in the success path, the compiler failed to allocate proper memory for it, leading to reverts in subsequent operations.

Changes:
- Renamed `err` to `data` for accuracy (this variable contains return data for both successful and failed calls)
- Added explicit length checks that force the compiler to properly allocate memory for the return data
- Added fallback error message when calls fail without providing error data