### PR TITLE
feat: use bytes instead of bytes32 in verification gateway

### DIFF
--- a/solidity/src/authorization/Authorization.sol
+++ b/solidity/src/authorization/Authorization.sol
@@ -555,7 +555,7 @@ contract Authorization is Ownable, ICallback, ReentrancyGuard {
     function addRegistries(
         uint64[] memory registries,
         address[][] memory users,
-        bytes32[] calldata vks,
+        bytes[] calldata vks,
         bool[] memory validateBlockNumber
     ) external onlyOwner {
         // Check that the verification gateway is set

--- a/solidity/src/verification/SP1VerificationGateway.sol
+++ b/solidity/src/verification/SP1VerificationGateway.sol
@@ -46,35 +46,24 @@ contract SP1VerificationGateway is VerificationGateway {
         bytes calldata domainProof,
         bytes calldata domainMessage
     ) external view override returns (bool) {
-        // Get the VK for the sender and the registry
+        // Get the VK for the sender and the registry (gas-friendly storage reference)
         bytes memory vk = programVKs[msg.sender][registry];
-
-        // If the VK is not set, revert
-        require(vk.length != 0, "VK not set for user and registry");
-        require(vk.length == 32, "VK must be 32 bytes");
-
-        // Call the specific verifier
-        ISP1Verifier sp1Verifier = getVerifier();
-
         // Get the domainVK
         bytes memory _domainVK = domainVK;
 
-        // Convert bytes to bytes32
-        bytes32 vkBytes32;
-        assembly {
-            // Skips the first 32 bytes (length) and reads the next 32 bytes
-            // This assumes vk is at least 32 bytes long, which is checked above
-            vkBytes32 := mload(add(vk, 32))
-        }
-
-        bytes32 domainVKBytes32;
+        // Validation
+        require(vk.length != 0, "VK not set for user and registry");
+        require(vk.length == 32, "VK must be 32 bytes");
         require(_domainVK.length == 32, "Domain VK must be 32 bytes");
-        assembly {
-            // Skips the first 32 bytes (length) and reads the next 32 bytes
-            // This assumes vk is at least 32 bytes long, which is checked above
-            domainVKBytes32 := mload(add(_domainVK, 32))
-        }
 
+        // Convert to bytes32 - we've already checked the length above so it won't truncate
+        bytes32 vkBytes32 = bytes32(vk);
+        bytes32 domainVKBytes32 = bytes32(_domainVK);
+
+        // Get verifier
+        ISP1Verifier sp1Verifier = getVerifier();
+
+        // Verify proofs
         sp1Verifier.verifyProof(vkBytes32, message, proof);
         sp1Verifier.verifyProof(domainVKBytes32, domainMessage, domainProof);
 

--- a/solidity/src/verification/VerificationGateway.sol
+++ b/solidity/src/verification/VerificationGateway.sol
@@ -15,13 +15,13 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
     address public verifier;
 
     /// @notice domainVK used to verify domain proofs
-    bytes32 public domainVK;
+    bytes public domainVK;
 
     /**
      * @notice Mapping of program verification keys by user address and registry ID
      * @dev Maps: user address => registry ID => verification key
      */
-    mapping(address => mapping(uint64 => bytes32)) public programVKs;
+    mapping(address => mapping(uint64 => bytes)) public programVKs;
 
     // Storage gap - reserves slots for future versions
     uint256[50] private __gap;
@@ -36,12 +36,12 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      * @param _verifier Address of the verification contract
      * @param _domainVK The domain verification key that is going to be used for this verification gateway
      */
-    function initialize(address _verifier, bytes32 _domainVK) external initializer {
+    function initialize(address _verifier, bytes calldata _domainVK) external initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
         require(_verifier != address(0), "Verifier cannot be zero address");
         verifier = _verifier;
-        require(_domainVK != bytes32(0), "Domain VK cannot be zero");
+        require(_domainVK.length != 0, "Domain VK cannot be empty");
         domainVK = _domainVK;
     }
 
@@ -60,8 +60,8 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      * @dev Only the owner can perform this action
      * @param _domainVK The new domainVK
      */
-    function updateDomainVK(bytes32 _domainVK) external onlyOwner {
-        require(_domainVK != bytes32(0), "Domain VK cannot be zero");
+    function updateDomainVK(bytes calldata _domainVK) external onlyOwner {
+        require(_domainVK.length != 0, "Domain VK cannot be empty");
         domainVK = _domainVK;
     }
 
@@ -71,7 +71,7 @@ abstract contract VerificationGateway is Initializable, OwnableUpgradeable, UUPS
      * @param registry The registry ID to associate with the verification key
      * @param vk The verification key to register
      */
-    function addRegistry(uint64 registry, bytes32 vk) external {
+    function addRegistry(uint64 registry, bytes calldata vk) external {
         programVKs[msg.sender][registry] = vk;
     }
 

--- a/solidity/test/authorization/AuthorizationZK.t.sol
+++ b/solidity/test/authorization/AuthorizationZK.t.sol
@@ -29,8 +29,8 @@ contract AuthorizationZKTest is Test {
     // ZK registry configuration
     uint64 registryId1 = 101;
     uint64 registryId2 = 102;
-    bytes32 vk1 = bytes32(uint256(0x123456));
-    bytes32 vk2 = bytes32(uint256(0x789abc));
+    bytes vk1 = abi.encodePacked(bytes32(uint256(0x123456)));
+    bytes vk2 = abi.encodePacked(bytes32(uint256(0x789abc)));
     bool validateBlockNumber1 = false;
     bool validateBlockNumber2 = true;
 
@@ -43,7 +43,7 @@ contract AuthorizationZKTest is Test {
         // Deploy verification gateway
         verificationGateway = new SP1VerificationGateway();
 
-        bytes32 domainVK = bytes32(uint256(0xdeadbeef));
+        bytes memory domainVK = abi.encodePacked(bytes32(uint256(0xdeadbeef)));
         bytes memory initializeData =
             abi.encodeWithSelector(verificationGateway.initialize.selector, verifier, domainVK);
 
@@ -86,7 +86,7 @@ contract AuthorizationZKTest is Test {
         users[1][0] = address(0); // Permissionless access
 
         // Create verification keys
-        bytes32[] memory vks = new bytes32[](2);
+        bytes[] memory vks = new bytes[](2);
         vks[0] = vk1;
         vks[1] = vk2;
 
@@ -99,7 +99,7 @@ contract AuthorizationZKTest is Test {
         auth.addRegistries(registries, users, vks, validateBlockNumbers);
 
         // Verify registry 1
-        bytes32 storedVk1 = verificationGateway.programVKs(address(auth), registryId1);
+        bytes memory storedVk1 = verificationGateway.programVKs(address(auth), registryId1);
         assertEq(storedVk1, vk1, "Verification key for registry 1 should be stored correctly");
 
         // Check authorized users for registry 1
@@ -109,7 +109,7 @@ contract AuthorizationZKTest is Test {
         assertEq(authorizedUsers1[1], user2, "Registry 1 should authorize user2");
 
         // Verify registry 2
-        bytes32 storedVk2 = verificationGateway.programVKs(address(auth), registryId2);
+        bytes memory storedVk2 = verificationGateway.programVKs(address(auth), registryId2);
         assertEq(storedVk2, vk2, "Verification key for registry 2 should be stored correctly");
 
         // Check authorized users for registry 2
@@ -137,7 +137,7 @@ contract AuthorizationZKTest is Test {
         users[1] = new address[](1);
         users[1][0] = user2;
 
-        bytes32[] memory vks = new bytes32[](2);
+        bytes[] memory vks = new bytes[](2);
         vks[0] = vk1;
         vks[1] = vk2;
 
@@ -148,7 +148,7 @@ contract AuthorizationZKTest is Test {
         auth.addRegistries(registriesToAdd, users, vks, validateBlockNumbers);
 
         // Verify registries were added
-        bytes32 storedVk1 = verificationGateway.programVKs(address(auth), registryId1);
+        bytes memory storedVk1 = verificationGateway.programVKs(address(auth), registryId1);
         assertEq(storedVk1, vk1, "Registry 1 should be added");
 
         // Now remove one registry
@@ -158,8 +158,8 @@ contract AuthorizationZKTest is Test {
         auth.removeRegistries(registriesToRemove);
 
         // Verify registry was removed
-        bytes32 removedVk = verificationGateway.programVKs(address(auth), registryId1);
-        assertEq(removedVk, bytes32(0), "Registry 1 should be removed from verification gateway");
+        bytes memory removedVk = verificationGateway.programVKs(address(auth), registryId1);
+        assertEq(removedVk.length, 0, "Registry 1 should be removed from verification gateway");
 
         // Verify the authorization data was also removed
         address[] memory authorizedUsers1 = auth.getZkAuthorizationsList(registryId1);
@@ -170,7 +170,7 @@ contract AuthorizationZKTest is Test {
         assertEq(lastExecBlock, 0, "Last execution block should be cleared for registry 1");
 
         // Verify other registry still exists
-        bytes32 storedVk2 = verificationGateway.programVKs(address(auth), registryId2);
+        bytes memory storedVk2 = verificationGateway.programVKs(address(auth), registryId2);
         assertEq(storedVk2, vk2, "Registry 2 should still exist");
 
         vm.stopPrank();
@@ -189,7 +189,7 @@ contract AuthorizationZKTest is Test {
         users[0] = new address[](1);
         users[0][0] = user1;
 
-        bytes32[] memory vks = new bytes32[](1);
+        bytes[] memory vks = new bytes[](1);
         vks[0] = vk1;
 
         bool[] memory validateBlockNumbers = new bool[](2);
@@ -232,7 +232,7 @@ contract AuthorizationZKTest is Test {
         users[0] = new address[](1);
         users[0][0] = user1;
 
-        bytes32[] memory vks = new bytes32[](2);
+        bytes[] memory vks = new bytes[](2);
         vks[0] = vk1;
         vks[1] = vk2;
 
@@ -260,7 +260,7 @@ contract AuthorizationZKTest is Test {
         users[0] = new address[](1);
         users[0][0] = user1;
 
-        bytes32[] memory vks = new bytes32[](1);
+        bytes[] memory vks = new bytes[](1);
         vks[0] = vk1;
 
         bool[] memory validateBlockNumbers = new bool[](1);
@@ -316,7 +316,7 @@ contract AuthorizationZKTest is Test {
         users[0] = new address[](1);
         users[0][0] = user1;
 
-        bytes32[] memory vks = new bytes32[](1);
+        bytes[] memory vks = new bytes[](1);
         vks[0] = vk1;
 
         bool[] memory validateBlockNumbers = new bool[](1);
@@ -349,7 +349,7 @@ contract AuthorizationZKTest is Test {
         users[0] = new address[](1);
         users[0][0] = user1;
 
-        bytes32[] memory vks = new bytes32[](1);
+        bytes[] memory vks = new bytes[](1);
         vks[0] = vk1;
 
         bool[] memory validateBlockNumbers = new bool[](1);

--- a/solidity/test/authorization/AuthorizationZK.t.sol
+++ b/solidity/test/authorization/AuthorizationZK.t.sol
@@ -29,8 +29,8 @@ contract AuthorizationZKTest is Test {
     // ZK registry configuration
     uint64 registryId1 = 101;
     uint64 registryId2 = 102;
-    bytes vk1 = abi.encodePacked(bytes32(uint256(0x123456)));
-    bytes vk2 = abi.encodePacked(bytes32(uint256(0x789abc)));
+    bytes vk1 = hex"123456";
+    bytes vk2 = hex"789abc";
     bool validateBlockNumber1 = false;
     bool validateBlockNumber2 = true;
 
@@ -43,7 +43,7 @@ contract AuthorizationZKTest is Test {
         // Deploy verification gateway
         verificationGateway = new SP1VerificationGateway();
 
-        bytes memory domainVK = abi.encodePacked(bytes32(uint256(0xdeadbeef)));
+        bytes memory domainVK = hex"deadbeef";
         bytes memory initializeData =
             abi.encodeWithSelector(verificationGateway.initialize.selector, verifier, domainVK);
 

--- a/solidity/test/authorization/AuthorizationZK.t.sol
+++ b/solidity/test/authorization/AuthorizationZK.t.sol
@@ -29,8 +29,8 @@ contract AuthorizationZKTest is Test {
     // ZK registry configuration
     uint64 registryId1 = 101;
     uint64 registryId2 = 102;
-    bytes vk1 = hex"123456";
-    bytes vk2 = hex"789abc";
+    bytes vk1 = abi.encodePacked(bytes32(uint256(0x123456)));
+    bytes vk2 = abi.encodePacked(bytes32(uint256(0x789abc)));
     bool validateBlockNumber1 = false;
     bool validateBlockNumber2 = true;
 
@@ -43,7 +43,7 @@ contract AuthorizationZKTest is Test {
         // Deploy verification gateway
         verificationGateway = new SP1VerificationGateway();
 
-        bytes memory domainVK = hex"deadbeef";
+        bytes memory domainVK = abi.encodePacked(bytes32(uint256(0xdeadbeef)));
         bytes memory initializeData =
             abi.encodeWithSelector(verificationGateway.initialize.selector, verifier, domainVK);
 


### PR DESCRIPTION
Use bytes instead of bytes32 in the verification gateway.

What we do then in the SP1 verification gateway when verifying is convert  to bytes32 which is what SP1 in particular will use. This allows having VKs that are not constricted to 32 length for when we support other verifications. 
Similar to what we have in CosmWasm where we are using `Binary` for the VK.