### PR TITLE
docs: clarify coordinator terminology in vault strategist docs entries

### DIFF
--- a/docs/src/examples/crosschain_vaults.md
+++ b/docs/src/examples/crosschain_vaults.md
@@ -13,7 +13,7 @@ In this example, we have made the following assumptions:
 - ERC-20 shares are issued to users on Ethereum.
 - If a user wishes to redeem their tokens, they can issue a withdrawal request which will burn the user's shares when tokens are redeemed.
 - The redemption rate that tells us how many tokens can be redeemed per shares is given by: \\( R = \frac{TotalAssets}{TotalIssuedShares} = \frac{TotalInVault + TotalInTransit + TotalInPostion}{TotalIssuedShares}\\)
-- A permissioned actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron where they are locked in some DeFi protocol. And vice-versa, the Strategist can withdraw from the position so the funds are redeemable on Ethereum. The redemption rate must be adjusted by the Strategist accordingly.
+- A permissioned coordinator actor called the "Strategist" is authorized to transport funds from Ethereum to Neutron where they are locked in some DeFi protocol. And vice-versa, the Strategist can withdraw from the position so the funds are redeemable on Ethereum. The redemption rate must be adjusted by the Strategist accordingly.
 
 ```mermaid
 ---
@@ -26,8 +26,8 @@ graph LR
 
 	User -- Tokens --> EV
 	EV -- Shares --> User
-	EV -- Strategist Transport --> NP
-	NP -- Strategist Transport --> EV
+	EV -- Coordinator Transport --> NP
+	NP -- Coordinator Transport --> EV
 ```
 
 While we have chosen Ethereum and Neutron as examples here, one could similarly construct such vaults between any two chains as long as they are supported by Valence Programs.
@@ -36,7 +36,7 @@ While we have chosen Ethereum and Neutron as examples here, one could similarly 
 
 Recall that Valence Programs are comprised of Libraries and Accounts. Libraries are a collection of Functions that perform token operations on the Accounts. Since there are two chains here, Libraries and Accounts will exist on both chains.
 
-Since gas is cheaper on Neutron than on Ethereum, computationally expensive operations, such as constraining the Strategist actions will be done on Neutron. Authorized messages will then be executed by each chain's Processor. Hyperlane is used to pass messages from the Authorization contract on Neutron to the Processor on Ethereum.
+Since gas is cheaper on Neutron than on Ethereum, computationally expensive operations, such as constraining the coordinator actions will be done on Neutron. Authorized messages will then be executed by each chain's Processor. Hyperlane is used to pass messages from the Authorization contract on Neutron to the Processor on Ethereum.
 
 ```mermaid
 ---

--- a/docs/src/examples/vault_strategist.md
+++ b/docs/src/examples/vault_strategist.md
@@ -1,14 +1,18 @@
 # Vault Strategist
 
-**Note:** _The Strategist is still in the design phase and includes new or experimental features of Valence Protocol that may not be supported in the current production release._
+**Note:** _Vault Strategist is a type of Valence Coordinator. More information about the
+coordinator capabilities and design principles can be found in the [Valence Coordinator SDK repo](https://github.com/timewave-computer/valence-coordinator-sdk)._
 
 ## Overview
 
-Vault Strategist is a type of off-chain solver that performs operations needed in order to keep the [Valence Vaults](./crosschain_vaults.md) functioning and up to date.
+Vault Strategist is a type of off-chain solver (coordinator) that performs operations needed
+in order to keep the [Valence Vaults](./crosschain_vaults.md) functioning and up to date.
 
-Strategist is meant to be run as an independent process, only interacting with the domains relevant for its operations via (g)RPC requests submitted to respective nodes.
+Coordinator is meant to be run as an independent process, only interacting with the domains
+relevant for its operations via (g)RPC requests submitted to respective nodes.
 
-A complete on-chain flow of a cross-chain Valence Vault — accepting deposits on Ethereum and entering a position on Neutron — might look as follows:
+A complete on-chain flow of a cross-chain Valence Vault — accepting deposits on Ethereum
+and entering a position on Neutron — might look as follows:
 
 ```mermaid
 ---
@@ -62,7 +66,7 @@ flowchart BT
 
 ## Prerequisites
 
-There are some prerequisites for a strategist to be able to carry out its entire order of operations.
+There are some prerequisites for a coordinator to be able to carry out its entire order of operations.
 
 These prerequisites will fit into the following broad categories:
 
@@ -120,7 +124,7 @@ Noble will host the inbound and outbound interchain accounts created by Valence 
 
 ### Valence Domain Clients
 
-The Strategist interacts with target domains by submitting (g)RPC requests.
+The Vault coordinator interacts with target domains by submitting (g)RPC requests.
 
 These requests are constructed and submitted using [Valence Domain Clients](https://github.com/timewave-computer/valence-domain-clients), which support `async`/`await`, batched requests spanning an arbitrary number of domains, encoding schemes, and other domain-specific semantics in a standardized manner.
 


### PR DESCRIPTION
closes #430 

# Description

Updates the cross-chain vaults and vault strategist docs entries to include the new Valence Coordinator terminology. For now I kept the notion of "Vault Strategist" and just added some clarifying notes that it is a type of coordinator.