### PR TITLE
refactor: allow multiple verifiers on authorization contract

### DIFF
--- a/contracts/authorization/schema/valence-authorization.json
+++ b/contracts/authorization/schema/valence-authorization.json
@@ -1595,17 +1595,23 @@
           {
             "type": "object",
             "required": [
-              "set_verification_gateway"
+              "set_verifier_contract"
             ],
             "properties": {
-              "set_verification_gateway": {
+              "set_verifier_contract": {
                 "type": "object",
                 "required": [
-                  "verification_gateway"
+                  "contract",
+                  "tag"
                 ],
                 "properties": {
-                  "verification_gateway": {
+                  "contract": {
                     "type": "string"
+                  },
+                  "tag": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
                   }
                 },
                 "additionalProperties": false
@@ -2055,14 +2061,19 @@
         "type": "object",
         "required": [
           "label",
+          "metadata_hash",
           "mode",
           "registry",
           "validate_last_block_execution",
+          "verifier_tag",
           "vk"
         ],
         "properties": {
           "label": {
             "type": "string"
+          },
+          "metadata_hash": {
+            "$ref": "#/definitions/Binary"
           },
           "mode": {
             "$ref": "#/definitions/AuthorizationModeInfo"
@@ -2074,6 +2085,11 @@
           },
           "validate_last_block_execution": {
             "type": "boolean"
+          },
+          "verifier_tag": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "vk": {
             "$ref": "#/definitions/Binary"
@@ -2224,11 +2240,21 @@
       {
         "type": "object",
         "required": [
-          "verification_gateway"
+          "verification_contract"
         ],
         "properties": {
-          "verification_gateway": {
+          "verification_contract": {
             "type": "object",
+            "required": [
+              "tag"
+            ],
+            "properties": {
+              "tag": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
             "additionalProperties": false
           }
         },
@@ -4277,7 +4303,7 @@
         }
       }
     },
-    "verification_gateway": {
+    "verification_contract": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Addr",
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
@@ -4380,15 +4406,20 @@
           "type": "object",
           "required": [
             "label",
+            "metadata_hash",
             "mode",
             "registry",
             "state",
             "validate_last_block_execution",
+            "verifier_tag",
             "vk"
           ],
           "properties": {
             "label": {
               "type": "string"
+            },
+            "metadata_hash": {
+              "$ref": "#/definitions/Binary"
             },
             "mode": {
               "$ref": "#/definitions/AuthorizationMode"
@@ -4403,6 +4434,11 @@
             },
             "validate_last_block_execution": {
               "type": "boolean"
+            },
+            "verifier_tag": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             },
             "vk": {
               "$ref": "#/definitions/Binary"

--- a/contracts/authorization/src/error.rs
+++ b/contracts/authorization/src/error.rs
@@ -158,4 +158,7 @@ pub enum ZKErrorReason {
 
     #[error("Invalid Coprocessor root")]
     InvalidCoprocessorRoot {},
+
+    #[error("Verifier contract already exists for this tag")]
+    VerifierContractAlreadyExists {},
 }

--- a/contracts/authorization/src/state.rs
+++ b/contracts/authorization/src/state.rs
@@ -8,7 +8,7 @@ use valence_authorization_utils::{
 pub const FIRST_OWNERSHIP: Item<bool> = Item::new("first_ownership");
 pub const SUB_OWNERS: Map<Addr, Empty> = Map::new("sub_owners");
 pub const AUTHORIZATIONS: Map<String, Authorization> = Map::new("authorizations");
-pub const VERIFICATION_GATEWAY: Item<Addr> = Item::new("verification_gateway");
+pub const VERIFIER_REGISTRY: Map<u64, Addr> = Map::new("verifier_registry");
 pub const ZK_AUTHORIZATIONS: Map<String, ZkAuthorization> = Map::new("zk_authorizations");
 pub const PROCESSOR_ON_MAIN_DOMAIN: Item<Addr> = Item::new("processor_on_main_domain");
 pub const EXTERNAL_DOMAINS: Map<String, ExternalDomain> = Map::new("external_domains");

--- a/contracts/authorization/src/tests/helpers.rs
+++ b/contracts/authorization/src/tests/helpers.rs
@@ -204,6 +204,7 @@ pub fn instantiate_and_set_verification_gateway(
     authorization: String,
     owner: String,
     domain_vk: Binary,
+    tag: u64,
 ) {
     let wasm = Wasm::new(app);
     let code_id = wasm
@@ -231,8 +232,9 @@ pub fn instantiate_and_set_verification_gateway(
 
     wasm.execute::<ExecuteMsg>(
         &authorization,
-        &ExecuteMsg::PermissionedAction(PermissionedMsg::SetVerificationGateway {
-            verification_gateway,
+        &ExecuteMsg::PermissionedAction(PermissionedMsg::SetVerifierContract {
+            tag,
+            contract: verification_gateway,
         }),
         &[],
         signer,

--- a/contracts/authorization/src/tests/user_actions.rs
+++ b/contracts/authorization/src/tests/user_actions.rs
@@ -791,12 +791,15 @@ fn pause_and_resume_processor_using_zk_authorizations() {
     )
     .unwrap();
 
+    let verifier_tag = 1;
+
     instantiate_and_set_verification_gateway(
         &setup.app,
         &setup.owner_accounts[0],
         authorization.clone(),
         setup.owner_addr.to_string(),
         Binary::from(sp1_vk.bytes32().into_bytes()),
+        verifier_tag,
     );
 
     // Let's create two zk authorizations, one to pause the processor and another to resume it, pause will have registry 1 and resume will have registry 2
@@ -805,6 +808,8 @@ fn pause_and_resume_processor_using_zk_authorizations() {
         mode: AuthorizationModeInfo::Permissionless,
         registry: 1,
         vk: Binary::from(sp1_vk.bytes32().into_bytes()),
+        verifier_tag,
+        metadata_hash: Binary::default(),
         validate_last_block_execution: false,
     };
     let zk_authorization_resume = ZkAuthorizationInfo {
@@ -812,6 +817,8 @@ fn pause_and_resume_processor_using_zk_authorizations() {
         mode: AuthorizationModeInfo::Permissionless,
         registry: 2,
         vk: Binary::from(sp1_vk.bytes32().into_bytes()),
+        verifier_tag,
+        metadata_hash: Binary::default(),
         validate_last_block_execution: false,
     };
     let zk_authorizations = vec![zk_authorization_pause, zk_authorization_resume];

--- a/packages/authorization-utils/src/msg.rs
+++ b/packages/authorization-utils/src/msg.rs
@@ -236,8 +236,9 @@ pub enum PermissionedMsg {
         domain: Domain,
     },
     // Set a verification gateway contract for ZK authorizations
-    SetVerificationGateway {
-        verification_gateway: String,
+    SetVerifierContract {
+        tag: u64,
+        contract: String,
     },
 }
 
@@ -372,7 +373,7 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     #[returns(Addr)]
-    VerificationGateway {},
+    VerificationContract { tag: u64 },
     #[returns(Vec<ProcessorCallbackInfo>)]
     ProcessorCallbacks {
         start_after: Option<u64>,

--- a/packages/authorization-utils/src/zk_authorization.rs
+++ b/packages/authorization-utils/src/zk_authorization.rs
@@ -19,6 +19,10 @@ pub struct ZkAuthorizationInfo {
     pub registry: u64,
     // The Verifying Key to be used
     pub vk: Binary,
+    // The verifier tag, it's a unique identifier that links to a specific verification gateway
+    pub verifier_tag: u64,
+    // Hash of the metadata of the program. This is purely informational and it's used to link the VK to the program
+    pub metadata_hash: Binary,
     // Flag to indicate if we need to validate the last block execution of a specific ZK authorization
     pub validate_last_block_execution: bool,
 }
@@ -30,6 +34,8 @@ impl ZkAuthorizationInfo {
             mode: self.mode.into_mode_validated(api),
             registry: self.registry,
             vk: self.vk,
+            verifier_tag: self.verifier_tag,
+            metadata_hash: self.metadata_hash,
             validate_last_block_execution: self.validate_last_block_execution,
             state: AuthorizationState::Enabled,
         }
@@ -42,6 +48,8 @@ pub struct ZkAuthorization {
     pub mode: AuthorizationMode,
     pub registry: u64,
     pub vk: Binary,
+    pub verifier_tag: u64,
+    pub metadata_hash: Binary,
     pub validate_last_block_execution: bool,
     pub state: AuthorizationState,
 }

--- a/solidity/src/authorization/Authorization.sol
+++ b/solidity/src/authorization/Authorization.sol
@@ -232,10 +232,10 @@ contract Authorization is Ownable, ICallback, ReentrancyGuard {
      * @notice Adds a new verifier contract for a specific tag
      * @dev Can only be called by the owner
      * @param tag The tag of the verifier
-     * @param _verifier Address of the verifier contract
+     * @param verifier Address of the verifier contract
      */
-    function setVerifierContract(uint64 tag, address _verifier) external onlyOwner {
-        verifierRegistry[tag] = VerificationGateway(_verifier);
+    function setVerifierContract(uint64 tag, address verifier) external onlyOwner {
+        verifierRegistry[tag] = VerificationGateway(verifier);
     }
 
     // ========================= Standard Authorizations =========================

--- a/solidity/test/authorization/AuthorizationStandard.t.sol
+++ b/solidity/test/authorization/AuthorizationStandard.t.sol
@@ -50,7 +50,7 @@ contract AuthorizationStandardTest is Test {
 
         // Deploy main contracts
         processor = new LiteProcessor(bytes32(0), address(0), 0, new address[](0));
-        auth = new Authorization(owner, address(processor), address(0), true);
+        auth = new Authorization(owner, address(processor), true);
 
         // Configure processor authorization
         processor.addAuthorizedAddress(address(auth));
@@ -175,14 +175,16 @@ contract AuthorizationStandardTest is Test {
     }
 
     /**
-     * @notice Test updating the verification gateway address
+     * @notice Test set a verifier contract
      */
     function testUpdateVerificationGateway() public {
         vm.startPrank(owner);
 
         address newVerificationGateway = address(0x9);
-        auth.updateVerificationGateway(newVerificationGateway);
-        assertEq(address(auth.verificationGateway()), newVerificationGateway, "Verification Gateway should be updated");
+        auth.setVerifierContract(1, newVerificationGateway);
+        assertEq(
+            address(auth.verifierRegistry(1)), newVerificationGateway, "Verification Gateway should have been added"
+        );
 
         vm.stopPrank();
     }


### PR DESCRIPTION
Makes the verification gateway contracts on the authorization contract a mapping identified by a u64 tag.
ZkAuthorizations will now have a verifier tag that identifies which tag to use for verification. There will also be a metadata field where the owner will add the hash of the program (TBD but will be the hash of a TOML with the program information including the ID).

This change is applied for both CW and EVM implementation.