### PR TITLE
chore: remove coprocessor root from verification gateway

### DIFF
--- a/solidity/src/verification/VerificationGateway.sol
+++ b/solidity/src/verification/VerificationGateway.sol
@@ -11,9 +11,6 @@ import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Ini
  * This contract provides the foundation for verifying proofs against registered verification keys.
  */
 abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPSUpgradeable {
-    /// @notice Root hash of the ZK coprocessor
-    bytes32 public coprocessorRoot;
-
     /// @notice Generic verifier address that will be specialized in derived contracts
     address public verifier;
 
@@ -32,14 +29,12 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
     }
 
     /**
-     * @notice Initializes the verification gateway replcaing the constructor with a coprocessor root and verifier address
-     * @param _coprocessorRoot The root hash of the coprocessor
+     * @notice Initializes the verification gateway replacing the constructor with an inizializer with the verifier address
      * @param _verifier Address of the verification contract
      */
-    function initialize(bytes32 _coprocessorRoot, address _verifier) external initializer {
+    function initialize(address _verifier) external initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
-        coprocessorRoot = _coprocessorRoot;
         require(_verifier != address(0), "Verifier cannot be zero address");
         verifier = _verifier;
     }


### PR DESCRIPTION
this field is not used for anything and should be removed from the contract