### PR TITLE
audit: remove duplicated check

### DIFF
--- a/solidity/src/vaults/OneWayVault.sol
+++ b/solidity/src/vaults/OneWayVault.sol
@@ -675,10 +675,6 @@ contract OneWayVault is
     function _withdraw(uint256 sharesToBurn, uint256 postFeeShares, string calldata receiver, address owner) internal {
         // Burn shares first (CEI pattern - Checks, Effects, Interactions)
         if (msg.sender != owner) {
-            uint256 allowed = allowance(owner, msg.sender);
-            if (allowed < sharesToBurn) {
-                revert("Insufficient allowance");
-            }
             _spendAllowance(owner, msg.sender, sharesToBurn);
         }
         _burn(owner, sharesToBurn);

--- a/solidity/src/vaults/ValenceVault.sol
+++ b/solidity/src/vaults/ValenceVault.sol
@@ -824,10 +824,6 @@ contract ValenceVault is
 
         // Burn shares first (CEI pattern)
         if (msg.sender != owner) {
-            uint256 allowed = allowance(owner, msg.sender);
-            if (allowed < shares) {
-                revert InsufficientAllowance(shares, allowed);
-            }
             _spendAllowance(owner, msg.sender, shares);
         }
         _burn(owner, shares);


### PR DESCRIPTION
spendAllowance already does the checks inside
```solidity
    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {
        uint256 currentAllowance = allowance(owner, spender);
        if (currentAllowance < type(uint256).max) {
            if (currentAllowance < value) {
                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
            }
            unchecked {
                _approve(owner, spender, currentAllowance - value, false);
            }
        }
    }
```