### PR TITLE
audit: add nonreentrant modifiers

### DIFF
--- a/solidity/src/processor/LiteProcessor.sol
+++ b/solidity/src/processor/LiteProcessor.sol
@@ -7,13 +7,14 @@ import {IProcessorMessageTypes} from "./interfaces/IProcessorMessageTypes.sol";
 import {IProcessor} from "./interfaces/IProcessor.sol";
 import {ProcessorErrors} from "./libs/ProcessorErrors.sol";
 import {ProcessorBase} from "./ProcessorBase.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /**
  * @title LiteProcessor
  * @notice A lightweight processor for handling cross-chain messages with atomic and non-atomic execution
- * @dev Implements IMessageRecipient for Hyperlane message handling and ProcessorBase for core shared processor logic
+ * @dev Implements IMessageRecipient for Hyperlane message handling, ProcessorBase for core shared processor logic and ReentrancyGuard to prevent re-entrancy attacks.
  */
-contract LiteProcessor is IMessageRecipient, ProcessorBase {
+contract LiteProcessor is IMessageRecipient, ProcessorBase, ReentrancyGuard {
     // ============ Constructor ============
     /**
      * @notice Initializes the LiteProcessor contract
@@ -64,7 +65,7 @@ contract LiteProcessor is IMessageRecipient, ProcessorBase {
      * @notice Handles incoming messages from an authorized addresses
      * @param _body The message payload
      */
-    function execute(bytes calldata _body) external payable override {
+    function execute(bytes calldata _body) external payable override nonReentrant {
         // Verify sender is authorized address
         require(authorizedAddresses[msg.sender], ProcessorErrors.UnauthorizedAccess());
 

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -8,6 +8,11 @@ import {ProcessorErrors} from "./libs/ProcessorErrors.sol";
 import {ProcessorEvents} from "./libs/ProcessorEvents.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/**
+ * @title Processor
+ * @notice (unimplemented) A full implementation of a Processor.
+ * @dev Implements IMessageRecipient for Hyperlane message handling, ProcessorBase for core shared processor logic and ReentrancyGuard to prevent re-entrancy attacks.
+ */
 contract Processor is IMessageRecipient, ProcessorBase, ReentrancyGuard {
     // Use the library for the Queue type
     using QueueMap for QueueMap.Queue;

--- a/solidity/src/processor/Processor.sol
+++ b/solidity/src/processor/Processor.sol
@@ -6,8 +6,9 @@ import {QueueMap} from "./libs/QueueMap.sol";
 import {ProcessorBase} from "./ProcessorBase.sol";
 import {ProcessorErrors} from "./libs/ProcessorErrors.sol";
 import {ProcessorEvents} from "./libs/ProcessorEvents.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract Processor is IMessageRecipient, ProcessorBase {
+contract Processor is IMessageRecipient, ProcessorBase, ReentrancyGuard {
     // Use the library for the Queue type
     using QueueMap for QueueMap.Queue;
 
@@ -58,7 +59,7 @@ contract Processor is IMessageRecipient, ProcessorBase {
      * @notice Handles incoming messages from an authorized addresses
      * @param _body The message payload
      */
-    function execute(bytes calldata _body) external payable override {
+    function execute(bytes calldata _body) external payable override nonReentrant {
         // TODO: Implement the execute function
     }
 }

--- a/solidity/src/vaults/OneWayVault.sol
+++ b/solidity/src/vaults/OneWayVault.sol
@@ -388,7 +388,7 @@ contract OneWayVault is
      * @param receiver Address to receive the vault shares
      * @return shares Amount of shares minted to receiver
      */
-    function deposit(uint256 assets, address receiver) public override whenNotPaused returns (uint256) {
+    function deposit(uint256 assets, address receiver) public override whenNotPaused nonReentrant returns (uint256) {
         if (_checkAndHandleStaleRate()) {
             return 0; // Exit early if vault was just paused
         }
@@ -419,7 +419,7 @@ contract OneWayVault is
      * @param receiver Address to receive the shares
      * @return assets Total amount of assets deposited (including fees)
      */
-    function mint(uint256 shares, address receiver) public override whenNotPaused returns (uint256) {
+    function mint(uint256 shares, address receiver) public override whenNotPaused nonReentrant returns (uint256) {
         if (_checkAndHandleStaleRate()) {
             return 0; // Exit early if vault was just paused
         }


### PR DESCRIPTION
even though this won't happen because we authorize addresses to execute on processor. We're protecting from reentrancy tries to reenter the execute function.

Same for the vault. We add reentrancy protection for malicious tokens, even though the vault will only work with trusted tokens.