### PR TITLE
audit: remove payable execute function

### DIFF
--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -64,7 +64,7 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
      * @notice Handles incoming messages from an authorized addresses
      * @param _body The message payload
      */
-    function execute(bytes calldata _body) external payable override {
+    function execute(bytes calldata _body) external override {
         // Verify sender is authorized address
         require(authorizedAddresses[msg.sender], ProcessorErrors.UnauthorizedAccess());
 

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -58,7 +58,7 @@ contract Processor is IMessageRecipient, ProcessorBase {
      * @notice Handles incoming messages from an authorized addresses
      * @param _body The message payload
      */
-    function execute(bytes calldata _body) external payable override {
+    function execute(bytes calldata _body) external override {
         // TODO: Implement the execute function
     }
 }

--- a/solidity/src/processor/ProcessorBase.sol
+++ b/solidity/src/processor/ProcessorBase.sol
@@ -64,7 +64,7 @@ abstract contract ProcessorBase is Ownable {
      * @notice Handles incoming messages from an authorized addresses
      * @param _body The message payload
      */
-    function execute(bytes calldata _body) external payable virtual;
+    function execute(bytes calldata _body) external virtual;
 
     /**
      * @notice Handles pause messages


### PR DESCRIPTION
can't remove it from handle because interface is inherited from Hyperlane and it's payable there.

It will eventually be removed anyways as we will remove Hyperlane support.
