### PR TITLE
Chore: fix supervaults version in supervaults-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,8 +5669,8 @@ dependencies = [
 
 [[package]]
 name = "mmvault"
-version = "0.1.6"
-source = "git+https://github.com/neutron-org/slinky-vault#8511585e564bca12e814e0c8692add7ae7e3f536"
+version = "2.0.0"
+source = "git+https://github.com/neutron-org/slinky-vault?branch=main#3a2537c846731b4752bdbee84eeb562e71273438"
 dependencies = [
  "cosmwasm-std 2.2.1",
  "cw-storage-plus 2.0.0",

--- a/contracts/libraries/clearing-queue-supervaults/Cargo.toml
+++ b/contracts/libraries/clearing-queue-supervaults/Cargo.toml
@@ -23,7 +23,7 @@ valence-macros          = { workspace = true }
 valence-library-utils   = { workspace = true }
 valence-library-base    = { workspace = true }
 valence-processor-utils = { workspace = true }
-mmvault                 = { git = "https://github.com/neutron-org/slinky-vault", package = "mmvault" }
+mmvault     = { git = "https://github.com/neutron-org/slinky-vault", package = "mmvault", branch = "main" }
 
 [dev-dependencies]
 cw-multi-test         = { workspace = true }

--- a/packages/supervaults-utils/Cargo.toml
+++ b/packages/supervaults-utils/Cargo.toml
@@ -15,4 +15,4 @@ valence-account-utils = { workspace = true }
 valence-library-utils = { workspace = true }
 # TODO: update these to point to respective releases once cut
 neutron-std = { git = "https://github.com/neutron-org/neutron-std", branch = "temp/pd_and_sod" }
-mmvault     = { git = "https://github.com/neutron-org/slinky-vault", package = "mmvault" }
+mmvault     = { git = "https://github.com/neutron-org/slinky-vault", package = "mmvault", branch = "main" }


### PR DESCRIPTION
This PR bumps mmvault package version to the latest version