### PR TITLE
feat: erc7540 vault deposit flow

### DIFF
--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+contract ValenceXCV {}

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -2,50 +2,74 @@
 pragma solidity ^0.8.28;
 
 import {ERC4626Upgradeable} from "@openzeppelin-contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import {BaseAccount} from "../accounts/BaseAccount.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {OwnableUpgradeable} from "@openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
-import {UUPSUpgradeable} from "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 
-contract ValenceXCV is
-    Initializable,
-    ERC4626Upgradeable,
-    OwnableUpgradeable,
-    ReentrancyGuardUpgradeable,
-    UUPSUpgradeable
-{
+contract ValenceXCV is Initializable, ERC4626Upgradeable, OwnableUpgradeable {
+    // current share price
     uint256 public sharePrice;
 
+    // authorized strategist address
+    address public strategist;
+
+    // Valence account for holding the deposited funds
+    address public depositAccount;
+
+    error InvalidSharePrice();
+
+    error OnlyStrategistAllowed();
+
+    error DepositAccountNotSet();
+    error StrategistNotSet();
+
+    event SharePriceUpdated(uint256 indexed sharePrice);
+
+    modifier onlyStrategist() {
+        if (msg.sender != strategist) {
+            revert OnlyStrategistAllowed();
+        }
+        _;
+    }
+
     constructor() {
-        _disableInitializers();
+        // _disableInitializers();
     }
 
     function initialize(
         address _owner,
+        address strategistAddress,
         address underlying,
+        address depositAccountAddress,
         string memory vaultTokenName,
         string memory vaultTokenSymbol,
         uint256 startSharePrice
     ) external initializer {
+        // initialize the vault share token
         __ERC20_init(vaultTokenName, vaultTokenSymbol);
+        // initialize the underlying (deposit) token
         __ERC4626_init(IERC20(underlying));
+        // set up ownership
         __Ownable_init(_owner);
-        __ReentrancyGuard_init();
-        __UUPSUpgradeable_init();
 
+        if (startSharePrice == 0) revert InvalidSharePrice();
         sharePrice = startSharePrice;
+
+        if (depositAccountAddress == address(0)) revert DepositAccountNotSet();
+        depositAccount = depositAccountAddress;
+
+        if (strategistAddress == address(0)) revert StrategistNotSet();
+        strategist = strategistAddress;
     }
 
-    /**
-     * @dev Function that authorizes contract upgrades - required by UUPSUpgradeable
-     * @param newImplementation address of the new implementation
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal override onlyOwner {
-        // Upgrade logic comes here
-        // No additional logic required beyond owner check in modifier
+    function setSharePrice(uint256 newSharePrice) external onlyStrategist {
+        // setting share price to 0 would allow for infinite mint
+        if (newSharePrice == 0) revert InvalidSharePrice();
+
+        sharePrice = newSharePrice;
+
+        emit SharePriceUpdated(newSharePrice);
     }
 }

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -1,4 +1,51 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-contract ValenceXCV {}
+import {ERC4626Upgradeable} from "@openzeppelin-contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {OwnableUpgradeable} from "@openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract ValenceXCV is
+    Initializable,
+    ERC4626Upgradeable,
+    OwnableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable
+{
+    uint256 public sharePrice;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _owner,
+        address underlying,
+        string memory vaultTokenName,
+        string memory vaultTokenSymbol,
+        uint256 startSharePrice
+    ) external initializer {
+        __ERC20_init(vaultTokenName, vaultTokenSymbol);
+        __ERC4626_init(IERC20(underlying));
+        __Ownable_init(_owner);
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+
+        sharePrice = startSharePrice;
+    }
+
+    /**
+     * @dev Function that authorizes contract upgrades - required by UUPSUpgradeable
+     * @param newImplementation address of the new implementation
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {
+        // Upgrade logic comes here
+        // No additional logic required beyond owner check in modifier
+    }
+}

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -66,6 +66,14 @@ contract ValenceXCV is
         _;
     }
 
+    modifier onlyControllerOrOperator(address controller) {
+        // assert that the caller is either the controller or an approved operator
+        if (controller != msg.sender && !operators[controller][msg.sender]) {
+            revert NotControllerOrOperator();
+        }
+        _;
+    }
+
     modifier whenSharePriceNotStale() {
         if (block.timestamp - lastUpdateTimestamp > sharePriceMaxAge) {
             revert StaleSharePrice();
@@ -154,6 +162,10 @@ contract ValenceXCV is
 
     // ERC-4626 deposit implementation that calls into the ERC-7540 deposit
     // with the addition of controller
+    // TODO: consider flagging this with `whenSharePriceNotStale` modifier,
+    // even though it will get checked in the other call. mostly just to be
+    // more explicit and to be extra sure that these checks happen in case the
+    // flow changes in the future
     function deposit(
         uint256 assets,
         address receiver
@@ -167,15 +179,16 @@ contract ValenceXCV is
         uint256 assets,
         address receiver,
         address controller
-    ) public whenSharePriceNotStale returns (uint256 shares) {
+    )
+        public
+        whenSharePriceNotStale
+        onlyControllerOrOperator(controller)
+        returns (uint256 shares)
+    {
         // zero deposits are not allowed
-        require(assets != 0, ZeroDepositAmount());
-
-        // assert that the caller is either the controller or an approved operator
-        require(
-            controller == msg.sender || operators[controller][msg.sender],
-            NotControllerOrOperator()
-        );
+        if (assets == 0) {
+            revert ZeroDepositAmount();
+        }
 
         // calculate the shares to be minted based on provided assets
         // and the current share price

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -10,13 +10,15 @@ import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Ini
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC7540Operator} from "../vaults/interfaces/IERC7540Operator.sol";
 import {IValenceVaultStrategist} from "../vaults/interfaces/IValenceVaultStrategist.sol";
+import {UUPSUpgradeable} from "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 contract ValenceXCV is
     Initializable,
     ERC4626Upgradeable,
     IERC7540Operator,
     OwnableUpgradeable,
-    IValenceVaultStrategist
+    IValenceVaultStrategist,
+    UUPSUpgradeable
 {
     using Math for uint256;
 
@@ -79,8 +81,11 @@ contract ValenceXCV is
         _;
     }
 
+    /// @dev Constructor that disables initializers
+    /// @notice Required for UUPS proxy pattern
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        // _disableInitializers();
+        _disableInitializers();
     }
 
     /// Initializes the vault.
@@ -109,6 +114,8 @@ contract ValenceXCV is
         __ERC4626_init(IERC20(underlying));
         // set up ownership
         __Ownable_init(_owner);
+        // proxy
+        __UUPSUpgradeable_init();
 
         if (startSharePrice == 0) revert InvalidSharePrice();
         sharePrice = startSharePrice;
@@ -126,6 +133,13 @@ contract ValenceXCV is
 
         // set the share precision based on the underlying token decimals
         ONE_SHARE = 10 ** decimals();
+    }
+
+    /// @dev Function that authorizes contract upgrades - required by UUPSUpgradeable
+    /// @param newImplementation address of the new implementation
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
+        // Upgrade logic comes here
+        // No additional logic required beyond owner check in modifier
     }
 
     // ========================================================================

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -67,6 +67,8 @@ contract ValenceXCV is
         _;
     }
 
+    // TODO: think whether this should instead be a hard pause (in state) that
+    // would require owner intervention
     /// @dev Restricts function to cases where the share price is up to date
     modifier onlyWhenSharePriceNotStale() {
         if (block.timestamp - lastUpdateTimestamp > sharePriceMaxAge) {

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -49,8 +49,7 @@ contract ValenceXCV is
     address public depositAccount;
 
     /// Mapping of controllers to their approved operators.
-    mapping(address controller => mapping(address operator => bool))
-        public operators;
+    mapping(address controller => mapping(address operator => bool)) public operators;
 
     /// @dev Restricts function access to strategist
     modifier onlyStrategist() {
@@ -137,10 +136,7 @@ contract ValenceXCV is
     /// @param controller The address of the controller
     /// @param operator The address of the operator to check
     /// @return A boolean indicating whether the operator is approved
-    function isOperator(
-        address controller,
-        address operator
-    ) external view returns (bool) {
+    function isOperator(address controller, address operator) external view returns (bool) {
         return operators[controller][operator];
     }
 
@@ -148,10 +144,7 @@ contract ValenceXCV is
     /// @param operator The address of the operator
     /// @param approved A boolean indicating whether to approve or revoke the operator
     /// @return A boolean indicating the success of the operation (always true)
-    function setOperator(
-        address operator,
-        bool approved
-    ) external returns (bool) {
+    function setOperator(address operator, bool approved) external returns (bool) {
         // set the operator status
         operators[msg.sender][operator] = approved;
         emit OperatorSet(msg.sender, operator, approved);
@@ -170,9 +163,7 @@ contract ValenceXCV is
 
         uint256 oldSharePrice = sharePrice;
         // get the absolute difference between the new and old share prices
-        uint256 delta = newSharePrice > oldSharePrice
-            ? newSharePrice - oldSharePrice
-            : oldSharePrice - newSharePrice;
+        uint256 delta = newSharePrice > oldSharePrice ? newSharePrice - oldSharePrice : oldSharePrice - newSharePrice;
 
         // verify that the delta is within our tolerance
         // maxPriceChange is expressed in bips, so we multiply the delta by 10000
@@ -190,10 +181,7 @@ contract ValenceXCV is
     /// @param assets The amount of assets to convert
     /// @param rounding The rounding direction
     /// @return The corresponding amount of shares
-    function _convertToShares(
-        uint256 assets,
-        Math.Rounding rounding
-    ) internal view override returns (uint256) {
+    function _convertToShares(uint256 assets, Math.Rounding rounding) internal view override returns (uint256) {
         return assets.mulDiv(ONE_SHARE, sharePrice, rounding);
     }
 
@@ -203,10 +191,7 @@ contract ValenceXCV is
     /// @param assets The amount of assets to deposit
     /// @param receiver The address that will receive the shares
     /// @return shares The amount of shares minted
-    function deposit(
-        uint256 assets,
-        address receiver
-    ) public override returns (uint256 shares) {
+    function deposit(uint256 assets, address receiver) public override returns (uint256 shares) {
         return deposit(assets, receiver, msg.sender);
     }
 
@@ -216,11 +201,7 @@ contract ValenceXCV is
     /// @param receiver The address that will receive the shares
     /// @param controller The address of the controller on whose behalf the deposit is made
     /// @return shares The amount of shares minted
-    function deposit(
-        uint256 assets,
-        address receiver,
-        address controller
-    )
+    function deposit(uint256 assets, address receiver, address controller)
         public
         onlyWhenSharePriceNotStale
         onlyControllerOrOperator(controller)
@@ -245,19 +226,9 @@ contract ValenceXCV is
     /// @param receiver The address that will receive the shares
     /// @param assets The amount of assets to deposit
     /// @param shares The amount of shares to mint
-    function _deposit(
-        address caller,
-        address receiver,
-        uint256 assets,
-        uint256 shares
-    ) internal override {
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
         // escrow the deposited assets to the deposit account (external contract)
-        SafeERC20.safeTransferFrom(
-            IERC20(asset()),
-            receiver,
-            depositAccount,
-            assets
-        );
+        SafeERC20.safeTransferFrom(IERC20(asset()), receiver, depositAccount, assets);
         _mint(receiver, shares);
 
         emit Deposit(caller, receiver, assets, shares);

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -9,22 +9,16 @@ import {OwnableUpgradeable} from "@openzeppelin-contracts-upgradeable/access/Own
 import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC7540Operator} from "../vaults/interfaces/IERC7540Operator.sol";
+import {IValenceVaultStrategist} from "../vaults/interfaces/IValenceVaultStrategist.sol";
 
 contract ValenceXCV is
     Initializable,
     ERC4626Upgradeable,
     IERC7540Operator,
-    OwnableUpgradeable
+    OwnableUpgradeable,
+    IValenceVaultStrategist
 {
     using Math for uint256;
-
-    /// @dev Emitted on successful share price update by the strategist.
-    /// @param sharePrice newly posted share price
-    /// @param updateTimestamp block.time of the update
-    event SharePriceUpdated(
-        uint256 indexed sharePrice,
-        uint256 indexed updateTimestamp
-    );
 
     error InvalidSharePrice();
     error OnlyStrategistAllowed();

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -10,9 +10,6 @@ import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Ini
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC7540Operator} from "../vaults/interfaces/IERC7540Operator.sol";
 
-// TODO: look into any ERC-4626 defaults and think if anyhthing else needs
-// to be overridden
-
 contract ValenceXCV is
     Initializable,
     ERC4626Upgradeable,
@@ -20,6 +17,25 @@ contract ValenceXCV is
     OwnableUpgradeable
 {
     using Math for uint256;
+
+    /**
+     * @dev Emitted on successful share price update by the strategist.
+     * @param sharePrice newly posted share price
+     * @param updateTimestamp block.time of the update
+     */
+    event SharePriceUpdated(
+        uint256 indexed sharePrice,
+        uint256 indexed updateTimestamp
+    );
+
+    error InvalidSharePrice();
+    error OnlyStrategistAllowed();
+    error NotControllerOrOperator();
+    error DepositAccountNotSet();
+    error StrategistNotSet();
+    error ZeroDepositAmount();
+    error StaleSharePrice();
+    error InvalidSharePriceMaxAge();
 
     uint256 internal ONE_SHARE;
 
@@ -42,20 +58,7 @@ contract ValenceXCV is
     mapping(address controller => mapping(address operator => bool))
         public operators;
 
-    error InvalidSharePrice();
-    error OnlyStrategistAllowed();
-    error NotControllerOrOperator();
-    error DepositAccountNotSet();
-    error StrategistNotSet();
-    error ZeroDepositAmount();
-    error StaleSharePrice();
-    error InvalidSharePriceMaxAge();
-
-    event SharePriceUpdated(
-        uint256 indexed sharePrice,
-        uint256 indexed updateTimestamp
-    );
-
+    /// @dev Restricts function access to strategist
     modifier onlyStrategist() {
         if (msg.sender != strategist) {
             revert OnlyStrategistAllowed();
@@ -63,14 +66,17 @@ contract ValenceXCV is
         _;
     }
 
+    /// @dev Restricts function access to the controller or any operators
+    /// approved by the controller
+    /// @param controller address of the target position owner
     modifier onlyControllerOrOperator(address controller) {
-        // assert that the caller is either the controller or an approved operator
         if (controller != msg.sender && !operators[controller][msg.sender]) {
             revert NotControllerOrOperator();
         }
         _;
     }
 
+    /// @dev Restricts function to cases where the share price is up to date
     modifier onlyWhenSharePriceNotStale() {
         if (block.timestamp - lastUpdateTimestamp > sharePriceMaxAge) {
             revert StaleSharePrice();
@@ -119,6 +125,10 @@ contract ValenceXCV is
     // ========================================================================
     // ========================= ERC-7540 OPERATOR ============================
     // ========================================================================
+
+    /// @dev Checks whether a given address is an approved operator
+    /// @param controller Request owner address that should approve the operators
+    /// @param operator Operator address to check the approval status of
     function isOperator(
         address controller,
         address operator

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -101,7 +101,7 @@ contract ValenceXCV is
         string memory vaultTokenSymbol,
         uint256 startSharePrice,
         uint256 maxSharePriceAge,
-        uint256 maxPriceChangeBips
+        uint256 maxPriceChangeBps
     ) external initializer {
         // initialize the vault share token
         __ERC20_init(vaultTokenName, vaultTokenSymbol);
@@ -113,7 +113,7 @@ contract ValenceXCV is
         if (startSharePrice == 0) revert InvalidSharePrice();
         sharePrice = startSharePrice;
         lastUpdateTimestamp = block.timestamp;
-        maxPriceChange = maxPriceChangeBips;
+        maxPriceChange = maxPriceChangeBps;
 
         if (maxSharePriceAge == 0) revert InvalidSharePriceMaxAge();
         sharePriceMaxAge = maxSharePriceAge;
@@ -216,7 +216,7 @@ contract ValenceXCV is
         // and the current share price
         shares = convertToShares(assets);
 
-        _deposit(controller, receiver, assets, shares);
+        _deposit(msg.sender, receiver, assets, shares);
     }
 
     /// Internal deposit logic. Transfers assets to the deposit account and mints shares.

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -43,15 +43,12 @@ contract ValenceXCV is
         public operators;
 
     error InvalidSharePrice();
-
     error OnlyStrategistAllowed();
     error NotControllerOrOperator();
-
     error DepositAccountNotSet();
     error StrategistNotSet();
     error ZeroDepositAmount();
     error StaleSharePrice();
-
     error InvalidSharePriceMaxAge();
 
     event SharePriceUpdated(
@@ -74,7 +71,7 @@ contract ValenceXCV is
         _;
     }
 
-    modifier whenSharePriceNotStale() {
+    modifier onlyWhenSharePriceNotStale() {
         if (block.timestamp - lastUpdateTimestamp > sharePriceMaxAge) {
             revert StaleSharePrice();
         }
@@ -181,7 +178,7 @@ contract ValenceXCV is
         address controller
     )
         public
-        whenSharePriceNotStale
+        onlyWhenSharePriceNotStale
         onlyControllerOrOperator(controller)
         returns (uint256 shares)
     {

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -18,11 +18,9 @@ contract ValenceXCV is
 {
     using Math for uint256;
 
-    /**
-     * @dev Emitted on successful share price update by the strategist.
-     * @param sharePrice newly posted share price
-     * @param updateTimestamp block.time of the update
-     */
+    /// @dev Emitted on successful share price update by the strategist.
+    /// @param sharePrice newly posted share price
+    /// @param updateTimestamp block.time of the update
     event SharePriceUpdated(
         uint256 indexed sharePrice,
         uint256 indexed updateTimestamp
@@ -37,24 +35,23 @@ contract ValenceXCV is
     error StaleSharePrice();
     error InvalidSharePriceMaxAge();
 
+    /// @dev The precision factor for one share, equivalent to 10^decimals().
     uint256 internal ONE_SHARE;
 
-    // current share price
+    /// The current price of one share in terms of the underlying asset.
     uint256 public sharePrice;
-    // timestamp of when the share price was last updated
+    /// The timestamp of the last share price update.
     uint256 public lastUpdateTimestamp;
-    // maximum age of the share price before it is considered stale,
-    // in seconds
+    /// The maximum age of the share price in seconds before it is considered stale.
     uint256 public sharePriceMaxAge;
 
-    // authorized strategist address
+    /// The address of the authorized strategist who can update the share price.
     address public strategist;
 
-    // Valence account for holding the deposited funds
+    /// The Valence account contract that holds the deposited funds.
     address public depositAccount;
 
-    // ERC7540 operator store. each controller can approve a set of operators
-    // to perform actions on their behalf.
+    /// Mapping of controllers to their approved operators.
     mapping(address controller => mapping(address operator => bool))
         public operators;
 
@@ -88,6 +85,15 @@ contract ValenceXCV is
         // _disableInitializers();
     }
 
+    /// Initializes the vault.
+    /// @param _owner The owner of the vault.
+    /// @param strategistAddress The address of the strategist.
+    /// @param underlying The address of the underlying asset token.
+    /// @param depositAccountAddress The address of the deposit account.
+    /// @param vaultTokenName The name of the vault token.
+    /// @param vaultTokenSymbol The symbol of the vault token.
+    /// @param startSharePrice The initial share price.
+    /// @param maxSharePriceAge The maximum age of the share price in seconds.
     function initialize(
         address _owner,
         address strategistAddress,
@@ -126,9 +132,10 @@ contract ValenceXCV is
     // ========================= ERC-7540 OPERATOR ============================
     // ========================================================================
 
-    /// @dev Checks whether a given address is an approved operator
-    /// @param controller Request owner address that should approve the operators
-    /// @param operator Operator address to check the approval status of
+    /// Checks whether a given address is an approved operator for a controller
+    /// @param controller The address of the controller
+    /// @param operator The address of the operator to check
+    /// @return A boolean indicating whether the operator is approved
     function isOperator(
         address controller,
         address operator
@@ -136,6 +143,10 @@ contract ValenceXCV is
         return operators[controller][operator];
     }
 
+    /// Approves or revokes an operator for the caller
+    /// @param operator The address of the operator
+    /// @param approved A boolean indicating whether to approve or revoke the operator
+    /// @return A boolean indicating the success of the operation (always true)
     function setOperator(
         address operator,
         bool approved
@@ -143,13 +154,15 @@ contract ValenceXCV is
         // set the operator status
         operators[msg.sender][operator] = approved;
         emit OperatorSet(msg.sender, operator, approved);
-        // return true to indicate success
         return true;
     }
 
     // ========================================================================
     // ============================ DEPOSIT LANE ==============================
     // ========================================================================
+
+    /// Sets the share price. Can only be called by the strategist
+    /// @param newSharePrice The new share price
     function setSharePrice(uint256 newSharePrice) external onlyStrategist {
         // setting share price to 0 would allow for infinite mint
         if (newSharePrice == 0) revert InvalidSharePrice();
@@ -160,6 +173,10 @@ contract ValenceXCV is
         emit SharePriceUpdated(newSharePrice, lastUpdateTimestamp);
     }
 
+    /// Converts a given amount of assets to shares
+    /// @param assets The amount of assets to convert
+    /// @param rounding The rounding direction
+    /// @return The corresponding amount of shares
     function _convertToShares(
         uint256 assets,
         Math.Rounding rounding
@@ -167,21 +184,25 @@ contract ValenceXCV is
         return assets.mulDiv(ONE_SHARE, sharePrice, rounding);
     }
 
-    // ERC-4626 deposit implementation that calls into the ERC-7540 deposit
-    // with the addition of controller
-    // TODO: consider flagging this with `whenSharePriceNotStale` modifier,
-    // even though it will get checked in the other call. mostly just to be
-    // more explicit and to be extra sure that these checks happen in case the
-    // flow changes in the future
+    /// Deposits assets into the vault and mints shares for the receiver.
+    /// This is the ERC-4626 compliant deposit function.
+    /// @dev calls into deposit(assets, receiver, controller) with controller = msg.sender
+    /// @param assets The amount of assets to deposit
+    /// @param receiver The address that will receive the shares
+    /// @return shares The amount of shares minted
     function deposit(
         uint256 assets,
         address receiver
     ) public override returns (uint256 shares) {
-        // forward to the 7540 deposit overload with controller = msg.sender
         return deposit(assets, receiver, msg.sender);
     }
 
-    // ERC-7540 deposit overload
+    /// Deposits assets into the vault and mints shares for the receiver.
+    /// This is the ERC-7540 compliant deposit function.
+    /// @param assets The amount of assets to deposit
+    /// @param receiver The address that will receive the shares
+    /// @param controller The address of the controller on whose behalf the deposit is made
+    /// @return shares The amount of shares minted
     function deposit(
         uint256 assets,
         address receiver,
@@ -204,6 +225,13 @@ contract ValenceXCV is
         _deposit(controller, receiver, assets, shares);
     }
 
+    /// Internal deposit logic. Transfers assets to the deposit account and mints shares.
+    /// Only modification to the default ERC-4626 is that deposited assets are escrowed
+    /// to the deposit account (external contract).
+    /// @param caller The address that initiated the deposit
+    /// @param receiver The address that will receive the shares
+    /// @param assets The amount of assets to deposit
+    /// @param shares The amount of shares to mint
     function _deposit(
         address caller,
         address receiver,

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -28,6 +28,7 @@ contract ValenceXCV is
     error ZeroDepositAmount();
     error StaleSharePrice();
     error InvalidSharePriceMaxAge();
+    error SharePriceChangeDeltaTooLarge();
 
     /// @dev The precision factor for one share, equivalent to 10^decimals().
     uint256 internal ONE_SHARE;
@@ -38,6 +39,8 @@ contract ValenceXCV is
     uint256 public lastUpdateTimestamp;
     /// The maximum age of the share price in seconds before it is considered stale.
     uint256 public sharePriceMaxAge;
+    /// Max allowed price change in a single share price update, in bips (1/100th of 1%)
+    uint256 public maxPriceChange;
 
     /// The address of the authorized strategist who can update the share price.
     address public strategist;
@@ -98,7 +101,8 @@ contract ValenceXCV is
         string memory vaultTokenName,
         string memory vaultTokenSymbol,
         uint256 startSharePrice,
-        uint256 maxSharePriceAge
+        uint256 maxSharePriceAge,
+        uint256 maxPriceChangeBips
     ) external initializer {
         // initialize the vault share token
         __ERC20_init(vaultTokenName, vaultTokenSymbol);
@@ -110,6 +114,7 @@ contract ValenceXCV is
         if (startSharePrice == 0) revert InvalidSharePrice();
         sharePrice = startSharePrice;
         lastUpdateTimestamp = block.timestamp;
+        maxPriceChange = maxPriceChangeBips;
 
         if (maxSharePriceAge == 0) revert InvalidSharePriceMaxAge();
         sharePriceMaxAge = maxSharePriceAge;
@@ -162,6 +167,18 @@ contract ValenceXCV is
     function setSharePrice(uint256 newSharePrice) external onlyStrategist {
         // setting share price to 0 would allow for infinite mint
         if (newSharePrice == 0) revert InvalidSharePrice();
+
+        uint256 oldSharePrice = sharePrice;
+        // get the absolute difference between the new and old share prices
+        uint256 delta = newSharePrice > oldSharePrice
+            ? newSharePrice - oldSharePrice
+            : oldSharePrice - newSharePrice;
+
+        // verify that the delta is within our tolerance
+        // maxPriceChange is expressed in bips, so we multiply the delta by 10000
+        if ((delta * 10000) / oldSharePrice > maxPriceChange) {
+            revert SharePriceChangeDeltaTooLarge();
+        }
 
         sharePrice = newSharePrice;
         lastUpdateTimestamp = block.timestamp;

--- a/solidity/src/vaults/ValenceXCV.sol
+++ b/solidity/src/vaults/ValenceXCV.sol
@@ -25,6 +25,11 @@ contract ValenceXCV is
 
     // current share price
     uint256 public sharePrice;
+    // timestamp of when the share price was last updated
+    uint256 public lastUpdateTimestamp;
+    // maximum age of the share price before it is considered stale,
+    // in seconds
+    uint256 public sharePriceMaxAge;
 
     // authorized strategist address
     address public strategist;
@@ -45,12 +50,25 @@ contract ValenceXCV is
     error DepositAccountNotSet();
     error StrategistNotSet();
     error ZeroDepositAmount();
+    error StaleSharePrice();
 
-    event SharePriceUpdated(uint256 indexed sharePrice);
+    error InvalidSharePriceMaxAge();
+
+    event SharePriceUpdated(
+        uint256 indexed sharePrice,
+        uint256 indexed updateTimestamp
+    );
 
     modifier onlyStrategist() {
         if (msg.sender != strategist) {
             revert OnlyStrategistAllowed();
+        }
+        _;
+    }
+
+    modifier whenSharePriceNotStale() {
+        if (block.timestamp - lastUpdateTimestamp > sharePriceMaxAge) {
+            revert StaleSharePrice();
         }
         _;
     }
@@ -66,7 +84,8 @@ contract ValenceXCV is
         address depositAccountAddress,
         string memory vaultTokenName,
         string memory vaultTokenSymbol,
-        uint256 startSharePrice
+        uint256 startSharePrice,
+        uint256 maxSharePriceAge
     ) external initializer {
         // initialize the vault share token
         __ERC20_init(vaultTokenName, vaultTokenSymbol);
@@ -77,6 +96,10 @@ contract ValenceXCV is
 
         if (startSharePrice == 0) revert InvalidSharePrice();
         sharePrice = startSharePrice;
+        lastUpdateTimestamp = block.timestamp;
+
+        if (maxSharePriceAge == 0) revert InvalidSharePriceMaxAge();
+        sharePriceMaxAge = maxSharePriceAge;
 
         if (depositAccountAddress == address(0)) revert DepositAccountNotSet();
         depositAccount = depositAccountAddress;
@@ -117,8 +140,9 @@ contract ValenceXCV is
         if (newSharePrice == 0) revert InvalidSharePrice();
 
         sharePrice = newSharePrice;
+        lastUpdateTimestamp = block.timestamp;
 
-        emit SharePriceUpdated(newSharePrice);
+        emit SharePriceUpdated(newSharePrice, lastUpdateTimestamp);
     }
 
     function _convertToShares(
@@ -143,7 +167,7 @@ contract ValenceXCV is
         uint256 assets,
         address receiver,
         address controller
-    ) public returns (uint256 shares) {
+    ) public whenSharePriceNotStale returns (uint256 shares) {
         // zero deposits are not allowed
         require(assets != 0, ZeroDepositAmount());
 
@@ -152,8 +176,6 @@ contract ValenceXCV is
             controller == msg.sender || operators[controller][msg.sender],
             NotControllerOrOperator()
         );
-
-        // TODO: staleness checks
 
         // calculate the shares to be minted based on provided assets
         // and the current share price

--- a/solidity/src/vaults/interfaces/IERC7540Operator.sol
+++ b/solidity/src/vaults/interfaces/IERC7540Operator.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+// interface for operator functionality inspired by ERC-6909, as described in ERC-7540:
+// https://eips.ethereum.org/EIPS/eip-7540#operators
+
+interface IERC7540Operator {
+    /**
+     * @dev Emitted when `controller` grants or revokes operator status for a `spender`.
+     */
+    event OperatorSet(
+        address indexed controller,
+        address indexed operator,
+        bool approved
+    );
+
+    /**
+     * @dev Returns true if `operator` is set as an operator for `controller`.
+     */
+    function isOperator(
+        address controller,
+        address operator
+    ) external view returns (bool);
+
+    /**
+     * @dev Grants or revokes `operator` rights to issue ERC-7540 requests on behalf of the caller (controller).
+     *
+     * Returns true if the operation was successful.
+     */
+    function setOperator(
+        address operator,
+        bool approved
+    ) external returns (bool);
+}

--- a/solidity/src/vaults/interfaces/IERC7540Operator.sol
+++ b/solidity/src/vaults/interfaces/IERC7540Operator.sol
@@ -8,27 +8,17 @@ interface IERC7540Operator {
     /**
      * @dev Emitted when `controller` grants or revokes operator status for a `spender`.
      */
-    event OperatorSet(
-        address indexed controller,
-        address indexed operator,
-        bool approved
-    );
+    event OperatorSet(address indexed controller, address indexed operator, bool approved);
 
     /**
      * @dev Returns true if `operator` is set as an operator for `controller`.
      */
-    function isOperator(
-        address controller,
-        address operator
-    ) external view returns (bool);
+    function isOperator(address controller, address operator) external view returns (bool);
 
     /**
      * @dev Grants or revokes `operator` rights to issue ERC-7540 requests on behalf of the caller (controller).
      *
      * Returns true if the operation was successful.
      */
-    function setOperator(
-        address operator,
-        bool approved
-    ) external returns (bool);
+    function setOperator(address operator, bool approved) external returns (bool);
 }

--- a/solidity/src/vaults/interfaces/IERC7540Redeem.sol
+++ b/solidity/src/vaults/interfaces/IERC7540Redeem.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+// TODO
+
+interface IERC7540Redeem {
+
+}

--- a/solidity/src/vaults/interfaces/IERC7540Redeem.sol
+++ b/solidity/src/vaults/interfaces/IERC7540Redeem.sol
@@ -3,6 +3,6 @@ pragma solidity ^0.8.28;
 
 // TODO
 
-interface IERC7540Redeem {
+interface ERC7540Redeem {
 
 }

--- a/solidity/src/vaults/interfaces/IERC7540Redeem.sol
+++ b/solidity/src/vaults/interfaces/IERC7540Redeem.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.28;
-
-// TODO
-
-interface ERC7540Redeem {
-
-}

--- a/solidity/src/vaults/interfaces/IValenceVaultStrategist.sol
+++ b/solidity/src/vaults/interfaces/IValenceVaultStrategist.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+interface IValenceVaultStrategist {
+    /// @dev Emitted on successful share price update by the strategist.
+    /// @param sharePrice newly posted share price
+    /// @param updateTimestamp block.time of the update
+    event SharePriceUpdated(
+        uint256 indexed sharePrice,
+        uint256 indexed updateTimestamp
+    );
+
+    /// Sets the share price.
+    /// @param newSharePrice The new share price.
+    function setSharePrice(uint256 newSharePrice) external;
+}

--- a/solidity/src/vaults/interfaces/IValenceVaultStrategist.sol
+++ b/solidity/src/vaults/interfaces/IValenceVaultStrategist.sol
@@ -5,10 +5,7 @@ interface IValenceVaultStrategist {
     /// @dev Emitted on successful share price update by the strategist.
     /// @param sharePrice newly posted share price
     /// @param updateTimestamp block.time of the update
-    event SharePriceUpdated(
-        uint256 indexed sharePrice,
-        uint256 indexed updateTimestamp
-    );
+    event SharePriceUpdated(uint256 indexed sharePrice, uint256 indexed updateTimestamp);
 
     /// Sets the share price.
     /// @param newSharePrice The new share price.

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -1,17 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
 import {Test, console} from "forge-std/src/Test.sol";
 import {ValenceXCV} from "../../src/vaults/ValenceXCV.sol";
+import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
+import {MockERC20} from "../mocks/MockERC20.sol";
 
 // run with: forge test --match-path test/vaults/ValenceXCV.t.sol -vvv
 
 contract ValenceXCVTest is Test {
+    // contracts
     ValenceXCV internal vault;
+    MockERC20 internal underlyingToken;
+    BaseAccount internal depositAccount;
+
+    // test addresses
+    address owner = address(1);
+    address strategist = address(2);
+    address user1 = address(3);
+    address user2 = address(4);
+
+    // vault config
+    uint256 initialSharePrice = 10 ** 18; // 1:1 initial rate
 
     function setUp() public {
-        console.log("Setting up ValenceXCVTest");
+        vm.startPrank(owner);
+
+        // deploy mock token and deposit account
+        underlyingToken = new MockERC20("Test Token", "TST", 18);
+        depositAccount = new BaseAccount(owner, new address[](0));
+
         vault = new ValenceXCV();
+
+        // initialize the vault
+        vault.initialize(
+            owner,
+            strategist,
+            address(underlyingToken),
+            address(depositAccount),
+            "ValenceXCV",
+            "vXCV",
+            initialSharePrice
+        );
+
+        underlyingToken.mint(user1, 1000 * 10 ** 18);
+        underlyingToken.mint(user2, 1000 * 10 ** 18);
+
+        vm.stopPrank();
+
+        // approve deposit tokens to be spent by the vault for users
+        vm.prank(user1);
+        underlyingToken.approve(address(vault), type(uint256).max);
+
+        vm.prank(user2);
+        underlyingToken.approve(address(vault), type(uint256).max);
     }
 
-    function testSetUpVault() public {
-        console.log("set up complete");
+    function testSetUpVault() public view {
+        assertEq(vault.owner(), owner);
+        assertEq(vault.strategist(), strategist);
+        assertEq(vault.depositAccount(), address(depositAccount));
+        assertEq(vault.name(), "ValenceXCV");
+        assertEq(vault.symbol(), "vXCV");
+        assertEq(vault.sharePrice(), initialSharePrice);
     }
 }

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -9,6 +9,13 @@ import {MockERC20} from "../mocks/MockERC20.sol";
 // run with: forge test --match-path test/vaults/ValenceXCV.t.sol -vvv
 
 contract ValenceXCVTest is Test {
+    event Deposit(
+        address indexed sender,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
     // contracts
     ValenceXCV internal vault;
     MockERC20 internal underlyingToken;
@@ -23,11 +30,21 @@ contract ValenceXCVTest is Test {
     // vault config
     uint256 initialSharePrice = 10 ** 18; // 1:1 initial rate
 
+    // start user balance
+    uint256 startUserBalance = 1000 * 10 ** 18;
+
+    uint8 UNDERLYING_PRECISION_DECIMALS = 18;
+    uint256 ONE_SHARE = 10 ** UNDERLYING_PRECISION_DECIMALS;
+
     function setUp() public {
         vm.startPrank(owner);
 
         // deploy mock token and deposit account
-        underlyingToken = new MockERC20("Test Token", "TST", 18);
+        underlyingToken = new MockERC20(
+            "Test Token",
+            "TST",
+            UNDERLYING_PRECISION_DECIMALS
+        );
         depositAccount = new BaseAccount(owner, new address[](0));
 
         vault = new ValenceXCV();
@@ -43,8 +60,8 @@ contract ValenceXCVTest is Test {
             initialSharePrice
         );
 
-        underlyingToken.mint(user1, 1000 * 10 ** 18);
-        underlyingToken.mint(user2, 1000 * 10 ** 18);
+        underlyingToken.mint(user1, startUserBalance);
+        underlyingToken.mint(user2, startUserBalance);
 
         vm.stopPrank();
 
@@ -63,5 +80,62 @@ contract ValenceXCVTest is Test {
         assertEq(vault.name(), "ValenceXCV");
         assertEq(vault.symbol(), "vXCV");
         assertEq(vault.sharePrice(), initialSharePrice);
+    }
+
+    function testSetSharePriceUnauthorized() public {
+        vm.prank(user1);
+        vm.expectRevert(ValenceXCV.OnlyStrategistAllowed.selector);
+        vault.setSharePrice(2 * initialSharePrice);
+    }
+
+    function testSetSharePriceInvalidAmount() public {
+        vm.prank(strategist);
+        vm.expectRevert(ValenceXCV.InvalidSharePrice.selector);
+        vault.setSharePrice(0);
+    }
+
+    function testSetSharePrice() public {
+        uint256 price_0 = vault.sharePrice();
+
+        vm.prank(strategist);
+        vault.setSharePrice(2 * price_0);
+
+        uint256 price_1 = vault.sharePrice();
+
+        assertNotEq(price_0, price_1);
+        assertEq(2 * price_0, price_1);
+    }
+
+    function testDeposit() public {
+        assertEq(vault.totalSupply(), 0);
+        assertEq(underlyingToken.balanceOf(address(depositAccount)), 0);
+        assertEq(underlyingToken.balanceOf(user1), startUserBalance);
+        assertEq(underlyingToken.balanceOf(address(vault)), 0);
+        assertEq(vault.balanceOf(user1), 0);
+        assertEq(vault.sharePrice(), initialSharePrice);
+
+        uint256 userDepositAmount = startUserBalance / 2;
+
+        uint256 expectedShares = (userDepositAmount * ONE_SHARE) /
+            initialSharePrice;
+
+        vm.prank(user1);
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit Deposit(user1, user1, userDepositAmount, expectedShares);
+        uint256 shares = vault.deposit(userDepositAmount, user1);
+        vm.stopPrank();
+
+        assertNotEq(shares, 0);
+        assertEq(vault.balanceOf(user1), shares);
+        assertEq(vault.totalSupply(), shares);
+        assertEq(
+            underlyingToken.balanceOf(address(depositAccount)),
+            userDepositAmount
+        );
+        assertEq(underlyingToken.balanceOf(address(vault)), 0);
+        assertEq(
+            underlyingToken.balanceOf(address(user1)),
+            startUserBalance - userDepositAmount
+        );
     }
 }

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -1,0 +1,17 @@
+import {Test, console} from "forge-std/src/Test.sol";
+import {ValenceXCV} from "../../src/vaults/ValenceXCV.sol";
+
+// run with: forge test --match-path test/vaults/ValenceXCV.t.sol -vvv
+
+contract ValenceXCVTest is Test {
+    ValenceXCV internal vault;
+
+    function setUp() public {
+        console.log("Setting up ValenceXCVTest");
+        vault = new ValenceXCV();
+    }
+
+    function testSetUpVault() public {
+        console.log("set up complete");
+    }
+}

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -9,21 +9,9 @@ import {MockERC20} from "../mocks/MockERC20.sol";
 // run with: forge test --match-path test/vaults/ValenceXCV.t.sol -vvv
 
 contract ValenceXCVTest is Test {
-    event Deposit(
-        address indexed sender,
-        address indexed owner,
-        uint256 assets,
-        uint256 shares
-    );
-    event OperatorSet(
-        address indexed controller,
-        address indexed operator,
-        bool approved
-    );
-    event SharePriceUpdated(
-        uint256 indexed sharePrice,
-        uint256 indexed updateTimestamp
-    );
+    event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
+    event OperatorSet(address indexed controller, address indexed operator, bool approved);
+    event SharePriceUpdated(uint256 indexed sharePrice, uint256 indexed updateTimestamp);
 
     // contracts
     ValenceXCV internal vault;
@@ -52,11 +40,7 @@ contract ValenceXCVTest is Test {
         vm.startPrank(owner);
 
         // deploy mock token and deposit account
-        underlyingToken = new MockERC20(
-            "Test Token",
-            "TST",
-            UNDERLYING_PRECISION_DECIMALS
-        );
+        underlyingToken = new MockERC20("Test Token", "TST", UNDERLYING_PRECISION_DECIMALS);
         depositAccount = new BaseAccount(owner, new address[](0));
 
         vault = new ValenceXCV();
@@ -163,8 +147,7 @@ contract ValenceXCVTest is Test {
     function testDeposit4626() public {
         uint256 userDepositAmount = startUserBalance / 2;
 
-        uint256 expectedShares = (userDepositAmount * ONE_SHARE) /
-            initialSharePrice;
+        uint256 expectedShares = (userDepositAmount * ONE_SHARE) / initialSharePrice;
 
         vm.prank(user1);
         vm.expectEmit(true, true, true, true, address(vault));
@@ -175,15 +158,9 @@ contract ValenceXCVTest is Test {
         assertNotEq(shares, 0);
         assertEq(vault.balanceOf(user1), shares);
         assertEq(vault.totalSupply(), shares);
-        assertEq(
-            underlyingToken.balanceOf(address(depositAccount)),
-            userDepositAmount
-        );
+        assertEq(underlyingToken.balanceOf(address(depositAccount)), userDepositAmount);
         assertEq(underlyingToken.balanceOf(address(vault)), 0);
-        assertEq(
-            underlyingToken.balanceOf(address(user1)),
-            startUserBalance - userDepositAmount
-        );
+        assertEq(underlyingToken.balanceOf(address(user1)), startUserBalance - userDepositAmount);
     }
 
     function testDepositStalenessChecks() public {
@@ -205,8 +182,7 @@ contract ValenceXCVTest is Test {
 
         uint256 userDepositAmount = startUserBalance / 2;
 
-        uint256 expectedShares = (userDepositAmount * ONE_SHARE) /
-            vault.sharePrice();
+        uint256 expectedShares = (userDepositAmount * ONE_SHARE) / vault.sharePrice();
 
         // perform a deposit with the new rate
         vm.prank(user1);
@@ -235,8 +211,7 @@ contract ValenceXCVTest is Test {
 
         uint256 userDepositAmount = startUserBalance / 2;
 
-        uint256 expectedShares = (userDepositAmount * ONE_SHARE) /
-            initialSharePrice;
+        uint256 expectedShares = (userDepositAmount * ONE_SHARE) / initialSharePrice;
 
         vm.prank(operator);
         vm.expectEmit(true, true, true, true, address(vault));
@@ -247,22 +222,15 @@ contract ValenceXCVTest is Test {
         assertNotEq(shares, 0);
         assertEq(vault.balanceOf(user1), shares);
         assertEq(vault.totalSupply(), shares);
-        assertEq(
-            underlyingToken.balanceOf(address(depositAccount)),
-            userDepositAmount
-        );
+        assertEq(underlyingToken.balanceOf(address(depositAccount)), userDepositAmount);
         assertEq(underlyingToken.balanceOf(address(vault)), 0);
-        assertEq(
-            underlyingToken.balanceOf(address(user1)),
-            startUserBalance - userDepositAmount
-        );
+        assertEq(underlyingToken.balanceOf(address(user1)), startUserBalance - userDepositAmount);
     }
 
     function testDeposit7540Controller() public {
         uint256 userDepositAmount = startUserBalance / 2;
 
-        uint256 expectedShares = (userDepositAmount * ONE_SHARE) /
-            initialSharePrice;
+        uint256 expectedShares = (userDepositAmount * ONE_SHARE) / initialSharePrice;
 
         vm.prank(user1);
         vm.expectEmit(true, true, true, true, address(vault));
@@ -273,15 +241,9 @@ contract ValenceXCVTest is Test {
         assertNotEq(shares, 0);
         assertEq(vault.balanceOf(user1), shares);
         assertEq(vault.totalSupply(), shares);
-        assertEq(
-            underlyingToken.balanceOf(address(depositAccount)),
-            userDepositAmount
-        );
+        assertEq(underlyingToken.balanceOf(address(depositAccount)), userDepositAmount);
         assertEq(underlyingToken.balanceOf(address(vault)), 0);
-        assertEq(
-            underlyingToken.balanceOf(address(user1)),
-            startUserBalance - userDepositAmount
-        );
+        assertEq(underlyingToken.balanceOf(address(user1)), startUserBalance - userDepositAmount);
     }
 
     function testSetOperator() public {

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -46,6 +46,7 @@ contract ValenceXCVTest is Test {
 
     uint8 UNDERLYING_PRECISION_DECIMALS = 18;
     uint256 ONE_SHARE = 10 ** UNDERLYING_PRECISION_DECIMALS;
+    uint256 MAX_PRICE_CHANGE = 500; // 5% max price change
 
     function setUp() public {
         vm.startPrank(owner);
@@ -69,7 +70,8 @@ contract ValenceXCVTest is Test {
             "ValenceXCV",
             "vXCV",
             initialSharePrice,
-            oneHourSecs
+            oneHourSecs,
+            MAX_PRICE_CHANGE
         );
 
         underlyingToken.mint(user1, startUserBalance);
@@ -121,20 +123,41 @@ contract ValenceXCVTest is Test {
 
     function testSetSharePrice() public {
         uint256 price_0 = vault.sharePrice();
+        uint256 small_change = price_0 + (price_0 * 2) / 100;
         uint256 update_timestamp_0 = vault.lastUpdateTimestamp();
 
         vm.warp(update_timestamp_0 + 1);
         vm.prank(strategist);
         vm.expectEmit(true, true, true, true, address(vault));
-        emit SharePriceUpdated(2 * price_0, update_timestamp_0 + 1);
-        vault.setSharePrice(2 * price_0);
+        emit SharePriceUpdated(small_change, update_timestamp_0 + 1);
+        vault.setSharePrice(small_change);
 
         uint256 price_1 = vault.sharePrice();
         uint256 update_timestamp_1 = vault.lastUpdateTimestamp();
 
         assertEq(update_timestamp_1, update_timestamp_0 + 1);
         assertNotEq(price_0, price_1);
-        assertEq(2 * price_0, price_1);
+        assertEq(small_change, price_1);
+    }
+
+    function testSetSharePriceRevertOnPriceIncreaseTooLarge() public {
+        uint256 price_0 = vault.sharePrice();
+        // 6% increase, while max is 5%
+        uint256 large_increase = price_0 + (price_0 * 6) / 100;
+
+        vm.prank(strategist);
+        vm.expectRevert(ValenceXCV.SharePriceChangeDeltaTooLarge.selector);
+        vault.setSharePrice(large_increase);
+    }
+
+    function testSetSharePriceRevertOnPriceDecreaseTooLarge() public {
+        uint256 price_0 = vault.sharePrice();
+        // 6% decrease, while max is 5%
+        uint256 large_decrease = price_0 - (price_0 * 6) / 100;
+
+        vm.prank(strategist);
+        vm.expectRevert(ValenceXCV.SharePriceChangeDeltaTooLarge.selector);
+        vault.setSharePrice(large_decrease);
     }
 
     function testDeposit4626() public {
@@ -175,8 +198,9 @@ contract ValenceXCVTest is Test {
 
         // update the share price
         uint256 currentSharePrice = vault.sharePrice();
+        uint256 small_change = (currentSharePrice * 2) / 100;
         vm.prank(strategist);
-        vault.setSharePrice(2 * currentSharePrice);
+        vault.setSharePrice(currentSharePrice + small_change);
         vm.stopPrank();
 
         uint256 userDepositAmount = startUserBalance / 2;

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -20,6 +20,10 @@ contract ValenceXCVTest is Test {
         address indexed operator,
         bool approved
     );
+    event SharePriceUpdated(
+        uint256 indexed sharePrice,
+        uint256 indexed updateTimestamp
+    );
 
     // contracts
     ValenceXCV internal vault;
@@ -35,6 +39,7 @@ contract ValenceXCVTest is Test {
 
     // vault config
     uint256 initialSharePrice = 10 ** 18; // 1:1 initial rate
+    uint256 oneHourSecs = 1 hours;
 
     // start user balance
     uint256 startUserBalance = 1000 * 10 ** 18;
@@ -63,7 +68,8 @@ contract ValenceXCVTest is Test {
             address(depositAccount),
             "ValenceXCV",
             "vXCV",
-            initialSharePrice
+            initialSharePrice,
+            oneHourSecs
         );
 
         underlyingToken.mint(user1, startUserBalance);
@@ -115,12 +121,18 @@ contract ValenceXCVTest is Test {
 
     function testSetSharePrice() public {
         uint256 price_0 = vault.sharePrice();
+        uint256 update_timestamp_0 = vault.lastUpdateTimestamp();
 
+        vm.warp(update_timestamp_0 + 1);
         vm.prank(strategist);
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit SharePriceUpdated(2 * price_0, update_timestamp_0 + 1);
         vault.setSharePrice(2 * price_0);
 
         uint256 price_1 = vault.sharePrice();
+        uint256 update_timestamp_1 = vault.lastUpdateTimestamp();
 
+        assertEq(update_timestamp_1, update_timestamp_0 + 1);
         assertNotEq(price_0, price_1);
         assertEq(2 * price_0, price_1);
     }
@@ -149,6 +161,37 @@ contract ValenceXCVTest is Test {
             underlyingToken.balanceOf(address(user1)),
             startUserBalance - userDepositAmount
         );
+    }
+
+    function testDepositStalenessChecks() public {
+        // expire the share price
+        vm.warp(block.timestamp + 2 days);
+
+        // attempt a deposit and assert that it reverts
+        vm.expectRevert(ValenceXCV.StaleSharePrice.selector);
+        vm.prank(user1);
+        vault.deposit(startUserBalance, user1);
+        vm.stopPrank();
+
+        // update the share price
+        uint256 currentSharePrice = vault.sharePrice();
+        vm.prank(strategist);
+        vault.setSharePrice(2 * currentSharePrice);
+        vm.stopPrank();
+
+        uint256 userDepositAmount = startUserBalance / 2;
+
+        uint256 expectedShares = (userDepositAmount * ONE_SHARE) /
+            vault.sharePrice();
+
+        // perform a deposit with the new rate
+        vm.prank(user1);
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit Deposit(user1, user1, userDepositAmount, expectedShares);
+        uint256 shares = vault.deposit(userDepositAmount, user1);
+        vm.stopPrank();
+
+        assertNotEq(shares, 0);
     }
 
     function testDeposit7540NotControllerNotOperator() public {

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/src/Test.sol";
 import {ValenceXCV} from "../../src/vaults/ValenceXCV.sol";
 import {BaseAccount} from "../../src/accounts/BaseAccount.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 // run with: forge test --match-path test/vaults/ValenceXCV.t.sol -vvv
 
@@ -43,10 +44,10 @@ contract ValenceXCVTest is Test {
         underlyingToken = new MockERC20("Test Token", "TST", UNDERLYING_PRECISION_DECIMALS);
         depositAccount = new BaseAccount(owner, new address[](0));
 
-        vault = new ValenceXCV();
+        ValenceXCV vaultImpl = new ValenceXCV();
 
-        // initialize the vault
-        vault.initialize(
+        bytes memory initData = abi.encodeWithSelector(
+            ValenceXCV.initialize.selector,
             owner,
             strategist,
             address(underlyingToken),
@@ -57,6 +58,17 @@ contract ValenceXCVTest is Test {
             oneHourSecs,
             MAX_PRICE_CHANGE
         );
+
+        // Create proxy via create2 and initialize in one step
+        bytes memory proxyCreationCode =
+            abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(address(vaultImpl), initData));
+
+        address proxyAddress;
+        assembly {
+            proxyAddress := create2(0, add(proxyCreationCode, 0x20), mload(proxyCreationCode), 0)
+        }
+
+        vault = ValenceXCV(payable(proxyAddress));
 
         underlyingToken.mint(user1, startUserBalance);
         underlyingToken.mint(user2, startUserBalance);

--- a/solidity/test/vaults/ValenceXCV.t.sol
+++ b/solidity/test/vaults/ValenceXCV.t.sol
@@ -202,21 +202,23 @@ contract ValenceXCVTest is Test {
     }
 
     function testDeposit7540Operator() public {
+        assertFalse(vault.isOperator(user1, operator));
         // first approve the operator
         vm.prank(user1);
         vm.expectEmit(true, true, true, true, address(vault));
-        emit OperatorSet(user1, operator, false);
-        vault.setOperator(operator, false);
+        emit OperatorSet(user1, operator, true);
+        vault.setOperator(operator, true);
         vm.stopPrank();
+
+        assertTrue(vault.isOperator(user1, operator));
 
         uint256 userDepositAmount = startUserBalance / 2;
 
         uint256 expectedShares = (userDepositAmount * ONE_SHARE) / initialSharePrice;
-
         vm.prank(operator);
         vm.expectEmit(true, true, true, true, address(vault));
         emit Deposit(operator, user1, userDepositAmount, expectedShares);
-        uint256 shares = vault.deposit(userDepositAmount, user1, operator);
+        uint256 shares = vault.deposit(userDepositAmount, user1, user1);
         vm.stopPrank();
 
         assertNotEq(shares, 0);


### PR DESCRIPTION
# Description

This is an intermediate pr for the updated two-way vault design that focuses on the deposit flow.
The follow-up pr will implement the withdraw flow as well as any leftover logic relating to owner operations, storage optimizations, proxy, etc.
Putting this out here now so that it's easier to review the core logic.

new additions/changes from the previous vaults:
- notion of `operator`: vault now implements `IERC7540Operator`, which describes the logic for users to approve other addresses (operators) to issue requests on their behalf
- pausing due to stale redemption rate/share price is now implicit: when calling deposit, `onlyWhenSharePriceNotStale` modifier will check for the last update timestamp and revert in case the price is stale (to be discussed)
  - this way if the vault stops accepting deposits due to stale price, the only thing needed to resume the normal operations will be to run the strategist and update the share price
